### PR TITLE
Add project documentation for Claude Code agents and conventions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ dist/
 build/
 
 coverage.out
+
+# Override global gitignore to track CLAUDE.md in this repo
+!CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,84 @@
+# AGENTS.md
+
+## Project Overview
+
+SREPD is a PagerDuty TUI for SREs built with Go and the Bubble Tea
+framework. It manages incidents, displays alerts/notes, and launches
+terminal windows for cluster investigation via ocm-container or
+direct `ocm backplane` login.
+
+## Build and Test Commands
+
+| Command | Purpose |
+|---------|---------|
+| `make build` | Build via goreleaser snapshot |
+| `make install` | Install to `$GOPATH/bin` |
+| `make test` | Run unit tests (`go test ./...`) |
+| `make lint` | Run golangci-lint |
+| `make vet` | Run `go vet ./...` |
+| `make fmt` | Format code with `gofmt -s` |
+| `make fmt-check` | Check formatting (CI-friendly, non-zero on diff) |
+| `make coverage` | Generate coverage report |
+| `make clean` | Remove build artifacts |
+| `make tidy` | Run `go mod tidy` |
+| `make test-all` | Run all checks: fmt-check, vet, lint, test |
+
+Pass extra test flags via `TESTOPTS`, e.g.:
+`make test TESTOPTS="-run TestFoo"`
+
+## Architecture
+
+- **Pattern**: Bubble Tea Model-View-Update (MVU)
+- **Async**: All PagerDuty API calls run as `tea.Cmd` closures
+  returning `tea.Msg` values. The Update loop is single-threaded.
+- **PD client**: Abstracted behind `PagerDutyClientInterface`
+  (in `pkg/pd/pd.go`). Mock at `pkg/pd/mock.go`.
+- **Launcher**: Builds terminal commands with variable substitution
+  (`%%CLUSTER_ID%%`, `%%INCIDENT_ID%%`). Supports multiple terminal
+  emulators via profiles.
+- **Config**: Viper-managed YAML at `~/.config/srepd/srepd.yaml`
+  with `SREPD_` env var prefix.
+
+## Test Patterns
+
+- Table-driven tests with `testing.T` subtests
+- Assertions via `github.com/stretchr/testify/assert`
+- Mock PD client in `pkg/pd/mock.go` with convention-based errors
+  (ID = "err" triggers error responses)
+- Test files: `*_test.go` alongside source files
+- TDD workflow: write failing test, implement, verify green,
+  run `make test-all`
+
+## Key Invariants
+
+- Never panic in library code; return errors
+- All PagerDuty API calls must use `context.WithTimeout`
+- Type assertions must use the comma-ok pattern
+- Tests before code (TDD)
+- Each PR must pass all CI checks
+
+## PR Workflow
+
+1. Create feature branch: `srepd/<description>`
+2. Write failing tests
+3. Implement minimum code to pass tests
+4. Run `make test-all` locally
+5. Push and create PR against `main`
+6. CI runs all checks via `make` targets
+7. Review, approve, merge
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `pkg/pd/pd.go` | PagerDuty API wrapper (all API calls) |
+| `pkg/pd/mock.go` | Mock PD client for testing |
+| `pkg/tui/model.go` | TUI model (state) |
+| `pkg/tui/tui.go` | Update loop and message handlers |
+| `pkg/tui/commands.go` | Async commands (API calls, login) |
+| `pkg/tui/views.go` | View rendering and templates |
+| `pkg/tui/keymap.go` | Key bindings |
+| `pkg/tui/msgHandlers.go` | Focus-mode key dispatch |
+| `pkg/launcher/launcher.go` | Terminal command builder |
+| `cmd/root.go` | CLI entry point |
+| `cmd/config.go` | Config validation |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,0 +1,99 @@
+# Project Conventions
+
+## Language -- Go
+
+- Language: Go
+- Go version: 1.24.2 (from go.mod)
+- Module path: `github.com/clcollins/srepd`
+- Entry point: `main.go` using cobra + viper
+- Linter: golangci-lint
+- Test framework: `go test` with `testify` for assertions
+- Build: goreleaser for releases, `go build` for dev installs
+
+### Code Organization
+
+```text
+cmd/              CLI entry point (cobra root command + config subcommand)
+pkg/pd/           PagerDuty API client wrapper and mock
+pkg/tui/          Bubble Tea TUI (model, views, commands, key bindings)
+pkg/launcher/     Terminal launcher for cluster investigation
+pkg/deprecation/  Configuration deprecation utilities
+pkg/rand/         Random ID generation
+hack/             Build and CI helper scripts
+```
+
+### Go Style
+
+- Follow standard Go conventions (Effective Go, Go Code Review
+  Comments)
+- Error handling: return errors, never panic in library code
+- Context: pass `context.Context` as first parameter where applicable
+- All PagerDuty API calls must use `context.WithTimeout`
+- Type assertions must use comma-ok pattern (never bare assertions)
+- Naming: use descriptive names; avoid single-letter variables outside
+  loop indices
+- Test-driven development: write failing tests before implementation
+
+## Makefile Standards
+
+- All targets `.PHONY`
+- Must include `build`, `test`, `lint`, `clean`, `fmt`, `coverage`,
+  `vet`, and `test-all` targets
+- `test-all` runs all checks: `fmt-check`, `vet`, `lint`, `test`
+- Each target is independently callable
+- `test` runs unit tests only (no lint dependency)
+- `fmt-check` exits non-zero if code is unformatted (CI-friendly)
+- Variables for configurable values (Go binary path, lint version)
+- Build output: goreleaser for releases, `/tmp/` or `GOPATH/bin` for
+  dev installs
+
+## CI Testing
+
+### GitHub Actions
+
+- CI runs on push to `main` and `srepd/**` branches, and on pull
+  requests to `main`
+- Each check runs as a separate parallel job calling
+  `make <target>` directly
+- Go version in CI matches `go.mod` version (extracted automatically)
+
+### Local vs Remote Execution
+
+- Locally: `make test-all` runs all checks
+- Remotely: GitHub Actions runs each `make` target in separate
+  parallel jobs
+- Both paths use the same Makefile targets, ensuring identical behavior
+
+### Required Checks
+
+| Check | Tool | Make Target |
+|-------|------|-------------|
+| Format | gofmt -s | `make fmt-check` |
+| Go vet | go vet | `make vet` |
+| Lint | golangci-lint | `make lint` |
+| Unit tests | go test | `make test` |
+| Coverage | go test -coverprofile | `make coverage` |
+| Build | go build | `make build` |
+
+## Linting
+
+- Fix all lint issues rather than suppressing rules, unless there is a
+  documented reason
+- Linter configuration: `.golangci.yml` at repo root (when created)
+
+## Platform
+
+- Primary platform: Linux (Fedora/RHEL)
+- Container engine: podman (never docker)
+- Build targets: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64
+- Terminal support: gnome-terminal, ptyxis, konsole, kitty, alacritty,
+  wezterm, foot, tmux
+
+## Version Control
+
+- Feature branches only; never commit directly to main
+- Branch naming: `srepd/<description>` (e.g., `srepd/p0-fix-panic`)
+- Concise commit messages with descriptive body
+- Attribution trailers required for AI-assisted work
+- No force-push without explicit user approval
+- Each improvement, fix, or feature gets its own branch and PR


### PR DESCRIPTION
## Summary
- Add `CONVENTIONS.md` with project standards for Go style, Makefile targets, CI testing, linting, and version control (modeled on unifi-bootstrapper)
- Add `AGENTS.md` as single source of truth for Claude Code agents: build commands, architecture overview, test patterns, key invariants, PR workflow
- Add `CLAUDE.md` that imports `AGENTS.md`
- Override global gitignore to track `CLAUDE.md` in this repo

## Test plan
- [x] Verify all three files render correctly on GitHub
- [x] Verify CLAUDE.md import resolves for Claude Code sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)