### PR TITLE
Adds initial framework for tests in commands.go

### DIFF
--- a/pkg/pd/mock.go
+++ b/pkg/pd/mock.go
@@ -1,0 +1,64 @@
+package pd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/PagerDuty/go-pagerduty"
+)
+
+var ErrMockError = fmt.Errorf("pd.Mock(): mock error") // Used to mock errors in unit tests
+
+type MockPagerDutyClient struct {
+	PagerDutyClient
+}
+
+func (m *MockPagerDutyClient) GetTeamWithContext(ctx context.Context, team string) (*pagerduty.Team, error) {
+	return &pagerduty.Team{Name: team}, nil
+}
+
+func (m *MockPagerDutyClient) GetIncidentWithContext(ctx context.Context, id string) (*pagerduty.Incident, error) {
+	// Provided so we can mock error responses for unit tests
+	if id == "err" {
+		return &pagerduty.Incident{}, ErrMockError
+	}
+	return &pagerduty.Incident{
+		APIObject: pagerduty.APIObject{
+			ID: id, // Incidents will always come back with the same ID as the request
+		},
+	}, nil
+}
+
+func (m *MockPagerDutyClient) ListIncidentAlertsWithContext(ctx context.Context, id string, opts pagerduty.ListIncidentAlertsOptions) (*pagerduty.ListAlertsResponse, error) {
+	if id == "err" {
+		return &pagerduty.ListAlertsResponse{}, ErrMockError
+	}
+	return &pagerduty.ListAlertsResponse{
+		Alerts: []pagerduty.IncidentAlert{
+			{
+				APIObject: pagerduty.APIObject{
+					ID: "QABCDEFG1234567",
+				},
+			},
+			{
+				APIObject: pagerduty.APIObject{
+					ID: "QABCDEFG7654321",
+				},
+			},
+		},
+	}, nil
+}
+
+func (m *MockPagerDutyClient) ListIncidentNotesWithContext(ctx context.Context, id string) ([]pagerduty.IncidentNote, error) {
+	if id == "err" {
+		return []pagerduty.IncidentNote{}, ErrMockError
+	}
+	return []pagerduty.IncidentNote{
+		{
+			ID: "QABCDEFG1234567",
+		},
+		{
+			ID: "QABCDEFG7654321",
+		},
+	}, nil
+}

--- a/pkg/pd/pd_test.go
+++ b/pkg/pd/pd_test.go
@@ -1,7 +1,6 @@
 package pd
 
 import (
-	"context"
 	"errors"
 	"reflect"
 	"testing"
@@ -9,14 +8,6 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 	"github.com/stretchr/testify/assert"
 )
