### PR TITLE
Add proper error handling within the tui

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -84,7 +84,8 @@ but rather a simple tool to make on-call tasks easier.`,
 		p := tea.NewProgram(m, tea.WithAltScreen())
 		_, err = p.Run()
 		if err != nil {
-			log.Fatal(err)
+			fmt.Println("fatal:", err)
+			os.Exit(1)
 		}
 	},
 }

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"html/template"
-	"log"
 	"strings"
 
 	"github.com/PagerDuty/go-pagerduty"
@@ -39,6 +38,13 @@ var (
 	}
 	helpStyle           = lipgloss.NewStyle().Foreground(lilac)
 	incidentViewerStyle = lipgloss.NewStyle().BorderStyle(lipgloss.NormalBorder()).BorderForeground(lipgloss.Color(gray)).Padding(2)
+	errorStyle          = lipgloss.NewStyle().
+				Bold(true).
+				Width(64).
+				Foreground(lipgloss.AdaptiveColor{Light: "#E11C9C", Dark: "#FF62DA"}).
+				Border(lipgloss.RoundedBorder()).
+				BorderForeground(lipgloss.AdaptiveColor{Light: "#E11C9C", Dark: "#FF62DA"}).
+				Padding(1, 3, 1, 3)
 )
 
 func (m model) renderHeader() string {
@@ -76,21 +82,23 @@ func statusArea(s string) string {
 	return fmt.Sprintf(fstring, s)
 }
 
-func (m model) template() string {
+func (m model) template() (string, error) {
 	debug("template")
 	template, err := template.New("incident").Funcs(funcMap).Parse(incidentTemplate)
 	if err != nil {
-		log.Fatal(err)
+		// TODO: Figure out how to handle this with a proper errMsg
+		return "", err
 	}
 
 	o := new(bytes.Buffer)
 	summary := summarize(m.selectedIncident, m.selectedIncidentAlerts, m.selectedIncidentNotes)
 	err = template.Execute(o, summary)
 	if err != nil {
-		log.Fatal(err)
+		// TODO: Figure out how to handle this with a proper errMsg
+		return "", err
 	}
 
-	return o.String()
+	return o.String(), nil
 }
 
 func summarize(i *pagerduty.Incident, a []pagerduty.IncidentAlert, n []pagerduty.IncidentNote) incidentSummary {


### PR DESCRIPTION
This PR adds proper error handling within the tui by setting any fatal error (and only fatal errors) to display within a popup error window, from which the user can either quit, or `esc` to go back to the previous window (potentially causing a panic).  Any function returning a tea.Cmd or tea.Msg of `errMsg` type will trigger this behavior.

Non-fatal errors are handled by the model `m.setStatus()` function and displayed at the top of the table window.

Fixes #9 

![image](https://github.com/clcollins/srepd/assets/197728/995206a5-fece-4f49-8ded-786305adebee)


Signed-off-by: Chris Collins <collins.christopher@gmail.com>
