### PR TITLE
Implement text wrapping in incident view

### DIFF
--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -215,7 +215,7 @@ func renderIncident(m *model) tea.Cmd {
 			return errMsg{err}
 		}
 
-		content, err := renderIncidentMarkdown(t)
+		content, err := renderIncidentMarkdown(t, m.incidentViewer.Width)
 		if err != nil {
 			return errMsg{err}
 		}

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -494,10 +494,17 @@ Details :
 {{ end }}
 `
 
-func renderIncidentMarkdown(content string) (string, error) {
+func renderIncidentMarkdown(content string, width int) (string, error) {
+	// Glamour adds its own padding/margins, so we need to subtract some space
+	// to prevent content from extending beyond the viewport
+	adjustedWidth := width - 4
+	if adjustedWidth < 40 {
+		adjustedWidth = 40 // Minimum reasonable width
+	}
+
 	renderer, err := glamour.NewTermRenderer(
 		glamour.WithAutoStyle(),
-		glamour.WithWordWrap(0),
+		glamour.WithWordWrap(adjustedWidth),
 	)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## Summary
- Long lines in the incident view now wrap to fit within the viewport width instead of extending off the right edge of the screen
- The glamour markdown renderer adds its own internal padding/margins, so the width is adjusted to account for this to ensure proper wrapping

## Changes
- Modified `renderIncidentMarkdown` to accept a width parameter (pkg/tui/views.go:497)
- Pass viewport width from `renderIncident` to glamour renderer (pkg/tui/commands.go:218)
- Calculate adjusted width by subtracting 4 characters to account for glamour's internal padding (pkg/tui/views.go:500)
- Added minimum width safeguard of 40 characters to prevent issues with very narrow viewports (pkg/tui/views.go:501-503)
- Configure glamour with `WithWordWrap(adjustedWidth)` instead of `WithWordWrap(0)` (pkg/tui/views.go:507)

## Test plan
- [x] Run the application and view incidents with long lines
- [x] Verify text wraps appropriately within the viewport
- [x] Verify no horizontal scrolling is required
- [x] Test with various terminal widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)