### PR TITLE
Fix table viewport panic on small terminal windows

### DIFF
--- a/pkg/tui/model_test.go
+++ b/pkg/tui/model_test.go
@@ -908,3 +908,53 @@ func TestSelectedIncidentSurvivesListUpdate(t *testing.T) {
 	assert.Equal(t, "Original Title", m.selectedIncident.Title,
 		"selectedIncident should retain original data after list reallocation")
 }
+
+func TestWindowSizeMsgHandler_SmallWindow(t *testing.T) {
+	tests := []struct {
+		name   string
+		width  int
+		height int
+	}{
+		{"standard 80x24 terminal", 80, 24},
+		{"tiny window", 40, 10},
+		{"minimum height", 20, 1},
+		{"zero height", 80, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := model{
+				table:          newTableWithStyles(),
+				actionLogTable: newActionLogTable(),
+				incidentViewer: newIncidentViewer(),
+				help:           newHelp(),
+				incidentCache:  make(map[string]*cachedIncidentData),
+			}
+
+			// First call sets columns (simulates initial startup WindowSizeMsg)
+			normalSize := tea.WindowSizeMsg{Width: 120, Height: 50}
+			result, _ := m.windowSizeMsgHandler(normalSize)
+			m = result.(model)
+
+			// Incidents arrive and populate the table
+			m.table.SetRows([]table.Row{
+				{".", "P123ABC", "Test incident", "test-service"},
+				{".", "P456DEF", "Another incident", "test-service-2"},
+				{".", "P789GHI", "Third incident", "test-service-3"},
+			})
+
+			// Second call with small window: columns are already set, so
+			// table.SetHeight will subtract a 2-line header from the height.
+			// Before the fix, this panicked with "slice bounds out of range"
+			// when the resulting viewport height went negative.
+			msg := tea.WindowSizeMsg{Width: tt.width, Height: tt.height}
+			assert.NotPanics(t, func() {
+				result, _ = m.windowSizeMsgHandler(msg)
+			})
+
+			m = result.(model)
+			assert.GreaterOrEqual(t, m.table.Height(), 1,
+				"viewport height must be positive to avoid panic in visibleLines")
+		})
+	}
+}

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -81,9 +81,11 @@ func (m model) windowSizeMsgHandler(msg tea.Msg) (tea.Model, tea.Cmd) {
 		actionLogReservedLines = 11
 	}
 	tableHeight := windowSize.Height - verticalScratchWidth - tableVerticalScratchWidth - rowCount - estimatedExtraLinesFromComponents - actionLogReservedLines - inputReservedLines - additionalSpacing
-	// Ensure table height is never negative (can happen with very small terminal windows)
-	if tableHeight < 1 {
-		tableHeight = 1
+	// table.SetHeight subtracts the rendered header height (2 lines: text + bottom border)
+	// from the value we pass, so the minimum must exceed the header height to keep the
+	// internal viewport height positive and avoid a panic in viewport.visibleLines
+	if tableHeight < 4 {
+		tableHeight = 4
 	}
 
 	m.table.SetHeight(tableHeight)


### PR DESCRIPTION
## Summary

- Fix panic (`slice bounds out of range [2:1]`) caused by negative viewport height when terminal is under 36 lines tall (including standard 24-line terminals)
- The table height calculation subtracted 35 lines of overhead, clamped the result to 1, but `table.SetHeight(1)` internally subtracts the 2-line styled header, producing `viewport.Height = -1`
- Raise minimum `tableHeight` from 1 to 4 so the viewport always has positive height after header subtraction
- Add `TestWindowSizeMsgHandler_SmallWindow` covering standard, tiny, minimum, and zero-height terminals

## Test plan

- [x] `go test ./pkg/tui/ -run TestWindowSizeMsgHandler_SmallWindow -v` passes
- [x] `go test ./...` full suite passes
- [x] `go build` succeeds
- [ ] Manual verification: run srepd in a standard 24-line terminal and confirm incidents are visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)