### PR TITLE
Add SOP launcher key binding (closes #53)

### DIFF
--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -808,13 +808,20 @@ func getDetailFieldFromAlert(f string, a pagerduty.IncidentAlert) string {
 	return fieldStr
 }
 
-// getSOPLink extracts the SOP link from the first alert that has a non-empty "link" detail field.
+// sopLinkFields lists the alert detail field names that may contain an SOP URL,
+// checked in priority order. "link" is used by most SRE alerts as a label;
+// "runbook_url" is the Prometheus/Alertmanager annotation convention.
+var sopLinkFields = []string{"link", "runbook_url"}
+
+// getSOPLink extracts the SOP link from alerts, checking multiple field names.
 // Returns the URL and true if found, or "" and false if no SOP link exists.
 func getSOPLink(alerts []pagerduty.IncidentAlert) (string, bool) {
 	for _, alert := range alerts {
-		link := getDetailFieldFromAlert("link", alert)
-		if link != "" {
-			return link, true
+		for _, field := range sopLinkFields {
+			link := getDetailFieldFromAlert(field, alert)
+			if link != "" {
+				return link, true
+			}
 		}
 	}
 	return "", false

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -326,6 +326,7 @@ type browserFinishedMsg struct {
 	err error
 }
 type openBrowserMsg string
+type openSOPMsg string
 
 func openBrowserCmd(browser []string, url string) tea.Cmd {
 	log.Debug("tui.openBrowserCmd(): opening browser")
@@ -805,6 +806,18 @@ func getDetailFieldFromAlert(f string, a pagerduty.IncidentAlert) string {
 		return ""
 	}
 	return fieldStr
+}
+
+// getSOPLink extracts the SOP link from the first alert that has a non-empty "link" detail field.
+// Returns the URL and true if found, or "" and false if no SOP link exists.
+func getSOPLink(alerts []pagerduty.IncidentAlert) (string, bool) {
+	for _, alert := range alerts {
+		link := getDetailFieldFromAlert("link", alert)
+		if link != "" {
+			return link, true
+		}
+	}
+	return "", false
 }
 
 // getEscalationPolicyKey is a helper function to determine the escalation policy key

--- a/pkg/tui/commands_test.go
+++ b/pkg/tui/commands_test.go
@@ -639,3 +639,69 @@ func TestLoginCommandStructureWithEnvVars(t *testing.T) {
 		})
 	}
 }
+
+func TestGetSOPLink_HasLink(t *testing.T) {
+	alerts := []pagerduty.IncidentAlert{
+		{
+			Body: map[string]interface{}{
+				"details": map[string]interface{}{
+					"link": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/some-alert.md",
+				},
+			},
+		},
+	}
+	link, ok := getSOPLink(alerts)
+	assert.True(t, ok)
+	assert.Equal(t, "https://github.com/openshift/ops-sop/blob/master/v4/alerts/some-alert.md", link)
+}
+
+func TestGetSOPLink_NoLink(t *testing.T) {
+	alerts := []pagerduty.IncidentAlert{
+		{
+			Body: map[string]interface{}{
+				"details": map[string]interface{}{
+					"cluster_id": "abc-123",
+				},
+			},
+		},
+	}
+	link, ok := getSOPLink(alerts)
+	assert.False(t, ok)
+	assert.Equal(t, "", link)
+}
+
+func TestGetSOPLink_EmptyAlerts(t *testing.T) {
+	alerts := []pagerduty.IncidentAlert{}
+	link, ok := getSOPLink(alerts)
+	assert.False(t, ok)
+	assert.Equal(t, "", link)
+}
+
+func TestGetSOPLink_NilAlerts(t *testing.T) {
+	link, ok := getSOPLink(nil)
+	assert.False(t, ok)
+	assert.Equal(t, "", link)
+}
+
+func TestGetSOPLink_MultipleAlerts(t *testing.T) {
+	// First alert has no link, second does - should return second's link
+	alerts := []pagerduty.IncidentAlert{
+		{
+			Body: map[string]interface{}{
+				"details": map[string]interface{}{
+					"cluster_id": "abc-123",
+				},
+			},
+		},
+		{
+			Body: map[string]interface{}{
+				"details": map[string]interface{}{
+					"link": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/second-alert.md",
+				},
+			},
+		},
+	}
+	link, ok := getSOPLink(alerts)
+	assert.True(t, ok)
+	assert.Equal(t, "https://github.com/openshift/ops-sop/blob/master/v4/alerts/second-alert.md", link)
+}

