### PR TITLE
Add option to re-escalate the alert

### DIFF
--- a/pkg/tui/keymap.go
+++ b/pkg/tui/keymap.go
@@ -11,7 +11,7 @@ func (k keymap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		// Each slice here is a column in the help window
 		{k.Up, k.Down, k.Enter, k.Back},
-		{k.Ack, k.Note, k.Silence},
+		{k.Ack, k.UnAck, k.Note, k.Silence},
 		{k.Login, k.Open},
 		{k.Team, k.Refresh, k.AutoRefresh, k.AutoAck},
 		{k.Quit, k.Help},
@@ -33,6 +33,7 @@ type keymap struct {
 	Note        key.Binding
 	Silence     key.Binding
 	Ack         key.Binding
+	UnAck       key.Binding
 	AutoAck     key.Binding
 	Input       key.Binding
 	Login       key.Binding
@@ -95,6 +96,10 @@ var defaultKeyMap = keymap{
 	Ack: key.NewBinding(
 		key.WithKeys("a"),
 		key.WithHelp("a", "acknowledge"),
+	),
+	UnAck: key.NewBinding(
+		key.WithKeys("ctrl+e"),
+		key.WithHelp("ctrl+e", "re-escalate"),
 	),
 	AutoAck: key.NewBinding(
 		key.WithKeys("ctrl+a"),

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -61,7 +61,6 @@ func (m model) windowSizeMsgHandler(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	estimatedExtraLinesFromComponents := 7 // TODO: figure out how to calculate this
 
-
 	horizontalScratchWidth := horizontalMargins + horizontalPadding + horizontalBorders
 	verticalScratchWidth := verticalMargins + verticalPadding + verticalBorders
 
@@ -219,7 +218,13 @@ func switchTableFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(msg, defaultKeyMap.Ack):
 			return m, doIfIncidentSelected(&m, tea.Sequence(
 				func() tea.Msg { return getIncidentMsg(incidentID) },
-				func() tea.Msg { return waitForSelectedIncidentsThenAcknowledgeMsg("wait") },
+				func() tea.Msg { return waitForSelectedIncidentsThenAcknowledgeMsg("Ack") },
+			))
+
+		case key.Matches(msg, defaultKeyMap.UnAck):
+			return m, doIfIncidentSelected(&m, tea.Sequence(
+				func() tea.Msg { return getIncidentMsg(incidentID) },
+				func() tea.Msg { return waitForSelectedIncidentsThenUnAcknowledgeMsg("UnAck") },
 			))
 
 		case key.Matches(msg, defaultKeyMap.Note):


### PR DESCRIPTION
Adds a key command (ctrl+e) to re-assign the alert to the escalation
policy level 1 (ie: re-escalate), to reassign at the end of an SRE's
shift.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
