### PR TITLE
Trigger an immediate refresh of the incident list when turning on auto-refresh

### DIFF
--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -114,7 +114,7 @@ func (m model) keyMsgHandler(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	if key.Matches(msg.(tea.KeyMsg), defaultKeyMap.AutoRefresh) {
 		m.autoRefresh = !m.autoRefresh
-		return m, nil
+		return m, updateIncidentList(m.config)
 	}
 
 	if key.Matches(msg.(tea.KeyMsg), defaultKeyMap.AutoAck) {

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -117,13 +117,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case setStatusMsg:
 		return m.setStatusMsgHandler(msg)
+
 	// Command to trigger a regular poll for new incidents
 	case PollIncidentsMsg:
 		if !m.autoRefresh {
 			return m, nil
 		}
-		m.setStatus("polling for new incidents...")
-		return m, func() tea.Msg { return updateIncidentListMsg("sender: PollIncidentsMsg") }
+		return m, updateIncidentList(m.config)
 
 	// Command to get an incident by ID
 	case getIncidentMsg:


### PR DESCRIPTION
Auto-refresh should immediately poll for new incidents when enabled,
rather than awaiting the PollIncidentsMsg.

Fixes #81 

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