--- a/pkg/tui/commands_test.go
+++ b/pkg/tui/commands_test.go
@@ -705,3 +705,36 @@ func TestGetSOPLink_MultipleAlerts(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, "https://github.com/openshift/ops-sop/blob/master/v4/alerts/second-alert.md", link)
 }
+
+func TestGetSOPLink_RunbookURL(t *testing.T) {
+	// Alert uses "runbook_url" instead of "link" (Prometheus annotation convention)
+	alerts := []pagerduty.IncidentAlert{
+		{
+			Body: map[string]interface{}{
+				"details": map[string]interface{}{
+					"runbook_url": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/UpgradeStateNotificationFailureSRE.md",
+				},
+			},
+		},
+	}
+	link, ok := getSOPLink(alerts)
+	assert.True(t, ok)
+	assert.Equal(t, "https://github.com/openshift/ops-sop/blob/master/v4/alerts/UpgradeStateNotificationFailureSRE.md", link)
+}
+
+func TestGetSOPLink_LinkTakesPriorityOverRunbookURL(t *testing.T) {
+	// Alert has both "link" and "runbook_url" - "link" should take priority
+	alerts := []pagerduty.IncidentAlert{
+		{
+			Body: map[string]interface{}{
+				"details": map[string]interface{}{
+					"link":        "https://github.com/openshift/ops-sop/blob/master/v4/alerts/primary.md",
+					"runbook_url": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/fallback.md",
+				},
+			},
+		},
+	}
+	link, ok := getSOPLink(alerts)
+	assert.True(t, ok)
+	assert.Equal(t, "https://github.com/openshift/ops-sop/blob/master/v4/alerts/primary.md", link)
+}

--- a/pkg/tui/keymap.go
+++ b/pkg/tui/keymap.go
@@ -16,7 +16,7 @@ func (k keymap) FullHelp() [][]key.Binding {
 		// Column 1: Help at top, navigation
 		{k.Help, k.Up, k.Down, k.Top, k.Bottom, k.Enter, k.Back},
 		// Column 2: Primary incident actions
-		{k.Ack, k.Note, k.Login, k.Open, k.UnAck, k.Silence},
+		{k.Ack, k.Note, k.Login, k.Open, k.SOP, k.UnAck, k.Silence},
 		// Column 3: Settings & toggles, Quit at bottom
 		{k.Team, k.Refresh, k.AutoRefresh, k.AutoAck, k.ToggleActionLog, k.Quit},
 	}
@@ -43,6 +43,7 @@ type keymap struct {
 	Input           key.Binding
 	Login           key.Binding
 	Open            key.Binding
+	SOP             key.Binding
 }
 
 type inputKeymap struct {
@@ -158,6 +159,10 @@ var defaultKeyMap = keymap{
 	Open: key.NewBinding(
 		key.WithKeys("o"),
 		key.WithHelp("o", "open in browser"),
+	),
+	SOP: key.NewBinding(
+		key.WithKeys("s"),
+		key.WithHelp("s", "open SOP"),
 	),
 }
 

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -350,6 +350,25 @@ func switchTableFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 			c := []string{defaultBrowserOpenCommand}
 			return m, openBrowserCmd(c, m.selectedIncident.HTMLURL)
 
+		case key.Matches(msg, defaultKeyMap.SOP):
+			if !m.incidentAlertsLoaded {
+				m.setStatus("Loading incident alerts, please wait...")
+				return m, nil
+			}
+			link, ok := getSOPLink(m.selectedIncidentAlerts)
+			if !ok {
+				m.setStatus("no SOP link found")
+				return m, nil
+			}
+			if defaultBrowserOpenCommand == "" {
+				return m, func() tea.Msg { return errMsg{fmt.Errorf("unsupported OS: no browser open command available")} }
+			}
+
+			m.addActionLogEntry("s", m.selectedIncident.ID, m.selectedIncident.Title, m.selectedIncident.Service.Summary)
+
+			c := []string{defaultBrowserOpenCommand}
+			return m, openBrowserCmd(c, link)
+
 		}
 	}
 	return m, tea.Batch(cmds...)
