### PR TITLE
Add framework for scheduled jobs; convert auto-refresh

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,7 +39,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const pollInterval = 15
+const tickInterval = 1
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -86,10 +86,8 @@ but rather a simple tool to make on-call tasks easier.`,
 
 		go func() {
 			for {
-				time.Sleep(pollInterval * time.Second)
-				p.Send(tui.PollIncidentsMsg{
-					PollInterval: pollInterval * time.Second,
-				})
+				time.Sleep(tickInterval * time.Second)
+				p.Send(tui.TickMsg{})
 			}
 		}()
 

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -174,11 +174,9 @@ type waitForSelectedIncidentThenDoMsg struct {
 }
 
 type TickMsg struct {
-	Tick int
 }
-type PollIncidentsMsg struct {
-	PollInterval time.Duration
-}
+
+type PollIncidentsMsg struct{}
 
 type renderIncidentMsg string
 
@@ -639,4 +637,16 @@ func doIfIncidentSelected(m *model, cmd tea.Cmd) tea.Cmd {
 		func() tea.Msg { return getIncidentMsg(m.table.SelectedRow()[1]) },
 		cmd,
 	)
+}
+
+func runScheduledJobs(m *model) []tea.Cmd {
+	var cmds []tea.Cmd
+	for _, job := range m.scheduledJobs {
+		if time.Since(job.lastRun) > job.frequency && job.jobMsg != nil {
+			log.Debug("Update: TicketMsg", "scheduledJob", job.jobMsg, "frequency", job.frequency, "lastRun", job.lastRun, "running", true)
+			cmds = append(cmds, job.jobMsg)
+			job.lastRun = time.Now()
+		}
+	}
+	return cmds
 }

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"time"
+
 	"github.com/PagerDuty/go-pagerduty"
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/table"
@@ -11,6 +13,13 @@ import (
 	"github.com/clcollins/srepd/pkg/launcher"
 	"github.com/clcollins/srepd/pkg/pd"
 )
+
+var initialScheduledJobs = []*scheduledJob{
+	{
+		jobMsg:    func() tea.Msg { return PollIncidentsMsg{} },
+		frequency: time.Second * 15,
+	},
+}
 
 type model struct {
 	err error
@@ -32,6 +41,8 @@ type model struct {
 	selectedIncident       *pagerduty.Incident
 	selectedIncidentNotes  []pagerduty.IncidentNote
 	selectedIncidentAlerts []pagerduty.IncidentAlert
+
+	scheduledJobs []*scheduledJob
 
 	autoAcknowledge bool
 	autoRefresh     bool
@@ -60,6 +71,7 @@ func InitialModel(
 		input:          newTextInput(),
 		incidentViewer: newIncidentViewer(),
 		status:         "",
+		scheduledJobs:  append([]*scheduledJob{}, initialScheduledJobs...),
 	}
 
 	// This is an ugly way to handle this error

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -45,6 +45,12 @@ type filteredMsg struct {
 	truncated bool
 }
 
+type scheduledJob struct {
+	jobMsg    tea.Cmd
+	lastRun   time.Time
+	frequency time.Duration
+}
+
 func filterMsgContent(msg tea.Msg) tea.Msg {
 	var truncatedMsg string
 	switch msg := msg.(type) {
@@ -94,8 +100,8 @@ func filterMsgContent(msg tea.Msg) tea.Msg {
 // return m, func() tea.Msg { getIncident(m.config, msg.incident.ID) }
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	msgType := reflect.TypeOf(msg)
-	// PollIncidentsMsgs are not helpful for logging
-	if msgType != reflect.TypeOf(PollIncidentsMsg{}) {
+	// TickMsg are not helpful for logging
+	if msgType != reflect.TypeOf(TickMsg{}) {
 		log.Debug("Update", msgType, filterMsgContent(msg))
 	}
 
@@ -107,7 +113,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.errMsgHandler(msg)
 
 	case TickMsg:
-		// Pass
+		return m, tea.Batch(runScheduledJobs(&m)...)
 
 	case tea.WindowSizeMsg:
 		return m.windowSizeMsgHandler(msg)
@@ -117,6 +123,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case setStatusMsg:
 		return m.setStatusMsgHandler(msg)
+
 	// Command to trigger a regular poll for new incidents
 	case PollIncidentsMsg:
 		if !m.autoRefresh {


### PR DESCRIPTION
This PR adds a framework for "scheduled jobs" and passes "TickMsg"
messages to the Update() function based on an interval set in the
root.go file (currently 1s per "tick").

This also converts the auto-refresh to a scheduled job, and sets a slice
of initial `[]*scheduledJob`. Each scheduled job is made up of:

```
type scheduledJob struct {
	jobMsg    tea.Cmd
	lastRun   time.Time
	frequency time.Duration
}
```

And the `jobMsg` `tea.Cmd` is run if the `lastRun` is further than `frequency` in
the past.  Each scheduled job is evalusted when a `TickMsg` is received.

The auto refresh feature is implemented as:

```
	{
		jobMsg:    func() tea.Msg { return PollIncidentsMsg{} },
		frequency: time.Second * 15,
	},
```

This job is added to the list of initial secheduled jobs on startup.
Currently, the job is run every 15 seconds, and if "auto-refresh" is
enabled, then incidents are updated.  In the future this will be
converted to adding or removing the scheduled job from the job list,
rather than parsing if "auto-refresh" is true or not, and `autoRefresh
bool` removed from the model.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
