### PR TITLE
Refactors some style things into their own package

### DIFF
--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -13,6 +13,7 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/clcollins/srepd/pkg/pd"
+	"github.com/clcollins/srepd/pkg/tui/symbols"
 )
 
 const (
@@ -449,13 +450,13 @@ func getDetailFieldFromAlert(f string, a pagerduty.IncidentAlert) string {
 	return ""
 }
 
-// acknowledged returns "A" for "acknowledged" if the incident has been acknowledged, or a dot for "triggered" otherwise
+// acknowledged returns "A" for "acknowledged" if the incident has been acknowledged, or a symbols.Dot for "triggered" otherwise
 func acknowledged(a []pagerduty.Acknowledgement) string {
 	if len(a) > 0 {
 		return "A"
 	}
 
-	return dot
+	return symbols.Dot
 }
 
 func doIfIncidentSelected(m *model, cmd tea.Cmd) tea.Cmd {

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/clcollins/srepd/pkg/pd"
+	"github.com/clcollins/srepd/pkg/tui/style"
 )
 
 type model struct {
@@ -96,7 +97,7 @@ func (m *model) toggleHelp() {
 func newTableWithStyles() table.Model {
 	debug("newTableWithStyles")
 	t := table.New(table.WithFocused(true))
-	t.SetStyles(tableStyle)
+	t.SetStyles(style.Table)
 	return t
 }
 
@@ -119,6 +120,6 @@ func newHelp() help.Model {
 func newIncidentViewer() viewport.Model {
 	debug("newIncidentViewer")
 	vp := viewport.New(100, 100)
-	vp.Style = incidentViewerStyle
+	vp.Style = style.IncidentViewer
 	return vp
 }

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/clcollins/srepd/pkg/tui/style"
+	"github.com/clcollins/srepd/pkg/tui/symbols"
 )
 
 // errMsgHandler is the message handler for the errMsg message
@@ -32,7 +33,7 @@ func (m model) windowSizeMsgHandler(msg tea.Msg) (tea.Model, tea.Cmd) {
 	m.help.Width = windowSize.Width - borderEdges
 
 	m.table.SetColumns([]table.Column{
-		{Title: dot, Width: 1},
+		{Title: symbols.Dot, Width: 1},
 		{Title: "ID", Width: eighthWindow + cellPadding - borderEdges},
 		{Title: "Summary", Width: eighthWindow * 3},
 		{Title: "Service", Width: eighthWindow * 3},

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -7,6 +7,7 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/clcollins/srepd/pkg/tui/style"
 )
 
 // errMsgHandler is the message handler for the errMsg message
@@ -23,9 +24,9 @@ func (m model) windowSizeMsgHandler(msg tea.Msg) (tea.Model, tea.Cmd) {
 	debug("windowSizeMsgHandler")
 	m.setStatus(fmt.Sprintf("window size changed: %v", msg.(tea.WindowSizeMsg)))
 	windowSize = msg.(tea.WindowSizeMsg)
-	top, _, bottom, _ := mainStyle.GetMargin()
+	top, _, bottom, _ := style.Main.GetMargin()
 	eighthWindow := windowSize.Width / 8
-	cellPadding := (horizontalPadding * 2) * 4
+	cellPadding := (style.HorizontalPadding * 2) * 4
 	borderEdges := 2 + 10
 
 	m.help.Width = windowSize.Width - borderEdges

--- a/pkg/tui/style/style.go
+++ b/pkg/tui/style/style.go
@@ -1,0 +1,47 @@
+package style
+
+import (
+	"github.com/charmbracelet/bubbles/table"
+	"github.com/charmbracelet/lipgloss"
+)
+
+const (
+	Gray       = lipgloss.Color("240")
+	PaleYellow = lipgloss.Color("229")
+	NeonPurple = lipgloss.Color("57")
+	Lilac      = lipgloss.Color("105")
+)
+
+var (
+	HorizontalPadding = 1
+
+	borderWidth = 1
+
+	Main = lipgloss.NewStyle().Margin(1, 0).Padding(0, HorizontalPadding)
+
+	Assignee = Main.Copy()
+
+	Status = Main.Copy()
+
+	AssignedStringWidth = len("Assigned to User") + (HorizontalPadding * 2 * 2) + (borderWidth * 2 * 2) + 10
+
+	TableContainer = lipgloss.NewStyle().BorderStyle(lipgloss.NormalBorder()).BorderForeground(Gray)
+
+	Table = table.Styles{
+		Selected: lipgloss.NewStyle().Bold(true).Foreground(PaleYellow).Background(NeonPurple),
+		Header:   lipgloss.NewStyle().Bold(false).Padding(0, 1).BorderStyle(lipgloss.NormalBorder()).BorderForeground(lipgloss.Color(Gray)).BorderBottom(true),
+		Cell:     lipgloss.NewStyle().Padding(0, 1),
+	}
+
+	Help = lipgloss.NewStyle().Foreground(Lilac)
+
+	IncidentViewer = lipgloss.NewStyle().BorderStyle(lipgloss.NormalBorder()).BorderForeground(lipgloss.Color(Gray)).Padding(2)
+
+	Error = lipgloss.NewStyle().
+		Bold(true).
+		Width(64).
+		Foreground(lipgloss.AdaptiveColor{Light: "#E11C9C", Dark: "#FF62DA"}).
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.AdaptiveColor{Light: "#E11C9C", Dark: "#FF62DA"}).
+		Padding(1, 3, 1, 3)
+)

--- a/pkg/tui/symbols/symbols.go
+++ b/pkg/tui/symbols/symbols.go
@@ -1,0 +1,7 @@
+package symbols
+
+const (
+	Dot       = "•"
+	UpArrow   = "↑"
+	DownArrow = "↓"
+)

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -13,12 +13,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/clcollins/srepd/pkg/tui/style"
-)
-
-const (
-	dot       = "•"
-	upArrow   = "↑"
-	downArrow = "↓"
+	"github.com/clcollins/srepd/pkg/tui/symbols"
 )
 
 var (
@@ -33,7 +28,7 @@ func (m model) View() string {
 	case m.err != nil:
 		debug("error")
 		errHelpView := style.Help.Render(help.New().View(errorViewKeyMap))
-		return (style.Error.Render(dot+"ERROR"+dot+"\n\n"+m.err.Error()) + "\n" + errHelpView)
+		return (style.Error.Render(symbols.Dot+"ERROR"+symbols.Dot+"\n\n"+m.err.Error()) + "\n" + errHelpView)
 
 	case m.viewingIncident:
 		debug("viewingIncident")

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -8,69 +8,45 @@ import (
 
 	"github.com/PagerDuty/go-pagerduty"
 	"github.com/charmbracelet/bubbles/help"
-	"github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/glamour"
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/clcollins/srepd/pkg/tui/style"
 )
 
 const (
-	dot        = "•"
-	upArrow    = "↑"
-	downArrow  = "↓"
-	gray       = lipgloss.Color("240")
-	paleYellow = lipgloss.Color("229")
-	neonPurple = lipgloss.Color("57")
-	lilac      = lipgloss.Color("105")
+	dot       = "•"
+	upArrow   = "↑"
+	downArrow = "↓"
 )
 
 var (
-	windowSize          tea.WindowSizeMsg
-	horizontalPadding   = 1
-	borderWidth         = 1
-	mainStyle           = lipgloss.NewStyle().Margin(0, 0).Padding(0, horizontalPadding)
-	assigneeStyle       = mainStyle.Copy()
-	statusStyle         = mainStyle.Copy()
-	assignedStringWidth = len("Assigned to User") + (horizontalPadding * 2 * 2) + (borderWidth * 2 * 2) + 10
-	tableContainerStyle = lipgloss.NewStyle().BorderStyle(lipgloss.NormalBorder()).BorderForeground(gray)
-	tableStyle          = table.Styles{
-		Selected: lipgloss.NewStyle().Bold(true).Foreground(paleYellow).Background(neonPurple),
-		Header:   lipgloss.NewStyle().Bold(false).Padding(0, 1).BorderStyle(lipgloss.NormalBorder()).BorderForeground(lipgloss.Color(gray)).BorderBottom(true),
-		Cell:     lipgloss.NewStyle().Padding(0, 1),
-	}
-	helpStyle           = lipgloss.NewStyle().Foreground(lilac)
-	incidentViewerStyle = lipgloss.NewStyle().BorderStyle(lipgloss.NormalBorder()).BorderForeground(lipgloss.Color(gray)).Padding(2)
-	errorStyle          = lipgloss.NewStyle().
-				Bold(true).
-				Width(64).
-				Foreground(lipgloss.AdaptiveColor{Light: "#E11C9C", Dark: "#FF62DA"}).
-				Border(lipgloss.RoundedBorder()).
-				BorderForeground(lipgloss.AdaptiveColor{Light: "#E11C9C", Dark: "#FF62DA"}).
-				Padding(1, 3, 1, 3)
+	windowSize tea.WindowSizeMsg
 )
 
 func (m model) View() string {
 	debug("View")
-	helpView := helpStyle.Render(m.help.View(defaultKeyMap))
+	helpView := style.Help.Render(m.help.View(defaultKeyMap))
 
 	switch {
 	case m.err != nil:
 		debug("error")
-		errHelpView := helpStyle.Render(help.New().View(errorViewKeyMap))
-		return (errorStyle.Render(dot+"ERROR"+dot+"\n\n"+m.err.Error()) + "\n" + errHelpView)
+		errHelpView := style.Help.Render(help.New().View(errorViewKeyMap))
+		return (style.Error.Render(dot+"ERROR"+dot+"\n\n"+m.err.Error()) + "\n" + errHelpView)
 
 	case m.viewingIncident:
 		debug("viewingIncident")
-		return mainStyle.Render(m.renderHeader() + "\n" + m.incidentViewer.View() + "\n" + helpView)
+		return style.Main.Render(m.renderHeader() + "\n" + m.incidentViewer.View() + "\n" + helpView)
 
 	default:
-		tableView := tableContainerStyle.Render(m.table.View())
+		tableView := style.TableContainer.Render(m.table.View())
 		if m.input.Focused() {
 			debug("viewingTable and input")
-			return mainStyle.Render(m.renderHeader() + "\n" + tableView + "\n" + m.input.View() + "\n" + helpView)
+			return style.Main.Render(m.renderHeader() + "\n" + tableView + "\n" + m.input.View() + "\n" + helpView)
 		}
 		debug("viewingTable")
-		return mainStyle.Render(m.renderHeader() + "\n" + tableView + "\n" + helpView)
+		return style.Main.Render(m.renderHeader() + "\n" + tableView + "\n" + helpView)
 	}
 }
 
@@ -87,8 +63,8 @@ func (m model) renderHeader() string {
 	s.WriteString(
 		lipgloss.JoinHorizontal(
 			0.2,
-			statusStyle.Width(windowSize.Width-assignedStringWidth).Render(statusArea(m.status)),
-			assigneeStyle.Render(assigneeArea(assignedTo)),
+			style.Status.Width(windowSize.Width-style.AssignedStringWidth).Render(statusArea(m.status)),
+			style.Assignee.Render(assigneeArea(assignedTo)),
 		),
 	)
 
@@ -111,9 +87,10 @@ func statusArea(s string) string {
 
 func (m model) template() (string, error) {
 	debug("template")
-	template, err := template.New("incident").Funcs(funcMap).Parse(incidentTemplate)
+	template, err := template.New("incident-full.tmpl").Funcs(funcMap).ParseFiles("pkg/tui/views/incident-full.tmpl")
 	if err != nil {
 		// TODO: Figure out how to handle this with a proper errMsg
+		fmt.Printf("Could not render template: %+v", err)
 		return "", err
 	}
 
@@ -121,6 +98,7 @@ func (m model) template() (string, error) {
 	summary := summarize(m.selectedIncident, m.selectedIncidentAlerts, m.selectedIncidentNotes)
 	err = template.Execute(o, summary)
 	if err != nil {
+		fmt.Printf("Could not render template: %+v", err)
 		// TODO: Figure out how to handle this with a proper errMsg
 		return "", err
 	}
@@ -256,58 +234,6 @@ var funcMap = template.FuncMap{
 	},
 	"ToUpper": strings.ToUpper,
 }
-
-const incidentTemplate = `
-# {{ .ID }} - {{ .Status }}
-
-{{ if .Priority }}PRIORITY {{ .Priority }} - {{ end }}{{ .Title }} - {{ .HTMLURL }}
-
-* Service: {{ .Service }}
-* Urgency: {{ .Urgency }}
-* Created: {{ .Created }}
-
-{{ if not .Acknowledged -}}
-Assigned to:{{ range $assignee := .Assigned }}
-+ *{{ $assignee }}* *(not yet acknowledged)*
-{{ end -}}
-{{ else -}}
-Acknowledged by:{{ range $ack := .Acknowledged }}
-+ **{{ $ack }}**
-{{ end -}}
-{{ end -}}
-
-## Notes
-
-{{ if .Notes }}
-{{ range $note := .Notes }}
-> {{ $note.Content }}
-
-- {{ $note.User }} @ {{ $note.Created }}
-{{ end }}
-{{ else }}
-_none_
-{{ end }}
-
-## Alerts ({{ len .Alerts }})
-
-{{ range $alert := .Alerts }}
-_{{ $alert.ID }}_{{ if $alert.Name }}- _{{ $alert.Name }}_{{ end }}
-
-* Cluster: {{ $alert.Cluster }}
-* SOP: {{ $alert.Link }}
-
-Details :
-
-* Service: {{ $alert.Service }}
-* Status: {{ $alert.Status }}
-* Created: {{ $alert.Created }}
-* Link: {{ $alert.HTMLURL }}
-{{ range $key, $value := $alert.Details }}
-* {{ $key }}: {{ $value }} 
-{{ end }}
-
-{{ end }}
-`
 
 func renderIncidentMarkdown(content string) (string, error) {
 	renderer, err := glamour.NewTermRenderer(

--- a/pkg/tui/views/incident-full.tmpl
+++ b/pkg/tui/views/incident-full.tmpl
@@ -1,0 +1,49 @@
+# {{ .ID }} - {{ .Status }}
+
+{{ if .Priority }}PRIORITY {{ .Priority }} - {{ end }}{{ .Title }} - {{ .HTMLURL }}
+
+* Service: {{ .Service }}
+* Urgency: {{ .Urgency }}
+* Created: {{ .Created }}
+
+{{ if not .Acknowledged -}}
+Assigned to:{{ range $assignee := .Assigned }}
++ *{{ $assignee }}* *(not yet acknowledged)*
+{{ end -}}
+{{ else -}}
+Acknowledged by:{{ range $ack := .Acknowledged }}
++ **{{ $ack }}**
+{{ end -}}
+{{ end -}}
+
+## Notes
+
+{{ if .Notes }}
+{{ range $note := .Notes }}
+> {{ $note.Content }}
+
+- {{ $note.User }} @ {{ $note.Created }}
+{{ end }}
+{{ else }}
+_none_
+{{ end }}
+
+## Alerts ({{ len .Alerts }})
+
+{{ range $alert := .Alerts }}
+_{{ $alert.ID }}_{{ if $alert.Name }}- _{{ $alert.Name }}_{{ end }}
+
+* Cluster: {{ $alert.Cluster }}
+* SOP: {{ $alert.Link }}
+
+Details :
+
+* Service: {{ $alert.Service }}
+* Status: {{ $alert.Status }}
+* Created: {{ $alert.Created }}
+* Link: {{ $alert.HTMLURL }}
+{{ range $key, $value := $alert.Details }}
+* {{ $key }}: {{ $value }} 
+{{ end }}
+
+{{ end }}


### PR DESCRIPTION
Replaces the inline template with a `.tmpl` file and folder for the
same, allowing us a path to add new template files and partials as
necessary without continuing to make the tui file any larger.

Also refactors the styles into their own package. While this may
initially seem unnecessary and add a bit of clutter to the codebase
because now you have more `style.Error` instead of `errorStyle` - I
believe this will eventually lead to a "cleaner" and more maintainable
codebase.

Additionally, refactors out the "symbols" for the same reasons.

Please feel free to accept or reject as you see fit - this was mostly me playing around with some things in order to start to familiarize myself with the code and how the code is working.