@@ -443,6 +462,14 @@ func switchIncidentFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			return m, func() tea.Msg { return openBrowserMsg("incident") }
+
+		case key.Matches(msg, defaultKeyMap.SOP):
+			// SOP link requires alerts to extract the link field
+			if !m.incidentAlertsLoaded {
+				m.setStatus("Loading incident alerts, please wait...")
+				return m, nil
+			}
+			return m, func() tea.Msg { return openSOPMsg("sop") }
 
 		}
 	}

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -587,6 +587,26 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		c := []string{defaultBrowserOpenCommand}
 		return m, openBrowserCmd(c, m.selectedIncident.HTMLURL)
 
+	case openSOPMsg:
+		if m.selectedIncident == nil {
+			m.setStatus("no incident selected")
+			return m, nil
+		}
+		link, ok := getSOPLink(m.selectedIncidentAlerts)
+		if !ok {
+			m.setStatus("no SOP link found")
+			return m, nil
+		}
+		if defaultBrowserOpenCommand == "" {
+			return m, func() tea.Msg { return errMsg{fmt.Errorf("unsupported OS: no browser open command available")} }
+		}
+
+		log.Debug("openSOPMsg", "incident", m.selectedIncident.ID, "link", link)
+		m.addActionLogEntry("s", m.selectedIncident.ID, m.selectedIncident.Title, m.selectedIncident.Service.Summary)
+
+		c := []string{defaultBrowserOpenCommand}
+		return m, openBrowserCmd(c, link)
+
 	case browserFinishedMsg:
 		if msg.err != nil {
 			m.setStatus(fmt.Sprintf("failed to open browser: %s", msg.err))


### PR DESCRIPTION
## Summary

- Add `s` key binding to open SOP links directly from alert details in the browser
- New pure function `getSOPLink(alerts)` extracts the first non-empty "link" field from alert body details
- Works in both table focus mode and incident focus mode, using the same `xdg-open` pattern as the existing `o` (Open in Browser) feature
- Shows "no SOP link found" status message when no alert contains a link field

## Implementation

- `getSOPLink` iterates alerts and delegates to the existing `getDetailFieldFromAlert("link", alert)` for safe extraction (comma-ok pattern, nil-safe)
- Key binding `s` dispatches `openSOPMsg` in incident focus mode, or opens the browser directly in table focus mode
- `openSOPMsg` handler in Update loop extracts the link and calls `openBrowserCmd` (reuses the existing browser-open infrastructure)
- SOP key appears in help menu Column 2 (primary incident actions)

## Test plan

- [x] `TestGetSOPLink_HasLink` -- alert with "link" in details returns URL, true
- [x] `TestGetSOPLink_NoLink` -- alert without "link" returns "", false
- [x] `TestGetSOPLink_EmptyAlerts` -- no alerts returns "", false
- [x] `TestGetSOPLink_NilAlerts` -- nil alerts returns "", false
- [x] `TestGetSOPLink_MultipleAlerts` -- first alert no link, second has link, returns second's link
- [x] `go test ./... -v -count=1` -- all tests pass
- [x] `go vet ./...` -- clean
- [x] `gofmt -s -l cmd pkg` -- clean

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)