### PR TITLE
Fix bug silencing selected incident

### DIFF
--- a/pkg/pd/pd.go
+++ b/pkg/pd/pd.go
@@ -269,6 +269,9 @@ func ReassignIncidents(client PagerDutyClient, incidents []*pagerduty.Incident, 
 	opts := []pagerduty.ManageIncidentsOptions{}
 
 	for _, incident := range incidents {
+		if incident == nil {
+			return i, fmt.Errorf("pd.ReassignIncidents(): incident is nil")
+		}
 		opts = append(opts, pagerduty.ManageIncidentsOptions{
 			ID:          incident.ID,
 			Assignments: a,

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -378,6 +378,7 @@ func reassignIncidents(p *pd.Config, i []*pagerduty.Incident, users []*pagerduty
 	}
 }
 
+type silenceSelectedIncidentMsg struct{}
 type silenceIncidentsMsg struct {
 	incidents []*pagerduty.Incident
 }

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -120,11 +120,9 @@ func switchTableFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 				func() tea.Msg { return getIncidentMsg(m.table.SelectedRow()[1]) },
 				func() tea.Msg {
 					return waitForSelectedIncidentThenDoMsg{
-						msg: "add note",
+						msg: "silence",
 						action: func() tea.Msg {
-							return silenceIncidentsMsg{
-								incidents: []*pagerduty.Incident{m.selectedIncident},
-							}
+							return silenceSelectedIncidentMsg{}
 						},
 					}
 				},
@@ -214,7 +212,7 @@ func switchIncidentFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, func() tea.Msg { return acknowledgeIncidentsMsg{incidents: []*pagerduty.Incident{m.selectedIncident}} }
 
 		case key.Matches(msg, defaultKeyMap.Silence):
-			return m, func() tea.Msg { return silenceIncidentsMsg{incidents: []*pagerduty.Incident{m.selectedIncident}} }
+			return m, func() tea.Msg { return silenceSelectedIncidentMsg{} }
 
 		case key.Matches(msg, defaultKeyMap.Note):
 			cmds = append(cmds, openEditorCmd(m.editor))


### PR DESCRIPTION
Maintains the ability to send an incident list to SilenceIncidentsMsg, but adds SilenceSelectedIncidentMsg to handle individual incident silence via keypress, fixing a bug where the parsing of the selected incident didn't happen on time, causing a panic.
