### PR TITLE
Fix unsafe type assertions in alert detail extraction

### DIFF
--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -781,15 +781,29 @@ func removeCommentsFromBytes(b []byte, prefixes ...string) string {
 	return content.String()
 }
 
+// getDetailFieldFromAlert safely extracts a string field from alert body details.
+// Returns "" if body, details, or field is missing or wrong type. Never panics.
 func getDetailFieldFromAlert(f string, a pagerduty.IncidentAlert) string {
-	if a.Body["details"] != nil {
-
-		if a.Body["details"].(map[string]interface{})[f] != nil {
-			return a.Body["details"].(map[string]interface{})[f].(string)
-		}
+	if a.Body == nil {
 		return ""
 	}
-	return ""
+	detailsRaw, ok := a.Body["details"]
+	if !ok || detailsRaw == nil {
+		return ""
+	}
+	details, ok := detailsRaw.(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	fieldRaw, ok := details[f]
+	if !ok || fieldRaw == nil {
+		return ""
+	}
+	fieldStr, ok := fieldRaw.(string)
+	if !ok {
+		return ""
+	}
+	return fieldStr
 }
 
 // getEscalationPolicyKey is a helper function to determine the escalation policy key

--- a/pkg/tui/commands_test.go
+++ b/pkg/tui/commands_test.go
@@ -484,6 +484,101 @@ func TestLoginEnvironmentVariables(t *testing.T) {
 	}
 }
 
+func TestGetDetailFieldFromAlert_NilBody(t *testing.T) {
+	// Alert with nil Body map should return ""
+	alert := pagerduty.IncidentAlert{
+		Body: nil,
+	}
+	result := getDetailFieldFromAlert("cluster_id", alert)
+	assert.Equal(t, "", result)
+}
+
+func TestGetDetailFieldFromAlert_EmptyBody(t *testing.T) {
+	// Alert with empty Body map (no "details" key) should return ""
+	alert := pagerduty.IncidentAlert{
+		Body: map[string]interface{}{},
+	}
+	result := getDetailFieldFromAlert("cluster_id", alert)
+	assert.Equal(t, "", result)
+}
+
+func TestGetDetailFieldFromAlert_MissingDetails(t *testing.T) {
+	// Body exists but has no "details" key
+	alert := pagerduty.IncidentAlert{
+		Body: map[string]interface{}{
+			"other_key": "some_value",
+		},
+	}
+	result := getDetailFieldFromAlert("cluster_id", alert)
+	assert.Equal(t, "", result)
+}
+
+func TestGetDetailFieldFromAlert_DetailsNotMap(t *testing.T) {
+	// Body["details"] is a string, not a map
+	alert := pagerduty.IncidentAlert{
+		Body: map[string]interface{}{
+			"details": "this is a string, not a map",
+		},
+	}
+	result := getDetailFieldFromAlert("cluster_id", alert)
+	assert.Equal(t, "", result)
+}
+
+func TestGetDetailFieldFromAlert_FieldNotString(t *testing.T) {
+	// Field exists in details but is an int, not a string
+	alert := pagerduty.IncidentAlert{
+		Body: map[string]interface{}{
+			"details": map[string]interface{}{
+				"cluster_id": 12345,
+			},
+		},
+	}
+	result := getDetailFieldFromAlert("cluster_id", alert)
+	assert.Equal(t, "", result)
+}
+
+func TestGetDetailFieldFromAlert_FieldIsBool(t *testing.T) {
+	// Field exists in details but is a bool, not a string
+	alert := pagerduty.IncidentAlert{
+		Body: map[string]interface{}{
+			"details": map[string]interface{}{
+				"active": true,
+			},
+		},
+	}
+	result := getDetailFieldFromAlert("active", alert)
+	assert.Equal(t, "", result)
+}
+
+func TestGetDetailFieldFromAlert_MissingField(t *testing.T) {
+	// Details map exists but requested field is not present
+	alert := pagerduty.IncidentAlert{
+		Body: map[string]interface{}{
+			"details": map[string]interface{}{
+				"alert_name": "TestAlert",
+			},
+		},
+	}
+	result := getDetailFieldFromAlert("cluster_id", alert)
+	assert.Equal(t, "", result)
+}
+
+func TestGetDetailFieldFromAlert_HappyPath(t *testing.T) {
+	// Valid structure with string field returns the value
+	alert := pagerduty.IncidentAlert{
+		Body: map[string]interface{}{
+			"details": map[string]interface{}{
+				"cluster_id": "abc-123-def",
+				"alert_name": "TestAlert",
+				"link":       "https://example.com/sop",
+			},
+		},
+	}
+	assert.Equal(t, "abc-123-def", getDetailFieldFromAlert("cluster_id", alert))
+	assert.Equal(t, "TestAlert", getDetailFieldFromAlert("alert_name", alert))
+	assert.Equal(t, "https://example.com/sop", getDetailFieldFromAlert("link", alert))
+}
+
 func TestLoginCommandStructureWithEnvVars(t *testing.T) {
 	// This test validates that environment variables are inserted at the correct
 	// position in the command - after the terminal separator but as arguments to

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -427,6 +427,13 @@ func summarizeAlerts(a []pagerduty.IncidentAlert) []alertSummary {
 		cluster := getDetailFieldFromAlert("cluster_id", alt)
 		link := getDetailFieldFromAlert("link", alt)
 
+		var details map[string]interface{}
+		if alt.Body != nil {
+			if d, ok := alt.Body["details"].(map[string]interface{}); ok {
+				details = d
+			}
+		}
+
 		s = append(s, alertSummary{
 			ID:       alt.ID,
 			Name:     name,
@@ -437,7 +444,7 @@ func summarizeAlerts(a []pagerduty.IncidentAlert) []alertSummary {
 			Created:  alt.CreatedAt,
 			Status:   alt.Status,
 			Incident: alt.Incident.ID,
-			Details:  alt.Body["details"].(map[string]interface{}),
+			Details:  details,
 		})
 
 	}


### PR DESCRIPTION
## Summary

- Replace bare type assertions with comma-ok pattern in `getDetailFieldFromAlert` (`commands.go`) and `summarizeAlerts` (`views.go`) to prevent panics when alerts have non-standard body structures (e.g., CPD alerts, custom integrations)
- Add 8 comprehensive unit tests covering nil body, empty body, missing details key, wrong-type details, wrong-type field values (int, bool), missing field, and happy path scenarios
- No function signature changes; purely defensive implementation fix

## Test plan

- [x] All 8 new `TestGetDetailFieldFromAlert_*` tests pass
- [x] Full test suite (`go test ./... -v -count=1`) passes with zero regressions
- [x] `go vet ./...` clean
- [ ] Manual verification: trigger an alert with non-standard body (e.g., CPD alert) and confirm no panic

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>