-
-type MockPagerDutyClient struct {
-	PagerDutyClient
-}
-
-func (m *MockPagerDutyClient) GetTeamWithContext(ctx context.Context, team string) (*pagerduty.Team, error) {
-	return &pagerduty.Team{Name: team}, nil
-}
 
 func TestGetTeams(t *testing.T) {
 	t.Run("GetTeams", func(t *testing.T) {

--- a/pkg/rand/rand.go
+++ b/pkg/rand/rand.go
@@ -1,0 +1,29 @@
+package rand
+
+// Credit to https://www.calhoun.io/creating-random-strings-in-go/
+
+import (
+	"math/rand"
+	"time"
+)
+
+const charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+var seededRand *rand.Rand = rand.New(
+	rand.NewSource(time.Now().UnixNano()))
+
+func StringWithCharset(length int, charset string) string {
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[seededRand.Intn(len(charset))]
+	}
+	return string(b)
+}
+
+func String(length int) string {
+	return StringWithCharset(length, charset)
+}
+
+func ID(prefix string) string {
+	return prefix + String(13)
+}

--- a/pkg/tui/commands_test.go
+++ b/pkg/tui/commands_test.go
@@ -1,12 +1,171 @@
 package tui
 
-import "testing"
+import (
+	"fmt"
+	"testing"
 
-//lint:ignore U1000 - future proofing
-func TestUpdateIncidentList(t *testing.T) {
-	// updateIncidentList accepts a pointer to a pd.Config struct
-	// and returns a tea.Cmd function. The tea.Cmd function returns
-	// a tea.Msg function. The tea.Msg function returns an
-	// updatedIncidentListMsg struct and an error.
+	"github.com/PagerDuty/go-pagerduty"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/clcollins/srepd/pkg/pd"
+	"github.com/clcollins/srepd/pkg/rand"
+	"github.com/stretchr/testify/assert"
+)
 
+func TestGetIncident(t *testing.T) {
+	mockConfig := &pd.Config{
+		Client: &pd.MockPagerDutyClient{},
+	}
+	id := rand.ID("Q") // simulate a PagerDuty alert ID
+
+	tests := []struct {
+		name     string
+		config   *pd.Config
+		id       string
+		expected tea.Msg
+	}{
+		{
+			name:     "return setStatusMsg if incident id is nil",
+			config:   mockConfig,
+			id:       "",
+			expected: setStatusMsg{nilIncidentMsg},
+		},
+		{
+			name:   "return gotIncidentMsg if incident id is provided",
+			config: mockConfig,
+			id:     id,
+			expected: gotIncidentMsg{
+				incident: &pagerduty.Incident{
+					APIObject: pagerduty.APIObject{
+						ID: id,
+					},
+				},
+				err: nil,
+			},
+		},
+		{
+			name:   "return gotIncidentMsg with not-nil error if error occurs",
+			config: mockConfig,
+			id:     "err", // "err" signals the mock client to produce a mock error
+			expected: gotIncidentMsg{
+				incident: &pagerduty.Incident{},
+				err:      pd.ErrMockError,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := getIncident(test.config, test.id)
+			msg := cmd()
+			assert.Equal(t, msg, test.expected)
+		})
+	}
+}
+
+func TestGetIncidentAlerts(t *testing.T) {
+	mockConfig := &pd.Config{
+		Client: &pd.MockPagerDutyClient{},
+	}
+	tests := []struct {
+		name     string
+		config   *pd.Config
+		id       string
+		expected tea.Msg
+	}{
+		{
+			name:     "return setStatusMsg if incident id is nil",
+			config:   mockConfig,
+			id:       "",
+			expected: setStatusMsg{nilIncidentMsg},
+		},
+		{
+			name:   "return gotIncidentAlertsMsg if incident id is provided",
+			config: mockConfig,
+			id:     rand.ID("Q"),
+			expected: gotIncidentAlertsMsg{
+				alerts: []pagerduty.IncidentAlert{
+					{
+						APIObject: pagerduty.APIObject{
+							ID: "QABCDEFG1234567",
+						},
+					},
+					{
+						APIObject: pagerduty.APIObject{
+							ID: "QABCDEFG7654321",
+						},
+					},
+				},
+				err: nil,
+			},
+		},
+		{
+			name:   "return gotIncidentAlertsMsg with not-nil error if error occurs",
+			config: mockConfig,
+			id:     "err", // "err" signals the mock client to produce a mock error
+			expected: gotIncidentAlertsMsg{
+				alerts: nil,
+				err:    fmt.Errorf("pd.GetAlerts(): failed to get alerts for incident `%v`: %v", "err", pd.ErrMockError),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := getIncidentAlerts(test.config, test.id)
+			msg := cmd()
+			assert.Equal(t, msg, test.expected)
+		})
+	}
+}
+
+func TestGetIncidentNotes(t *testing.T) {
+	mockConfig := &pd.Config{
+		Client: &pd.MockPagerDutyClient{},
+	}
+	tests := []struct {
+		name     string
+		config   *pd.Config
+		id       string
+		expected tea.Msg
+	}{
+		{
+			name:     "return setStatusMsg if incident id is nil",
+			config:   mockConfig,
+			id:       "",
+			expected: setStatusMsg{nilIncidentMsg},
+		},
+		{
+			name:   "return gotIncidentNotesMsg if incident id is provided",
+			config: mockConfig,
+			id:     rand.ID("Q"),
+			expected: gotIncidentNotesMsg{
+				notes: []pagerduty.IncidentNote{
+					{
+						ID: "QABCDEFG1234567",
+					},
+					{
+						ID: "QABCDEFG7654321",
+					},
+				},
+				err: nil,
+			},
+		},
+		{
+			name:   "return gotIncidentNotesMsg with not-nil error if error occurs",
+			config: mockConfig,
+			id:     "err", // "err" signals the mock client to produce a mock error
+			expected: gotIncidentNotesMsg{
+				notes: []pagerduty.IncidentNote{},
+				err:   fmt.Errorf("pd.GetNotes(): failed to get incident notes `%v`: %v", "err", pd.ErrMockError),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := getIncidentNotes(test.config, test.id)
+			msg := cmd()
+			assert.Equal(t, msg, test.expected)
+		})
+	}
 }

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -77,6 +77,21 @@ func filterMsgContent(msg tea.Msg) tea.Msg {
 	}
 }
 
+// The Update function is called for every message that is sent to the model,
+// and it is responsible for updating the model based on the message and returning
+// the new model and a command to execute.  These commands should be actual
+// tea.Cmds, not functions that return tea.Msgs, though that signature is also a
+// tea.Cmd, unless Update should handle the msg, or the msg is a tea.Batch or
+// tea.Sequence.
+//
+// eg, good:
+// return m, getIncident(m.config, msg.incident.ID)
+//
+// eg, ok:
+// return m, func() tea.Msg { return errMsg{msg.err} }
+//
+// eg, bad:
+// return m, func() tea.Msg { getIncident(m.config, msg.incident.ID) }
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	msgType := reflect.TypeOf(msg)
 	// PollIncidentsMsgs are not helpful for logging


### PR DESCRIPTION
This adds initial tests and a pattern to use as a framework for adding
unit tests for the rest of the `tea.Cmd` functions in `commands.go`, as well
as explanation of the pattern for future contributors.

The `tui.go` `Update()` command will receive `tea.Msg`s and return `tea.Cmd`s.
All the `tea.Cmds` (except those in the actual Bubble Tea framework) will
be collected in `commands.go`.  Each command will have an outgoing `tea.Msg`
that contains any relevant results. Commands may also have incoming
`tea.Msg`s, but these are deprecated as the `Update()` function is
converted to call commands directly rather than `func() tea.Msg {}`
commands, which are an unnecessary intermediary.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
