### PR TITLE
Add incident summary as initial content when adding a note

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Features:
 * Reassign incidents to a (configured) "silent" user (ie. silence the alert)
 * Acknowledge incidents
 * Resizes nicely(-ish) when the terminal is resized
+* Un-Acknowledge incidents (re-assign to the Escalation Policy)
 
 Planned Features:
 
-* Un-Acknowledge incidents (re-assign to the Escalation Policy)
 * View arbitrary incidents
 * Assign incidents to any PagerDuty User ID
 * Edit incident titles

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -61,7 +61,6 @@ func (m model) windowSizeMsgHandler(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	estimatedExtraLinesFromComponents := 7 // TODO: figure out how to calculate this
 
-
 	horizontalScratchWidth := horizontalMargins + horizontalPadding + horizontalBorders
 	verticalScratchWidth := verticalMargins + verticalPadding + verticalBorders
 
@@ -226,7 +225,8 @@ func switchTableFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, doIfIncidentSelected(&m, tea.Sequence(
 				func() tea.Msg { return getIncidentMsg(incidentID) },
 				func() tea.Msg {
-					return waitForSelectedIncidentThenDoMsg{action: openEditorCmd(m.editor), msg: "add note"}
+					msg := "add note"
+					return waitForSelectedIncidentThenDoMsg{action: func() tea.Msg { return parseTemplateForNoteMsg(msg) }, msg: msg}
 				},
 			))
 
@@ -294,9 +294,6 @@ func switchIncidentFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case key.Matches(msg, defaultKeyMap.Silence):
 			return m, func() tea.Msg { return silenceSelectedIncidentMsg{} }
-
-		case key.Matches(msg, defaultKeyMap.Note):
-			cmds = append(cmds, openEditorCmd(m.editor))
 
 		case key.Matches(msg, defaultKeyMap.Refresh):
 			return m, func() tea.Msg { return getIncidentMsg(m.selectedIncident.ID) }

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -253,6 +253,18 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.setStatus(fmt.Sprintf("showing %d/%d incidents...", len(m.table.Rows()), totalIncidentCount))
 		}
 
+	case parseTemplateForNoteMsg:
+		if m.selectedIncident == nil {
+			m.setStatus("failed to open editor - no selected incident")
+		}
+		cmds = append(cmds, parseTemplateForNote(m.selectedIncident))
+
+	case parsedTemplateForNoteMsg:
+		if msg.err != nil {
+			return m, func() tea.Msg { return errMsg{msg.err} }
+		}
+		cmds = append(cmds, openEditorCmd(m.editor, msg.content))
+
 	case editorFinishedMsg:
 		if msg.err != nil {
 			return m, func() tea.Msg { return errMsg{msg.err} }

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -96,6 +96,7 @@ var (
 
 	paddedStyle = mainStyle.Padding(0, 2, 0, 1)
 
+	//lint:ignore U1000 - future proofing
 	warningStyle = lipgloss.NewStyle().Foreground(srepdPallet.warning.text).Background(srepdPallet.warning.background)
 
 	tableContainerStyle = lipgloss.NewStyle().Border(lipgloss.RoundedBorder(), true)
@@ -242,6 +243,29 @@ func (m model) template() (string, error) {
 	err = template.Execute(o, summary)
 	if err != nil {
 		// TODO: Figure out how to handle this with a proper errMsg
+		return "", err
+	}
+
+	return o.String(), nil
+}
+
+func addNoteTemplate(id string, title string, service string) (string, error) {
+	template, err := template.New("note").Parse(noteTemplate)
+	if err != nil {
+		return "", err
+	}
+
+	o := new(bytes.Buffer)
+	err = template.Execute(o, struct {
+		ID      string
+		Title   string
+		Service string
+	}{
+		ID:      id,
+		Title:   title,
+		Service: service,
+	})
+	if err != nil {
 		return "", err
 	}
 
@@ -456,3 +480,14 @@ func renderIncidentMarkdown(content string) (string, error) {
 
 	return str, nil
 }
+
+const noteTemplate = `
+
+# Please enter the note message content above. Lines starting
+# with '#' will be ignored and an empty message aborts the note.
+#
+# Incident: {{ .ID }}
+# Summary: {{ .Title }}
+# Service: {{ .Service }}
+#
+`


### PR DESCRIPTION
Adds an incident summary (format below) to the initial content when
opening the editor to add a note to an incident, and drops comment lines
("#") before writing the note, mirroring the behavior of a git commit
message.

Fixes #37

Format:

```
# Please enter the note message content above. Lines starting
# with '#' will be ignored and an empty message aborts the note.
#
# Incident: {{ .ID }}
# Summary: {{ .Title }}
# Service: {{ .Service }}
#
```

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
