### PR TITLE
Ensure incident ID is retrieved for each selected row per update

### DIFF
--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -106,6 +106,11 @@ type gotIncidentMsg struct {
 }
 
 func getIncident(p *pd.Config, id string) tea.Cmd {
+	if id == "" {
+		return func() tea.Msg {
+			return setStatusMsg{"No incident selected"}
+		}
+	}
 	return func() tea.Msg {
 		ctx := context.Background()
 		i, err := p.Client.GetIncidentWithContext(ctx, id)
@@ -425,11 +430,8 @@ func acknowledged(a []pagerduty.Acknowledgement) string {
 func doIfIncidentSelected(m *model, cmd tea.Cmd) tea.Cmd {
 	if m.table.SelectedRow() == nil {
 		log.Debug("doIfIncidentSelected", "selectedRow", "nil")
-		m.setStatus(nilIncidentErr)
 		m.viewingIncident = false
-		return tea.Sequence(
-			func() tea.Msg { return errMsg{errors.New(nilIncidentErr)} },
-		)
+		return func() tea.Msg { return setStatusMsg{nilIncidentMsg} }
 	}
 	log.Debug("doIfIncidentSelected", "selectedRow", m.table.SelectedRow())
 	return tea.Sequence(

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -70,6 +70,19 @@ func InitialModel(
 	}
 }
 
+func (m *model) clearSelectedIncident(reason interface{}) {
+	if m.selectedIncident != nil {
+		log.Debug("clearSelectedIncident", "selectedIncident", m.selectedIncident.ID, "cleared", false)
+		// Don't return here - we still want to clear out any notes/alerts and viewingIncident
+		// even if the incident might be nil
+	}
+	m.selectedIncident = nil
+	m.selectedIncidentNotes = nil
+	m.selectedIncidentAlerts = nil
+	m.viewingIncident = false
+	log.Debug("clearSelectedIncident", "selectedIncident", m.selectedIncident, "cleared", true, "reason", reason)
+}
+
 func (m *model) setStatus(msg string) {
 	log.Info("setStatus", "status", msg)
 	m.status = msg

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -119,6 +119,7 @@ func switchTableFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, func() tea.Msg { return updatedIncidentListMsg{m.incidentList, nil} })
 
 		case key.Matches(msg, defaultKeyMap.Refresh):
+			m.clearSelectedIncident(msg.String() + " (refresh)")
 			m.setStatus(loadingIncidentsStatus)
 			cmds = append(cmds, updateIncidentList(m.config))
 
@@ -218,10 +219,7 @@ func switchIncidentFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// This un-sets the selected incident and returns to the table view
 		case key.Matches(msg, defaultKeyMap.Back):
-			m.viewingIncident = false
-			m.selectedIncident = nil
-			m.selectedIncidentAlerts = nil
-			m.selectedIncidentNotes = nil
+			m.clearSelectedIncident(msg.String() + " (back)")
 
 		case key.Matches(msg, defaultKeyMap.Ack):
 			return m, func() tea.Msg { return acknowledgeIncidentsMsg{incidents: []*pagerduty.Incident{m.selectedIncident}} }

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -362,10 +362,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		)
 
 	case clearSelectedIncidentsMsg:
-		m.viewingIncident = false
-		m.selectedIncident = nil
-		m.selectedIncidentNotes = nil
-		m.selectedIncidentAlerts = nil
+		m.clearSelectedIncident(msg)
 		return m, nil
 	}
 

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -16,10 +16,15 @@ const (
 	defaultInputPrompt = " $ "
 	u
 	nilNoteErr     = "incident note content is empty"
-	nilIncidentErr = "no incident selected"
+	nilIncidentMsg = "no incident selected"
 )
 
 type errMsg struct{ error }
+type setStatusMsg struct{ string }
+
+func (s setStatusMsg) Status() string {
+	return s.string
+}
 
 func (m model) Init() tea.Cmd {
 	if m.err != nil {
@@ -80,8 +85,17 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		return m.keyMsgHandler(msg)
 
+	case setStatusMsg:
+		return m.setStatusMsgHandler(msg)
+
 	// Command to get an incident by ID
 	case getIncidentMsg:
+		if msg == "" {
+			return m, func() tea.Msg {
+				return setStatusMsg{"no incident selected"}
+			}
+		}
+
 		m.setStatus(fmt.Sprintf("getting details for incident %v...", msg))
 		cmds = append(cmds, getIncident(m.config, string(msg)))
 


### PR DESCRIPTION
This adds a call to get the incident id of the incident
represented in the selcted row each time the table view is updated, and
this ID is used to select the incident with getSelectedIncident().

This ensures that the currently highlighted row is always the incident
that is acted upon in table view, rather than a previously selected
incident.

When no row is selected, attempts to act on an incident return a status
message to that effect, rather than panicing.

Fixes https://github.com/clcollins/srepd/issues/44
Fixes https://github.com/clcollins/srepd/issues/50
Fixes https://github.com/clcollins/srepd/issues/52

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
