### PR TITLE
Remove wordwrap to compact incident output

### DIFF
--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -307,12 +307,10 @@ Details :
 func renderIncidentMarkdown(content string) (string, error) {
 	renderer, err := glamour.NewTermRenderer(
 		glamour.WithAutoStyle(),
-		glamour.WithWordWrap(windowSize.Width),
 	)
 	if err != nil {
 		return "", err
 	}
-
 	str, err := renderer.Render(content)
 	if err != nil {
 		return str, err


### PR DESCRIPTION
The word wrapping option passed to the glamour markdown renderer is
assing new lines to the output of the incident view screen.  This
removes the wordwrapping, condensing the output and makign the view a
bit more orderly.

Fixes #55

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
