### PR TITLE
Adds initial pass at tmux compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ A typical linux configuration to launch a new terminal window may look something
 
 ```yaml
 terminal: gnome-terminal
-cluster_login_command: ocm-container -C
+cluster_login_command: ocm backplane login
 ```
 
 ### MacOS

--- a/README.md
+++ b/README.md
@@ -81,3 +81,85 @@ ignoredusers:
 ## Try it out
 
 The easiest way to get started with SREPD, after adding the required config file, is to just clone this repository and run `go build -o ${GOPATH}/bin/srepd .`
+
+## Automatic Login Configuration
+
+To enable automatic login directly from SREPD you will need to configure the `terminal` and `cluster_login_command` settings in the srepd config file.
+
+### Linux
+A typical linux configuration to launch a new terminal window may look something like what follows. Be sure to change to your preferred terminal or preferred ops environment (ocm-container, ocm-backplane session, osdctl session, etc)
+
+```yaml
+terminal: gnome-terminal
+cluster_login_command: ocm-container -C
+```
+
+### MacOS
+Configuration for MacOS is not as straightforward because of the way that MacOS handles applications differently from Linux. We've provided a few separate ways to configure SREPD to handle automatic logins.
+
+#### Default MacOS terminal
+The following configuration will launch a new MacOS default terminal window to automatically login to a cluster. This example uses ocm-container but feel free to modify to fit your preferred workflow.
+
+```yaml
+cluster_login_command: tell application "Terminal" to do script "ocm-container -C %%CLUSTER_ID%%"
+terminal: osascript -e
+collapse_login_command: true
+```
+
+#### iTerm2 Support
+iTerm2 is even more special in the fact that you can't tell it to 'do script' like you can with the default Terminal on MacOS. You will need to create a separate shell script to invoke from SREPD that will then run the osascript command needed to create a new iTerm2 window/tab and call the login script.
+
+```bash
+#!/bin/bash
+
+osascript \
+  -e 'tell application "iTerm" to tell current window to set newWindow to (create tab with default profile)' \
+  -e "tell application \"iTerm\" to tell current session of newWindow to write text \"${*}\""
+```
+
+Then, you would add the following to your srepd config:
+
+```yaml
+terminal: /Users/kbater/Projects/spikes/srepd
+cluster_login_command: ocm-container -C
+```
+
+### Tmux support
+Alternatively to launching a whole new terminal window, if you're already using tmux you can use the following configuration to create new tmux-windows and auto-launch your environment from there:
+
+```yaml
+cluster_login_command: ocm-container -C %%CLUSTER_ID%%
+terminal: tmux new-window
+collapse_login_command: true
+```
+
+### Automatic Login Features
+The first feature of Automatic Login is the ability to replace certain strings with their cluster-specific details. When you pass `%%VARIABLE%%` in your `terminal` or `cluster_login_command` configuration strings they will dynamically be replaced with the alert-specific variable. This allows you to be able to put the specific details of these variables inside the command. The first argument of the `terminal` setting MUST NOT BE a replaceable value.
+
+Currently, only `%%CLUSTER_ID%%` is supported. It's also important to note that if `%%CLUSTER_ID%%` does NOT appear in the `cluster_login_command` config setting that the cluster ID will be appended to the end of the cluster login command. If the replacable `%%CLUSTER_ID%%` string is present in the `cluster_login_command` setting, it will NOT be appended to the end.
+
+Examples:
+```
+## Assume the cluster ID for these examples is `abcdefg`
+
+cluster_login_command: ocm backplane login %%CLUSTER_ID%% --multi
+## effectively runs "ocm backplane login abcdefg --multi"
+
+cluster_login_command: ocm backplane login --multi
+## effectively runs "ocm backplane login --multi abcdefg"
+```
+
+There's also a boolean flag `collapse_login_command`. This is sometimes necessary when passing the login command as an argument to another application, like when passing it to tmux or to the MacOS terminal. This is required because of the way that Go passes a list of strings into the `exec.Command` function. As an example:
+
+```yaml
+terminal: tmux new-window
+cluster_login_command: ocm-container -C %%CLUSTER_ID%%
+collapse_login_command: true
+## effectively generates the command `tmux new-window 'ocm-container -C abcdefg'` - allowing the whole cluster-login command to be passed as a single string
+## the slice would look like this: []string{"tmux", "new-window", "ocm-container -C abcdefg"}
+
+terminal: tmux new-window
+cluster_login_command: ocm-container -C
+## effectively generates the command `tmux new-window ocm-container -C abcdefg` - which passes each space-delimited string as a separate argument to the new-window tmux command.
+## the slice would look like this: []string{"tmux", "new-window", "ocm-container", "-C", "abcdefg"}
+```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -97,8 +97,9 @@ but rather a simple tool to make on-call tasks easier.`,
 			viper.GetStringSlice("ignoredusers"),
 			viper.GetStringSlice("editor"),
 			tui.ClusterLauncher{
-				Terminal:            viper.GetStringSlice("terminal"),
-				ClusterLoginCommand: viper.GetStringSlice("cluster_login_command"),
+				Terminal:             viper.GetStringSlice("terminal"),
+				ClusterLoginCommand:  viper.GetStringSlice("cluster_login_command"),
+				CollapseLoginCommand: viper.GetBool("collapse_login_command"),
 				// DEPRECATING SHELL: Shell:               viper.GetStringSlice("shell"),
 			},
 		)

--- a/pkg/launcher/launcher.go
+++ b/pkg/launcher/launcher.go
@@ -59,7 +59,18 @@ func (l *ClusterLauncher) BuildLoginCommand(cluster string) ([]string, error) {
 	command = append(command, l.terminal[0])
 	command = append(command, replaceVars(l.terminal[1:], cluster)...)
 
+	needsClusterIDAppended := true
+	for _, str := range l.clusterLoginCommand {
+		if strings.Contains(str, "%%CLUSTER_ID%%") {
+			needsClusterIDAppended = false
+		}
+	}
 	loginCmd := replaceVars(l.clusterLoginCommand, cluster)
+
+	if needsClusterIDAppended {
+		loginCmd = append(loginCmd, cluster)
+	}
+
 	if l.settings.collapseLoginCommand {
 		command = append(command, strings.Join(loginCmd, " "))
 	} else {

--- a/pkg/launcher/launcher.go
+++ b/pkg/launcher/launcher.go
@@ -1,0 +1,78 @@
+package launcher
+
+import (
+	"fmt"
+	"strings"
+)
+
+type ClusterLauncher struct {
+	terminal            []string
+	clusterLoginCommand []string
+	settings            launcherSettings
+}
+
+type launcherSettings struct {
+	collapseLoginCommand bool
+}
+
+func NewClusterLauncher(terminal []string, clusterLoginCommand []string) (ClusterLauncher, error) {
+	launcher := ClusterLauncher{
+		terminal:            terminal,
+		clusterLoginCommand: clusterLoginCommand,
+		settings:            launcherSettings{},
+	}
+
+	return launcher, nil
+}
+
+func (l *ClusterLauncher) SetCollapseLoginCommand(setting bool) {
+	l.settings.collapseLoginCommand = setting
+}
+
+func (l *ClusterLauncher) Validate() error {
+	errs := []error{}
+
+	if l.terminal == nil {
+		errs = append(errs, fmt.Errorf("terminal is not set"))
+	}
+
+	if l.clusterLoginCommand == nil {
+		errs = append(errs, fmt.Errorf("clusterLoginCommand is not set"))
+	}
+
+	if len(l.terminal) > 0 && strings.Contains(l.terminal[0], "%%") {
+		errs = append(errs, fmt.Errorf("first terminal argument cannot have a replaceable"))
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("login error: %v", errs)
+	}
+	return nil
+}
+
+func (l *ClusterLauncher) BuildLoginCommand(cluster string) ([]string, error) {
+	command := []string{}
+
+	// Handle the Terminal command
+	// The first arg should not be something replaceable, as checked in the
+	// validate function
+	command = append(command, l.terminal[0])
+	command = append(command, replaceVars(l.terminal[1:], cluster)...)
+
+	loginCmd := replaceVars(l.clusterLoginCommand, cluster)
+	if l.settings.collapseLoginCommand {
+		command = append(command, strings.Join(loginCmd, " "))
+	} else {
+		command = append(command, loginCmd...)
+	}
+
+	return command, nil
+}
+
+func replaceVars(args []string, cluster string) []string {
+	transformedArgs := []string{}
+	for _, str := range args {
+		transformedArgs = append(transformedArgs, strings.Replace(str, "%%CLUSTER_ID%%", cluster, -1))
+	}
+	return transformedArgs
+}

--- a/pkg/launcher/launcher_test.go
+++ b/pkg/launcher/launcher_test.go
@@ -77,7 +77,7 @@ func TestLoginCommandBuild(t *testing.T) {
 			},
 			expectErr: false,
 			comparisonFN: func(t *testing.T, cmd []string) {
-				expected := "%%CLUSTER_ID%% abcdefg ocm backplane login"
+				expected := "%%CLUSTER_ID%% abcdefg ocm backplane login abcdefg"
 				if strings.Join(cmd, " ") != expected {
 					t.Fatalf("Expected command to be %s, got %s", expected, strings.Join(cmd, " "))
 				}
@@ -114,6 +114,20 @@ func TestLoginCommandBuild(t *testing.T) {
 					if cmd[k] != expected[k] {
 						t.Fatalf("Expected command slice %#v but got %#v", expected, cmd)
 					}
+				}
+			},
+		},
+		{
+			name: "cluster login command when it has no replaceable values should have the cluster ID appended to the end",
+			launcher: ClusterLauncher{
+				terminal:            []string{"gnome-terminal"},
+				clusterLoginCommand: []string{"ocm-container"},
+			},
+			expectErr: false,
+			comparisonFN: func(t *testing.T, cmd []string) {
+				expected := "gnome-terminal ocm-container abcdefg"
+				if expected != strings.Join(cmd, " ") {
+					t.Fatalf("Expected cluster ID to be automaticall appended. Got: %s, expected: %s", cmd, expected)
 				}
 			},
 		},

--- a/pkg/launcher/launcher_test.go
+++ b/pkg/launcher/launcher_test.go
@@ -1,0 +1,135 @@
+package launcher
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestClusterLauncherValidation(t *testing.T) {
+	tests := []struct {
+		name            string
+		terminalArg     []string
+		loginCommandArg []string
+		expectErr       bool
+	}{
+		{
+			name:            "Tests that the clusterLauncher can be created successfully",
+			terminalArg:     []string{"tmux", "new-window", "-n", "%%CLUSTER_NAME%%"},
+			loginCommandArg: []string{"ocm-container", "-C", "%%CLUSTER_ID%%"},
+			expectErr:       false,
+		},
+		{
+			name:            "Tests both terminal and login args are nil",
+			terminalArg:     nil,
+			loginCommandArg: nil,
+			expectErr:       true,
+		},
+		{
+			name:            "Tests terminal is nill but login args are not",
+			terminalArg:     nil,
+			loginCommandArg: []string{"ocm", "backplane", "session"},
+			expectErr:       true,
+		},
+		{
+			name:            "Tests terminal is not nil but login args are nil",
+			terminalArg:     []string{"/bin/xterm"},
+			loginCommandArg: nil,
+			expectErr:       true,
+		},
+		{
+			name:            "Tests that the first terminal argument cannot be a replaceable",
+			terminalArg:     []string{"%%CLUSTER_ID%%", "something"},
+			loginCommandArg: []string{"ocm-container"},
+			expectErr:       true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			launcher, err := NewClusterLauncher(test.terminalArg, test.loginCommandArg)
+			if err != nil {
+				t.Fatalf("Unexpected Error initializing Launcher")
+			}
+
+			err = launcher.Validate()
+			if test.expectErr && err == nil {
+				t.Fatalf("Expected error but none fired")
+			}
+			if !test.expectErr && err != nil {
+				t.Fatalf("Expected no error but got %v", err)
+			}
+		})
+	}
+}
+
+func TestLoginCommandBuild(t *testing.T) {
+	tests := []struct {
+		name         string
+		launcher     ClusterLauncher
+		expectErr    bool
+		comparisonFN func(*testing.T, []string)
+	}{
+		{
+			name: "Validate that the first argument won't be replaced",
+			launcher: ClusterLauncher{
+				terminal:            []string{"%%CLUSTER_ID%%", "%%CLUSTER_ID%%"},
+				clusterLoginCommand: []string{"ocm", "backplane", "login"},
+			},
+			expectErr: false,
+			comparisonFN: func(t *testing.T, cmd []string) {
+				expected := "%%CLUSTER_ID%% abcdefg ocm backplane login"
+				if strings.Join(cmd, " ") != expected {
+					t.Fatalf("Expected command to be %s, got %s", expected, strings.Join(cmd, " "))
+				}
+			},
+		},
+		{
+			name: "validate that cluster login command can be replaced",
+			launcher: ClusterLauncher{
+				terminal:            []string{"gnome-terminal"},
+				clusterLoginCommand: []string{"ocm", "%%CLUSTER_ID%%", "backplane", "login", "-C", "%%CLUSTER_ID%%", "--manager"},
+			},
+			expectErr: false,
+			comparisonFN: func(t *testing.T, cmd []string) {
+				expected := "gnome-terminal ocm abcdefg backplane login -C abcdefg --manager"
+				if strings.Join(cmd, " ") != expected {
+					t.Fatalf("Expected command to be %s, got: %s", expected, strings.Join(cmd, " "))
+				}
+			},
+		},
+		{
+			name: "validate that the cluster login command can be collapsed to a single string",
+			launcher: ClusterLauncher{
+				terminal:            []string{"tmux", "new-window", "-n", "%%CLUSTER_ID%%"},
+				clusterLoginCommand: []string{"ocm-container", "-C", "%%CLUSTER_ID%%"},
+				settings:            launcherSettings{collapseLoginCommand: true},
+			},
+			expectErr: false,
+			comparisonFN: func(t *testing.T, cmd []string) {
+				expected := []string{"tmux", "new-window", "-n", "abcdefg", "ocm-container -C abcdefg"}
+				if len(expected) != len(cmd) {
+					t.Fatalf("Expected command slice %#v but got %#v", expected, cmd)
+				}
+				for k, _ := range cmd {
+					if cmd[k] != expected[k] {
+						t.Fatalf("Expected command slice %#v but got %#v", expected, cmd)
+					}
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmd, err := test.launcher.BuildLoginCommand("abcdefg")
+			if test.expectErr && err == nil {
+				t.Fatal("Expected an error and got none")
+			}
+			if !test.expectErr && err != nil {
+				t.Fatalf("Was not expecting an error but got: %v", err)
+			}
+
+			test.comparisonFN(t, cmd)
+		})
+	}
+}

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/clcollins/srepd/pkg/launcher"
 	"github.com/clcollins/srepd/pkg/pd"
 )
 
@@ -18,7 +19,7 @@ type model struct {
 
 	config   *pd.Config
 	editor   []string
-	launcher ClusterLauncher
+	launcher launcher.ClusterLauncher
 
 	table table.Model
 	input textinput.Model
@@ -45,7 +46,7 @@ func InitialModel(
 	user string,
 	ignoredusers []string,
 	editor []string,
-	launcher ClusterLauncher,
+	launcher launcher.ClusterLauncher,
 ) (tea.Model, tea.Cmd) {
 	if d {
 		debugLogging = true


### PR DESCRIPTION
### What type of PR is this?

Feature/Cleanup

### What this PR does / Why we need it?

Reconfigures the launcher to work with Tmux, MacOS default Terminal and adds docs on how to use this with iTerm2 on MacOS. Should contain no breaking changes for existing users.

### Which Jira/Github issue(s) does this PR fix?

### Special notes for your reviewer

Will need to be tested with a linux machine. Specifically if there are existing configurations I want to make sure they're not breaking.
~Also still needs some docs updates.~

### Pre-checks (if applicable)

- [x] Ran unit tests locally against the changes
- [x] Included documentation changes with PR

