### PR TITLE
Preserve selected incident across auto-refresh list updates

### DIFF
--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -337,6 +337,17 @@ func (m *model) ageOutResolvedIncidents(maxAge time.Duration) {
 	m.updateActionLogTable()
 }
 
+// findRowIndex returns the index of the row in rows whose incident ID column
+// (column 1) matches incidentID. Returns -1 if not found or rows is empty.
+func findRowIndex(rows []table.Row, incidentID string) int {
+	for i, row := range rows {
+		if len(row) > 1 && row[1] == incidentID {
+			return i
+		}
+	}
+	return -1
+}
+
 func newTableWithStyles() table.Model {
 	t := table.New(table.WithFocused(true))
 	t.SetStyles(tableStyle)

--- a/pkg/tui/model_test.go
+++ b/pkg/tui/model_test.go
@@ -909,6 +909,48 @@ func TestSelectedIncidentSurvivesListUpdate(t *testing.T) {
 		"selectedIncident should retain original data after list reallocation")
 }
 
+func TestFindRowIndex_Found(t *testing.T) {
+	rows := []table.Row{
+		{"triggered", "Q111", "First Incident", "service-a"},
+		{"acknowledged", "Q222", "Second Incident", "service-b"},
+		{"triggered", "Q333", "Third Incident", "service-c"},
+	}
+
+	tests := []struct {
+		name       string
+		incidentID string
+		expected   int
+	}{
+		{"finds first row", "Q111", 0},
+		{"finds middle row", "Q222", 1},
+		{"finds last row", "Q333", 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := findRowIndex(rows, tt.incidentID)
+			assert.Equal(t, tt.expected, result, "Expected row index %d for incident %s", tt.expected, tt.incidentID)
+		})
+	}
+}
+
+func TestFindRowIndex_NotFound(t *testing.T) {
+	rows := []table.Row{
+		{"triggered", "Q111", "First Incident", "service-a"},
+		{"acknowledged", "Q222", "Second Incident", "service-b"},
+	}
+
+	result := findRowIndex(rows, "QNOTFOUND")
+	assert.Equal(t, -1, result, "Expected -1 when incident ID is not in rows")
+}
+
+func TestFindRowIndex_EmptyRows(t *testing.T) {
+	var rows []table.Row
+
+	result := findRowIndex(rows, "Q123")
+	assert.Equal(t, -1, result, "Expected -1 when rows slice is empty")
+}
+
 func TestWindowSizeMsgHandler_SmallWindow(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -457,7 +457,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// Capture the currently highlighted incident ID before rebuilding rows
 		var highlightedID string
-		if currentRow := m.table.SelectedRow(); currentRow != nil && len(currentRow) > 1 {
+		if currentRow := m.table.SelectedRow(); len(currentRow) > 1 {
 			highlightedID = currentRow[1]
 		}
 

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -455,6 +455,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 
+		// Capture the currently highlighted incident ID before rebuilding rows
+		var highlightedID string
+		if currentRow := m.table.SelectedRow(); currentRow != nil && len(currentRow) > 1 {
+			highlightedID = currentRow[1]
+		}
+
 		var totalIncidentCount int
 		var rows []table.Row
 
@@ -467,6 +473,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		m.table.SetRows(rows)
+
+		// Restore cursor to the previously highlighted incident
+		if highlightedID != "" {
+			if idx := findRowIndex(rows, highlightedID); idx >= 0 {
+				m.table.SetCursor(idx)
+			}
+		}
 
 		if totalIncidentCount == 1 {
 			m.setStatus(fmt.Sprintf("showing %d/%d incident...", len(m.table.Rows()), totalIncidentCount))


### PR DESCRIPTION
## Summary
- Fixes the auto-refresh deselecting the currently highlighted incident when `updatedIncidentListMsg` arrives and `table.SetRows()` resets the cursor position
- Adds a pure `findRowIndex(rows, incidentID)` function to locate an incident's row index by ID (column 1)
- Before `SetRows()`, captures the highlighted incident ID; after `SetRows()`, restores the cursor to that incident's new row position

Fixes #72

## Test plan
- [x] `TestFindRowIndex_Found` - verifies correct index returned for first, middle, and last rows
- [x] `TestFindRowIndex_NotFound` - returns -1 when incident ID is absent
- [x] `TestFindRowIndex_EmptyRows` - returns -1 for empty row slice
- [x] `go test ./... -v -count=1` passes all 53 tests with zero regressions
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)