### PR TITLE
Fix base64 encoding for ocm-container CLI compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ When using `ocm-container` as your cluster login command, srepd automatically pa
 The following environment variables are automatically set:
 
 * `PAGERDUTY_INCIDENT` - The PagerDuty incident ID
-* `ALERT_DETAILS` - Base64 URL-encoded JSON containing the full incident object, all associated alerts, and incident notes
+* `ALERT_DETAILS` - Base64-encoded JSON containing the full incident object, all associated alerts, and incident notes
 
 Example usage inside ocm-container:
 
@@ -237,7 +237,7 @@ Example usage inside ocm-container:
 # View the incident ID
 echo $PAGERDUTY_INCIDENT
 
-# Decode and view the full alert details (note: using base64 -d with URL encoding)
+# Decode and view the full alert details
 echo $ALERT_DETAILS | base64 -d | jq .
 
 # Extract specific alert information

--- a/README.md
+++ b/README.md
@@ -247,6 +247,6 @@ echo $ALERT_DETAILS | base64 -d | jq '.alerts[0].body.details.cluster_id'
 echo $ALERT_DETAILS | base64 -d | jq '.notes'
 ```
 
-**Note:** The `ALERT_DETAILS` variable uses base64 URL encoding (RFC 4648) without padding to avoid parsing issues with `=` characters.
+**Note:** The `ALERT_DETAILS` variable uses standard base64 encoding without padding to avoid parsing issues with `=` characters in ocm-container's env var handling.
 
 These environment variables are automatically added when you use the login feature (press `l` on an incident). No additional configuration is required.

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func main() {
 
 	// Use async writer to prevent log I/O from blocking the UI
 	asyncWriter := newAsyncWriter(f, 1000) // Buffer up to 1000 log messages
-	defer asyncWriter.Close()
+	defer asyncWriter.Close() //nolint:errcheck
 
 	log.SetOutput(asyncWriter)
 

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -448,9 +448,10 @@ func login(vars map[string]string, launcher launcher.ClusterLauncher, incident *
 		if err != nil {
 			log.Warn("tui.login(): failed to marshal alert data", "error", err)
 		} else {
-			// Use RawURLEncoding which doesn't add padding (no = characters)
-			// This avoids issues with ocm-container's env var parsing which splits on =
-			encoded := base64.RawURLEncoding.EncodeToString(jsonData)
+			// Use RawStdEncoding: standard base64 alphabet (+/) without padding (no = characters)
+			// No padding avoids issues with ocm-container's env var parsing which splits on =
+			// Standard alphabet ensures `echo $ALERT_DETAILS | base64 -d` works in the container
+			encoded := base64.RawStdEncoding.EncodeToString(jsonData)
 			envFlags = append(envFlags, "-e", fmt.Sprintf("ALERT_DETAILS=%s", encoded))
 		}
 	}

--- a/pkg/tui/commands_test.go
+++ b/pkg/tui/commands_test.go
@@ -458,14 +458,14 @@ func TestLoginEnvironmentVariables(t *testing.T) {
 			assert.NoError(t, err, "Failed to marshal alertData")
 			assert.NotNil(t, jsonData, "JSON data should not be nil")
 
-			// Test that it can be base64 URL encoded (without padding)
-			encoded := base64.RawURLEncoding.EncodeToString(jsonData)
+			// Test that it can be base64 encoded (standard alphabet, without padding)
+			encoded := base64.RawStdEncoding.EncodeToString(jsonData)
 			assert.NotEmpty(t, encoded, "Base64 encoding should not be empty")
 			// Verify no padding characters
-			assert.NotContains(t, encoded, "=", "RawURLEncoding should not contain = padding")
+			assert.NotContains(t, encoded, "=", "RawStdEncoding should not contain = padding")
 
 			// Test that it can be decoded back
-			decoded, err := base64.RawURLEncoding.DecodeString(encoded)
+			decoded, err := base64.RawStdEncoding.DecodeString(encoded)
 			assert.NoError(t, err, "Failed to decode base64")
 
 			var decodedData alertData

--- a/pkg/tui/model_test.go
+++ b/pkg/tui/model_test.go
@@ -267,11 +267,7 @@ func TestGetHighlightedIncident(t *testing.T) {
 			m.incidentList = tt.incidentList
 
 			// Set up table rows to match incident list
-			if tt.hasSelectedRow && len(tt.incidentList) > 0 {
-				// Manually set the cursor to simulate a selected row
-				// We'll use the test directly by creating a mock selected row
-				// Since we can't easily mock the table.SelectedRow(), we'll test by
-				// setting up the incident list and verifying the lookup logic
+			if tt.hasSelectedRow && len(tt.incidentList) > 0 { //nolint:staticcheck // placeholder for future selected row simulation
 			}
 
 			// For this test, we'll directly test the lookup logic

--- a/pkg/tui/model_test.go
+++ b/pkg/tui/model_test.go
@@ -266,10 +266,6 @@ func TestGetHighlightedIncident(t *testing.T) {
 			m := createTestModel()
 			m.incidentList = tt.incidentList
 
-			// Set up table rows to match incident list
-			if tt.hasSelectedRow && len(tt.incidentList) > 0 { //nolint:staticcheck // placeholder for future selected row simulation
-			}
-
 			// For this test, we'll directly test the lookup logic
 			// by simulating what getHighlightedIncident does
 			var result *pagerduty.Incident

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -252,17 +252,6 @@ func (m model) renderHeader() string {
 	return s.String()
 }
 
-func (m model) renderActionLogHeader() string {
-	headerText := "Action Log"
-	// Center the header text horizontally
-	// Using windowSize.Width and paddedStyle to match the main UI width
-	centeredHeader := lipgloss.NewStyle().
-		Width(windowSize.Width).
-		Align(lipgloss.Center).
-		Render(headerText)
-	return paddedStyle.Render(centeredHeader)
-}
-
 func (m model) renderBottomStatus() string {
 	var s strings.Builder
 	var selectedID string


### PR DESCRIPTION
## Summary
- Switch `ALERT_DETAILS` encoding from `base64.RawURLEncoding` to `base64.RawStdEncoding`
- `RawURLEncoding` uses URL-safe alphabet (`-_`) incompatible with `base64 -d` in ocm-container
- `RawStdEncoding` uses standard alphabet (`+/`) that `base64 -d` understands, while still omitting `=` padding that breaks ocm-container's env var parsing
- Fix pre-existing lint issues uncovered by CI: suppress errcheck on deferred `asyncWriter.Close()`, remove unused `renderActionLogHeader()` function, and remove empty test branch

## Test plan
- [ ] Verify `echo $ALERT_DETAILS | base64 -d | jq .` works inside ocm-container after login
- [ ] Verify no `=` padding characters appear in the encoded value
- [ ] Run existing unit tests (`go test ./pkg/tui/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)