### PR TITLE
Enhance mock PagerDuty client with pagination and call counting

### DIFF
--- a/pkg/pd/mock.go
+++ b/pkg/pd/mock.go
@@ -9,15 +9,49 @@ import (
 
 var ErrMockError = fmt.Errorf("pd.Mock(): mock error") // Used to mock errors in unit tests
 
+// ListMembersResponse holds a single response (or error) for ListMembersWithContext.
+// Use a slice of these in MockPagerDutyClient.ListMembersResponses to simulate
+// paginated responses across successive calls.
+type ListMembersResponse struct {
+	Response *pagerduty.ListTeamMembersResponse
+	Err      error
+}
+
 type MockPagerDutyClient struct {
 	PagerDutyClient
+
+	// CallCounts tracks how many times each method has been called, keyed by
+	// method name (e.g. "GetIncidentWithContext"). The map is lazily
+	// initialized on first use so a zero-value MockPagerDutyClient works
+	// without any setup.
+	CallCounts map[string]int
+
+	// ListMembersResponses is an optional response queue for
+	// ListMembersWithContext. When populated, successive calls pop from the
+	// front of the slice. When empty or nil, a default empty response is
+	// returned instead.
+	ListMembersResponses []ListMembersResponse
+
+	// listMembersIndex tracks the current position in ListMembersResponses.
+	listMembersIndex int
+}
+
+// recordCall increments the call count for the named method, lazily
+// initializing the CallCounts map if needed.
+func (m *MockPagerDutyClient) recordCall(method string) {
+	if m.CallCounts == nil {
+		m.CallCounts = make(map[string]int)
+	}
+	m.CallCounts[method]++
 }
 
 func (m *MockPagerDutyClient) GetTeamWithContext(ctx context.Context, team string) (*pagerduty.Team, error) {
+	m.recordCall("GetTeamWithContext")
 	return &pagerduty.Team{Name: team}, nil
 }
 
 func (m *MockPagerDutyClient) GetIncidentWithContext(ctx context.Context, id string) (*pagerduty.Incident, error) {
+	m.recordCall("GetIncidentWithContext")
 	// Provided so we can mock error responses for unit tests
 	if id == "err" {
 		return &pagerduty.Incident{}, ErrMockError
@@ -30,6 +64,7 @@ func (m *MockPagerDutyClient) GetIncidentWithContext(ctx context.Context, id str
 }
 
 func (m *MockPagerDutyClient) ListIncidentsWithContext(ctx context.Context, opts pagerduty.ListIncidentsOptions) (*pagerduty.ListIncidentsResponse, error) {
+	m.recordCall("ListIncidentsWithContext")
 	// Provided so we can mock error responses for unit tests
 	if opts.UserIDs != nil && opts.UserIDs[0] == "err" {
 		return &pagerduty.ListIncidentsResponse{}, ErrMockError
@@ -51,6 +86,7 @@ func (m *MockPagerDutyClient) ListIncidentsWithContext(ctx context.Context, opts
 }
 
 func (m *MockPagerDutyClient) ListIncidentAlertsWithContext(ctx context.Context, id string, opts pagerduty.ListIncidentAlertsOptions) (*pagerduty.ListAlertsResponse, error) {
+	m.recordCall("ListIncidentAlertsWithContext")
 	if id == "err" {
 		return &pagerduty.ListAlertsResponse{}, ErrMockError
 	}
@@ -71,6 +107,7 @@ func (m *MockPagerDutyClient) ListIncidentAlertsWithContext(ctx context.Context,
 }
 
 func (m *MockPagerDutyClient) ListIncidentNotesWithContext(ctx context.Context, id string) ([]pagerduty.IncidentNote, error) {
+	m.recordCall("ListIncidentNotesWithContext")
 	if id == "err" {
 		return []pagerduty.IncidentNote{}, ErrMockError
 	}
@@ -85,6 +122,7 @@ func (m *MockPagerDutyClient) ListIncidentNotesWithContext(ctx context.Context, 
 }
 
 func (m *MockPagerDutyClient) ManageIncidentsWithContext(ctx context.Context, email string, opts []pagerduty.ManageIncidentsOptions) (*pagerduty.ListIncidentsResponse, error) {
+	m.recordCall("ManageIncidentsWithContext")
 	var response = &pagerduty.ListIncidentsResponse{}
 
 	for _, opt := range opts {
@@ -108,4 +146,25 @@ func (m *MockPagerDutyClient) ManageIncidentsWithContext(ctx context.Context, em
 	}
 
 	return response, nil
+}
+
+// ListMembersWithContext returns responses from the ListMembersResponses queue
+// when configured, otherwise returns a default empty response. This allows
+// tests to simulate paginated member listings by enqueuing multiple responses
+// with different More values.
+func (m *MockPagerDutyClient) ListMembersWithContext(ctx context.Context, id string, opts pagerduty.ListTeamMembersOptions) (*pagerduty.ListTeamMembersResponse, error) {
+	m.recordCall("ListMembersWithContext")
+
+	// If a response queue is configured, pop from it
+	if len(m.ListMembersResponses) > 0 && m.listMembersIndex < len(m.ListMembersResponses) {
+		entry := m.ListMembersResponses[m.listMembersIndex]
+		m.listMembersIndex++
+		if entry.Err != nil {
+			return &pagerduty.ListTeamMembersResponse{}, entry.Err
+		}
+		return entry.Response, nil
+	}
+
+	// Default fallback: return an empty, non-paginated response
+	return &pagerduty.ListTeamMembersResponse{}, nil
 }

--- a/pkg/pd/mock_test.go
+++ b/pkg/pd/mock_test.go
@@ -1,0 +1,176 @@
+package pd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/PagerDuty/go-pagerduty"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnhancedMock_BackwardCompatible(t *testing.T) {
+	// Creating a mock the old way (zero-value struct) must still behave identically
+	// to the current mock behavior: "err" ID triggers ErrMockError, normal IDs return
+	// fixed responses.
+	mock := &MockPagerDutyClient{}
+	ctx := context.Background()
+
+	t.Run("GetIncidentWithContext returns incident for normal ID", func(t *testing.T) {
+		incident, err := mock.GetIncidentWithContext(ctx, "P12345")
+		assert.NoError(t, err)
+		assert.Equal(t, "P12345", incident.ID)
+	})
+
+	t.Run("GetIncidentWithContext returns error for err ID", func(t *testing.T) {
+		_, err := mock.GetIncidentWithContext(ctx, "err")
+		assert.ErrorIs(t, err, ErrMockError)
+	})
+
+	t.Run("ListIncidentsWithContext returns fixed incidents", func(t *testing.T) {
+		resp, err := mock.ListIncidentsWithContext(ctx, pagerduty.ListIncidentsOptions{})
+		assert.NoError(t, err)
+		assert.Len(t, resp.Incidents, 2)
+		assert.Equal(t, "QABCDEFG1234567", resp.Incidents[0].ID)
+		assert.Equal(t, "QABCDEFG7654321", resp.Incidents[1].ID)
+	})
+
+	t.Run("GetTeamWithContext returns team with name matching ID", func(t *testing.T) {
+		team, err := mock.GetTeamWithContext(ctx, "myteam")
+		assert.NoError(t, err)
+		assert.Equal(t, "myteam", team.Name)
+	})
+
+	t.Run("ManageIncidentsWithContext returns error for err ID", func(t *testing.T) {
+		opts := []pagerduty.ManageIncidentsOptions{
+			{ID: "err"},
+		}
+		_, err := mock.ManageIncidentsWithContext(ctx, "test@example.com", opts)
+		assert.ErrorIs(t, err, ErrMockError)
+	})
+
+	t.Run("ManageIncidentsWithContext returns incidents for normal IDs", func(t *testing.T) {
+		opts := []pagerduty.ManageIncidentsOptions{
+			{ID: "P12345"},
+		}
+		resp, err := mock.ManageIncidentsWithContext(ctx, "test@example.com", opts)
+		assert.NoError(t, err)
+		assert.Len(t, resp.Incidents, 2)
+	})
+}
+
+func TestEnhancedMock_PaginatedListMembers(t *testing.T) {
+	// Configure mock to return More=true on first call, More=false on second.
+	// This exercises the response queue feature for ListMembersWithContext.
+	mock := &MockPagerDutyClient{
+		ListMembersResponses: []ListMembersResponse{
+			{
+				Response: &pagerduty.ListTeamMembersResponse{
+					APIListObject: pagerduty.APIListObject{More: true},
+					Members: []pagerduty.Member{
+						{User: pagerduty.APIObject{ID: "USER1"}},
+						{User: pagerduty.APIObject{ID: "USER2"}},
+					},
+				},
+			},
+			{
+				Response: &pagerduty.ListTeamMembersResponse{
+					APIListObject: pagerduty.APIListObject{More: false},
+					Members: []pagerduty.Member{
+						{User: pagerduty.APIObject{ID: "USER3"}},
+					},
+				},
+			},
+		},
+	}
+
+	// Use GetTeamMemberIDs which loops over ListMembersWithContext pagination
+	teams := []*pagerduty.Team{
+		{APIObject: pagerduty.APIObject{ID: "TEAM1"}},
+	}
+	opts := pagerduty.ListTeamMembersOptions{Limit: 2, Offset: 0}
+	memberIDs, err := GetTeamMemberIDs(mock, teams, opts)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"USER1", "USER2", "USER3"}, memberIDs)
+}
+
+func TestEnhancedMock_PaginatedListMembersError(t *testing.T) {
+	// Configure mock to return an error on the second page
+	mock := &MockPagerDutyClient{
+		ListMembersResponses: []ListMembersResponse{
+			{
+				Response: &pagerduty.ListTeamMembersResponse{
+					APIListObject: pagerduty.APIListObject{More: true},
+					Members: []pagerduty.Member{
+						{User: pagerduty.APIObject{ID: "USER1"}},
+					},
+				},
+			},
+			{
+				Err: ErrMockError,
+			},
+		},
+	}
+
+	teams := []*pagerduty.Team{
+		{APIObject: pagerduty.APIObject{ID: "TEAM1"}},
+	}
+	opts := pagerduty.ListTeamMembersOptions{Limit: 1, Offset: 0}
+	_, err := GetTeamMemberIDs(mock, teams, opts)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to retrieve users")
+}
+
+func TestEnhancedMock_CallCounting(t *testing.T) {
+	mock := &MockPagerDutyClient{}
+	ctx := context.Background()
+
+	// Initially all counts should be zero
+	assert.Equal(t, 0, mock.CallCounts["GetIncidentWithContext"])
+	assert.Equal(t, 0, mock.CallCounts["ListIncidentsWithContext"])
+
+	// Make some calls
+	_, _ = mock.GetIncidentWithContext(ctx, "P1")
+	_, _ = mock.GetIncidentWithContext(ctx, "P2")
+	_, _ = mock.GetIncidentWithContext(ctx, "P3")
+
+	assert.Equal(t, 3, mock.CallCounts["GetIncidentWithContext"])
+
+	_, _ = mock.ListIncidentsWithContext(ctx, pagerduty.ListIncidentsOptions{})
+	assert.Equal(t, 1, mock.CallCounts["ListIncidentsWithContext"])
+
+	// Methods not called should still be zero
+	assert.Equal(t, 0, mock.CallCounts["GetTeamWithContext"])
+
+	// Call GetTeamWithContext once
+	_, _ = mock.GetTeamWithContext(ctx, "team1")
+	assert.Equal(t, 1, mock.CallCounts["GetTeamWithContext"])
+}
+
+func TestEnhancedMock_CallCountingAllMethods(t *testing.T) {
+	mock := &MockPagerDutyClient{}
+	ctx := context.Background()
+
+	_, _ = mock.ListIncidentAlertsWithContext(ctx, "P1", pagerduty.ListIncidentAlertsOptions{})
+	_, _ = mock.ListIncidentNotesWithContext(ctx, "P1")
+	_, _ = mock.ManageIncidentsWithContext(ctx, "test@example.com", []pagerduty.ManageIncidentsOptions{{ID: "P1"}})
+
+	assert.Equal(t, 1, mock.CallCounts["ListIncidentAlertsWithContext"])
+	assert.Equal(t, 1, mock.CallCounts["ListIncidentNotesWithContext"])
+	assert.Equal(t, 1, mock.CallCounts["ManageIncidentsWithContext"])
+}
+
+func TestEnhancedMock_ResponseQueueFallback(t *testing.T) {
+	// When ListMembersResponses is nil (not configured), the mock should still
+	// satisfy the interface. We test that it doesn't panic.
+	mock := &MockPagerDutyClient{}
+	ctx := context.Background()
+
+	// ListMembersWithContext without a response queue should return a default
+	// empty response (backward compatible fallback)
+	resp, err := mock.ListMembersWithContext(ctx, "TEAM1", pagerduty.ListTeamMembersOptions{})
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.False(t, resp.More)
+}


### PR DESCRIPTION
## Summary

- Add `CallCounts map[string]int` to `MockPagerDutyClient` for tracking method invocations in tests (lazily initialized, zero-value safe)
- Add `ListMembersResponses` response queue for simulating paginated `ListMembersWithContext` calls with configurable `More=true/false`
- Implement `ListMembersWithContext` on the mock with queue-based responses and empty-response fallback
- Add `recordCall()` helper that increments call counts in all 6 existing mock methods
- Add comprehensive test suite in `pkg/pd/mock_test.go` (6 tests: backward compatibility, paginated responses, error propagation, call counting, queue exhaustion)

## Backward compatibility

The zero-value `&MockPagerDutyClient{}` works identically to before. All existing tests in `pkg/pd/pd_test.go` and `pkg/tui/commands_test.go` pass without modification.

## Test plan

- [x] `TestEnhancedMock_BackwardCompatible` - verifies "err" convention and fixed responses still work
- [x] `TestEnhancedMock_PaginatedListMembers` - verifies multi-page member listing via `GetTeamMemberIDs`
- [x] `TestEnhancedMock_PaginatedListMembersError` - verifies error on second page propagates correctly
- [x] `TestEnhancedMock_CallCounting` - verifies per-method call count tracking
- [x] `TestEnhancedMock_CallCountingAllMethods` - verifies counting works across all mock methods
- [x] `TestEnhancedMock_ResponseQueueFallback` - verifies empty queue returns default response
- [x] Full test suite passes: `go test ./... -v -count=1` (zero regressions)
- [x] `go vet ./...` clean
- [x] `go fmt ./...` clean

Created with assistance from Claude <claude@anthropic.com>