### PR TITLE
Suppress multiple acks in issue view

### DIFF
--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"html/template"
+	"slices"
 	"strings"
 
 	"github.com/PagerDuty/go-pagerduty"
@@ -238,8 +239,12 @@ func summarizeIncident(i *pagerduty.Incident) incidentSummary {
 	for _, asn := range i.Assignments {
 		s.Assigned = append(s.Assigned, asn.Assignee.Summary)
 	}
+
 	for _, ack := range i.Acknowledgements {
-		s.Acknowledged = append(s.Acknowledged, ack.Acknowledger.Summary)
+		// Suppress multiple acknowledgements by the same person being shown in the summary
+		if !slices.Contains(s.Acknowledged, ack.Acknowledger.Summary) {
+			s.Acknowledged = append(s.Acknowledged, ack.Acknowledger.Summary)
+		}
 	}
 
 	return s


### PR DESCRIPTION
When viewing an issue, if the same person has acked the issue multiple
times, it shows up as multiple acks in the acknowledgement list.  This
PR suppresses multiple acks by the same person, showing only the first.

Fixes # 46

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
