### PR TITLE
remap silence to prevent accidental silencing

### DIFF
--- a/pkg/tui/keymap.go
+++ b/pkg/tui/keymap.go
@@ -82,8 +82,8 @@ var defaultKeyMap = keymap{
 		key.WithHelp("n", "add [n]ote"),
 	),
 	Silence: key.NewBinding(
-		key.WithKeys("s"),
-		key.WithHelp("s", "silence"),
+		key.WithKeys("ctrl+s"),
+		key.WithHelp("ctrl+s", "silence"),
 	),
 	Ack: key.NewBinding(
 		key.WithKeys("a"),


### PR DESCRIPTION
This PR remaps silencing to `ctrl+s` to prevent accidental silencing of alerts, prior to #22 being worked on for vim- or tmux-style command combination.
