### PR TITLE
Fix error handling for exec of "launch" command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,18 +18,15 @@ export GOPROXY=https://proxy.golang.org
 # Disable CGO so that we always generate static binaries:
 export CGO_ENABLED=0
 
+default: build
 
 .PHONY: build
 build:
-	goreleaser build --snapshot  --clean --single-target
+	$(GOENV) go build -o build/$(PROJECT_NAME) .
 
 .PHONY: install
-install:
-	go build -o ${GOPATH}/bin/srepd .
-
-.PHONY: install-local
-install-local: build
-	cp dist/*/srepd ~/.local/bin/srepd
+install: build
+	cp build/srepd ~/.local/bin/$(PROJECT_NAME)
 
 .PHONY: mod
 mod:

--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ Planned Features:
 
 SREPD uses the [Viper](https://github.com/spf13/viper) configuration setup, and will read required values from `~/.config/srepd/srepd.yaml`.
 
-Configuration variables have the following precedence: 
+Configuration variables have the following precedence:
 
 `command line arguments > environment variables > config file values`
 
-**Required Values**
+### Required Values
 
 * token: A PagerDuty Oauth Token
 * teams: A list of PagerDuty team IDs to gather incidents for
@@ -52,18 +52,18 @@ service_escalation_policies:
   PABC123: PXYZ890
 ```
 
-**Optional Values**
+### Optional Values
 
 * ignoredusers: A list of PagerDuty user IDs to exclude from retrieved incident lists.
 * editor: Your choice of editor.  Defaults to the `$EDITOR` environment variable.
-* cluster_login_cmd: Command used to login to a cluster from SREPD.  Defaults to `/usr/local/bin/ocm backplane login`
+* cluster_login_command: Command used to login to a cluster from SREPD.  Defaults to `/usr/local/bin/ocm backplane login`
 * terminal: Your choice of terminal to use when launching external commands. Defaults to `/usr/bin/gnome-terminal`.
 
-__NOTE:__ The cluster_login_cmd and terminal accept a variable for `%%CLUSTER_ID%%` to stand in for the Cluster ID in the command. At least one of the two, most likely `cluster_login_cmd` MUST have the `%%CLUSTER_ID%%` placeholder set. See [AUTOMATIC LOGIN FEATURES](#automatic-login-features) for more details about config variables.
+**NOTE:** The cluster_login_command and terminal accept a variable for `%%CLUSTER_ID%%` to stand in for the Cluster ID in the command. At least one of the two, most likely `cluster_login_command` MUST have the `%%CLUSTER_ID%%` placeholder set. See [AUTOMATIC LOGIN FEATURES](#automatic-login-features) for more details about config variables.
 
 An example srepd.yaml file might look like so:
 
-```
+```yaml
 ---
 # Editor will always be overridden by the ENV variable
 # unless the ENV is not set for some reason
@@ -117,6 +117,7 @@ The easiest way to get started with SREPD, after adding the required config file
 To enable automatic login directly from SREPD you will need to configure the `terminal` and `cluster_login_command` settings in the srepd config file.
 
 ### Linux
+
 A typical linux configuration to launch a new terminal window may look something like what follows. Be sure to change to your preferred terminal or preferred ops environment (ocm-container, ocm-backplane session, osdctl session, etc)
 
 ```yaml
@@ -128,7 +129,6 @@ cluster_login_command: ocm backplane login %%CLUSTER_ID%%
 ```
 
 Each terminal has its own way of accepting an argument for a command to run after launching. Some examples known to work:
-
 
 ```yaml
 # Contour (in this example, via Flatpak)
@@ -150,11 +150,12 @@ terminal: terminator --execute
 cluster_login_command: ocm backplane login %%CLUSTER_ID%%
 ```
 
-
 ### MacOS
+
 Configuration for MacOS is not as straightforward because of the way that MacOS handles applications differently from Linux. We've provided a few separate ways to configure SREPD to handle automatic logins.
 
 #### Default MacOS terminal
+
 The following configuration will launch a new MacOS default terminal window to automatically login to a cluster. This example uses ocm-container but feel free to modify to fit your preferred workflow.
 
 ```yaml
@@ -164,6 +165,7 @@ cluster_login_command: tell application "Terminal" to do script "ocm-container -
 ```
 
 #### iTerm2 Support
+
 iTerm2 is even more special in the fact that you can't tell it to 'do script' like you can with the default Terminal on MacOS. You will need to create a separate shell script to invoke from SREPD that will then run the osascript command needed to create a new iTerm2 window/tab and call the login script.
 
 ```bash
@@ -192,8 +194,8 @@ terminal: tmux new-window --
 cluster_login_command: ocm backplane login %%CLUSTER_ID%%
 ```
 
-<a name="automatic-login-features"></a>
 ### Automatic Login Features
+
 The first feature of Automatic Login is the ability to replace certain strings with their cluster-specific details. When you pass `%%VARIABLE%%` in your `terminal` or `cluster_login_command` configuration strings they will dynamically be replaced with the alert-specific variable. This allows you to be able to put the specific details of these variables inside the command. The first argument of the `terminal` setting MUST NOT BE a replaceable value.
 
 Supported Variables:
@@ -206,7 +208,8 @@ Note regarding `%%CLUSTER_ID%%`:
 It's also important to note that if `%%CLUSTER_ID%%` does NOT appear in the `cluster_login_command` config setting that the cluster ID will be appended to the end of the cluster login command. If the replaceable `%%CLUSTER_ID%%` string is present in the `cluster_login_command` setting, it will NOT be appended to the end.
 
 Examples:
-```
+
+```text
 ## Assume the cluster ID for these examples is `abcdefg`
 
 ## effectively runs "ocm backplane login abcdefg --multi"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,7 +69,8 @@ but rather a simple tool to make on-call tasks easier.`,
 
 		launcher, err := launcher.NewClusterLauncher(viper.GetString("terminal"), viper.GetString("cluster_login_command"))
 		if err != nil {
-			log.Warn(err)
+			fmt.Println(err)
+			log.Fatal(err)
 		}
 
 		m, _ := tui.InitialModel(
@@ -93,6 +94,7 @@ but rather a simple tool to make on-call tasks easier.`,
 
 		_, err = p.Run()
 		if err != nil {
+			fmt.Println(err)
 			log.Fatal(err)
 		}
 	},

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -487,6 +487,7 @@ func login(vars map[string]string, launcher launcher.ClusterLauncher) tea.Cmd {
 	}
 
 	processErr := c.Wait()
+
 	if processErr != nil {
 		if exitError, ok := processErr.(*exec.ExitError); ok {
 			execExitErr := &execErr{
@@ -508,7 +509,8 @@ func login(vars map[string]string, launcher launcher.ClusterLauncher) tea.Cmd {
 	if err != nil {
 		log.Warn("tui.login():", "execStdErr", err.Error())
 		return func() tea.Msg {
-			return loginFinishedMsg{err}
+			// Do not return the execStdErr as an error
+			return loginFinishedMsg{}
 		}
 	}
 

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -33,6 +33,27 @@ const (
 	loadingIncidentsStatus = "loading incidents..."
 )
 
+type execErr struct {
+	Err        error
+	ExitErr    *exec.ExitError
+	ExecStdErr string
+}
+
+func (ee *execErr) Error() string {
+	// Podman will return errors with the same formatting as this program
+	// so strip out `Error: ` prefix and `\n` suffixes, since ocm-container
+	// will just put them back
+	s := ee.ExecStdErr
+	s = strings.TrimPrefix(s, "Error: ")
+	s = strings.TrimPrefix(s, "error: ")
+	s = strings.TrimSuffix(s, "\n")
+	return s
+}
+
+func (ee *execErr) Code() int {
+	return ee.ExitErr.ExitCode()
+}
+
 // TODO: Deprecate incoming message
 // getIncidentMsg is a message that triggers the fetching of an incident
 type getIncidentMsg string
@@ -411,51 +432,98 @@ func login(vars map[string]string, launcher launcher.ClusterLauncher) tea.Cmd {
 	c := exec.Command(command[0], command[1:]...)
 
 	log.Debug(fmt.Sprintf("tui.login(): %v", c.String()))
-	stderr, pipeErr := c.StderrPipe()
-	if pipeErr != nil {
-		log.Debug("tui.login():", "pipeErr", pipeErr.Error())
+
+	var stdOut io.ReadCloser
+	var stdOutPipeErr error
+	stdOut, stdOutPipeErr = c.StdoutPipe()
+	if stdOutPipeErr != nil {
+		log.Warn("tui.login():", "stdOutPipeErr", stdOutPipeErr.Error())
 		return func() tea.Msg {
-			return loginFinishedMsg{err: pipeErr}
+			return loginFinishedMsg{stdOutPipeErr}
 		}
 	}
 
-	err := c.Start()
+	var stdErr io.ReadCloser
+	var stdErrPipeErr error
+	stdErr, stdErrPipeErr = c.StderrPipe()
+	if stdErrPipeErr != nil {
+		log.Warn("tui.login():", "stdErrErr", stdErrPipeErr.Error())
+		return func() tea.Msg {
+			return loginFinishedMsg{stdErrPipeErr}
+		}
+	}
+
+	startCmdErr := c.Start()
+	if startCmdErr != nil {
+		log.Warn("tui.login():", "startCmdErr", startCmdErr.Error())
+		return func() tea.Msg {
+			return loginFinishedMsg{startCmdErr}
+		}
+	}
+
+	var out []byte
+	var stdOutReadErr error
+	out, stdOutReadErr = io.ReadAll(stdOut)
+	if stdOutReadErr != nil {
+		log.Warn("tui.login():", "stdOutReadErr", stdOutReadErr.Error())
+		return func() tea.Msg {
+			return loginFinishedMsg{stdOutReadErr}
+		}
+	}
+
+	var errOut []byte
+	var stdErrReadErr error
+	errOut, stdErrReadErr = io.ReadAll(stdErr)
+	if stdErrReadErr != nil {
+		log.Warn("tui.login():", "stdErrReadErr", stdErrReadErr.Error())
+		return func() tea.Msg {
+			return loginFinishedMsg{stdErrReadErr}
+		}
+	}
+
+	var err error
+	if len(errOut) > 0 {
+		err = errors.New(string(errOut))
+	}
+
+	processErr := c.Wait()
+	if processErr != nil {
+		if exitError, ok := processErr.(*exec.ExitError); ok {
+			execExitErr := &execErr{
+				Err:        processErr,
+				ExitErr:    exitError,
+				ExecStdErr: string(errOut),
+			}
+			log.Warn("tui.login():", "processErr", execExitErr)
+			return func() tea.Msg {
+				return loginFinishedMsg{execExitErr}
+			}
+		}
+		log.Warn("tui.login():", "processErr", processErr.Error())
+		return func() tea.Msg {
+			return loginFinishedMsg{processErr}
+		}
+	}
+
 	if err != nil {
-		log.Debug("tui.login():", "startErr", err.Error())
+		log.Warn("tui.login():", "execStdErr", err.Error())
 		return func() tea.Msg {
 			return loginFinishedMsg{err}
 		}
 	}
 
-	out, err := io.ReadAll(stderr)
-	if err != nil {
-		log.Debug("tui.login():", "loginStdErr", err.Error())
-		return func() tea.Msg {
-			return loginFinishedMsg{err}
-		}
-	}
-
-	// c.Wait() must be run after reading any output from stderrPipe
-	err = c.Wait()
-	if err != nil {
-		log.Debug("tui.login():", "waitErr", err.Error())
-		return func() tea.Msg {
-			return loginFinishedMsg{err}
-		}
-	}
-
+	var stdOutAsErr error
 	if len(out) > 0 {
-		outErr := fmt.Errorf("%s", out)
-		log.Debug("tui.login():", "outErr", outErr.Error())
+		stdOutAsErr = errors.New(string(out))
+		log.Warn("tui.login():", "stdOutAsErr", stdOutAsErr.Error())
 		return func() tea.Msg {
-			return loginFinishedMsg{outErr}
+			return loginFinishedMsg{stdOutAsErr}
 		}
 	}
 
 	return func() tea.Msg {
-		return loginFinishedMsg{err}
+		return loginFinishedMsg{}
 	}
-
 }
 
 type clearSelectedIncidentsMsg string


### PR DESCRIPTION
Adds additional/better error handling for the "launch" command, to
hopefully capture edge cases with gtk warning returned from konsole.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
