### PR TITLE
Normalize table key handler patterns and fix Open key bug

### DIFF
--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -235,10 +235,17 @@ func switchTableFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.setStatus(loadingIncidentsStatus)
 			cmds = append(cmds, updateIncidentList(m.config))
 
-		// In table mode, highlighted incidents are not selected yet, so they need to be retrieved
-		// and then can be acted upon.  Since tea.Sequence does not wait for completion, the
-		// "waitForSelectedIncidentsThen..." functions are used to wait for the selected incident
-		// to be retrieved from PagerDuty
+		// --- Incident action key handler pattern ---
+		// Most actions that operate on an incident follow this normalized pattern:
+		//   1. Check SelectedRow() == nil -> "no incident highlighted" (handles empty table)
+		//   2. Call syncSelectedIncidentToHighlightedRow() to ensure selectedIncident
+		//      matches the currently highlighted row (handles startup, list refresh, etc.)
+		//   3. Check selectedIncident == nil -> "no incident selected" (edge case: ID not in list)
+		//   4. Proceed with the action
+		//
+		// Login uses a different pattern (doIfIncidentSelected) because it needs to
+		// fetch full incident data from the API before proceeding.
+
 		case key.Matches(msg, defaultKeyMap.Enter):
 			// Check if we have cached data for this incident
 			if cached, exists := m.incidentCache[incidentID]; exists {
@@ -297,6 +304,11 @@ func switchTableFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.setStatus("no incident highlighted")
 				return m, nil
 			}
+			m.syncSelectedIncidentToHighlightedRow()
+			if m.selectedIncident == nil {
+				m.setStatus("no incident selected")
+				return m, nil
+			}
 			return m, func() tea.Msg { return silenceSelectedIncidentMsg{} }
 
 		case key.Matches(msg, defaultKeyMap.Ack):
@@ -304,11 +316,21 @@ func switchTableFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.setStatus("no incident highlighted")
 				return m, nil
 			}
+			m.syncSelectedIncidentToHighlightedRow()
+			if m.selectedIncident == nil {
+				m.setStatus("no incident selected")
+				return m, nil
+			}
 			return m, func() tea.Msg { return acknowledgeIncidentsMsg{} }
 
 		case key.Matches(msg, defaultKeyMap.UnAck):
 			if m.table.SelectedRow() == nil {
 				m.setStatus("no incident highlighted")
+				return m, nil
+			}
+			m.syncSelectedIncidentToHighlightedRow()
+			if m.selectedIncident == nil {
+				m.setStatus("no incident selected")
 				return m, nil
 			}
 			return m, func() tea.Msg { return unAcknowledgeIncidentsMsg{} }
@@ -326,11 +348,19 @@ func switchTableFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, parseTemplateForNote(m.selectedIncident)
 
 		case key.Matches(msg, defaultKeyMap.Login):
+			// Login uses doIfIncidentSelected() instead of the standard sync pattern
+			// because it needs to fetch full incident details + alerts from the API
+			// before proceeding (via getIncidentMsg + waitForSelectedIncidentThenDoMsg).
 			return m, doIfIncidentSelected(&m, func() tea.Msg {
 				return waitForSelectedIncidentThenDoMsg{action: func() tea.Msg { return loginMsg("login") }, msg: "wait"}
 			})
 
 		case key.Matches(msg, defaultKeyMap.Open):
+			if m.table.SelectedRow() == nil {
+				m.setStatus("no incident highlighted")
+				return m, nil
+			}
+			m.syncSelectedIncidentToHighlightedRow()
 			if m.selectedIncident == nil {
 				m.setStatus("no incident selected")
 				return m, nil

--- a/pkg/tui/msgHandlers_test.go
+++ b/pkg/tui/msgHandlers_test.go
@@ -42,6 +42,26 @@ func noteKeyMsg() tea.KeyMsg {
 	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}}
 }
 
+// openKeyMsg returns a tea.KeyMsg that matches the Open key binding ('o').
+func openKeyMsg() tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'o'}}
+}
+
+// ackKeyMsg returns a tea.KeyMsg that matches the Ack key binding ('a').
+func ackKeyMsg() tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}}
+}
+
+// silenceKeyMsg returns a tea.KeyMsg that matches the Silence key binding (ctrl+s).
+func silenceKeyMsg() tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyCtrlS}
+}
+
+// unAckKeyMsg returns a tea.KeyMsg that matches the UnAck key binding (ctrl+e).
+func unAckKeyMsg() tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyCtrlE}
+}
+
 func TestTableMode_NoteKeyWithNoSelectedIncident(t *testing.T) {
 	// Scenario: The table has rows with incidents highlighted, but
 	// selectedIncident is nil because the user has not explicitly navigated
@@ -122,4 +142,152 @@ func TestTableMode_NoteKeyWithNoRows(t *testing.T) {
 	// No command should be returned
 	assert.Nil(t, cmd,
 		"Note key with empty table should not return a command")
+}
+
+func TestTableMode_OpenKeyWithNoSelectedIncident(t *testing.T) {
+	// Scenario: The table has rows with incidents highlighted, but
+	// selectedIncident is nil because the user has not explicitly navigated
+	// (no up/down key press to trigger syncSelectedIncidentToHighlightedRow).
+	// Pressing Open key should NOT return "no incident selected" - it should
+	// sync the highlighted row and proceed to the open action.
+
+	incidents := []pagerduty.Incident{
+		{
+			APIObject:          pagerduty.APIObject{ID: "Q111", HTMLURL: "https://example.pagerduty.com/incidents/Q111"},
+			Title:              "Test Alert",
+			Service:            pagerduty.APIObject{ID: "SVC1", Summary: "test-service"},
+			LastStatusChangeAt: time.Now().Format(time.RFC3339),
+		},
+	}
+
+	m := createTestModelWithTableRows(incidents)
+	// Explicitly ensure selectedIncident is nil to simulate the bug condition
+	m.selectedIncident = nil
+
+	// Press the Open key
+	result, cmd := m.Update(openKeyMsg())
+	updatedModel := result.(model)
+
+	// The status should NOT be "no incident selected" - that was the bug
+	assert.NotEqual(t, "no incident selected", updatedModel.status,
+		"Open key should not report 'no incident selected' when a row is highlighted")
+
+	// A command should be returned (openBrowserCmd or equivalent)
+	assert.NotNil(t, cmd,
+		"Open key should return a command when a row is highlighted")
+}
+
+func TestTableMode_OpenKeyWithNoRows(t *testing.T) {
+	// Scenario: Table has no rows at all. Pressing Open key should gracefully
+	// handle this (status message about no incident, no panic).
+
+	m := createTestModel()
+	m.table = table.New(table.WithFocused(true))
+
+	result, cmd := m.Update(openKeyMsg())
+	updatedModel := result.(model)
+
+	// Should set some status about no incident being available
+	assert.Contains(t, updatedModel.status, "no incident",
+		"Open key with empty table should report no incident")
+
+	// No command should be returned
+	assert.Nil(t, cmd,
+		"Open key with empty table should not return a command")
+}
+
+func TestTableMode_AckKeyWithNoSelectedIncident(t *testing.T) {
+	// Scenario: The table has rows with incidents highlighted, but
+	// selectedIncident is nil. Pressing Ack key should sync the highlighted
+	// row and proceed. The message handler will resolve the incident.
+
+	incidents := []pagerduty.Incident{
+		{
+			APIObject:          pagerduty.APIObject{ID: "Q111", HTMLURL: "https://example.pagerduty.com/incidents/Q111"},
+			Title:              "Test Alert",
+			Service:            pagerduty.APIObject{ID: "SVC1", Summary: "test-service"},
+			LastStatusChangeAt: time.Now().Format(time.RFC3339),
+		},
+	}
+
+	m := createTestModelWithTableRows(incidents)
+	m.selectedIncident = nil
+
+	// Press the Ack key
+	result, cmd := m.Update(ackKeyMsg())
+	updatedModel := result.(model)
+
+	// After pressing Ack, selectedIncident should have been synced
+	assert.NotNil(t, updatedModel.selectedIncident,
+		"Ack key should sync selectedIncident to highlighted row")
+	assert.Equal(t, "Q111", updatedModel.selectedIncident.ID,
+		"Synced selectedIncident should match highlighted row")
+
+	// A command should be returned
+	assert.NotNil(t, cmd,
+		"Ack key should return a command when a row is highlighted")
+}
+
+func TestTableMode_SilenceKeyWithNoSelectedIncident(t *testing.T) {
+	// Scenario: The table has rows with incidents highlighted, but
+	// selectedIncident is nil. Pressing Silence key should sync the highlighted
+	// row and proceed.
+
+	incidents := []pagerduty.Incident{
+		{
+			APIObject:          pagerduty.APIObject{ID: "Q111", HTMLURL: "https://example.pagerduty.com/incidents/Q111"},
+			Title:              "Test Alert",
+			Service:            pagerduty.APIObject{ID: "SVC1", Summary: "test-service"},
+			LastStatusChangeAt: time.Now().Format(time.RFC3339),
+		},
+	}
+
+	m := createTestModelWithTableRows(incidents)
+	m.selectedIncident = nil
+
+	// Press the Silence key
+	result, cmd := m.Update(silenceKeyMsg())
+	updatedModel := result.(model)
+
+	// After pressing Silence, selectedIncident should have been synced
+	assert.NotNil(t, updatedModel.selectedIncident,
+		"Silence key should sync selectedIncident to highlighted row")
+	assert.Equal(t, "Q111", updatedModel.selectedIncident.ID,
+		"Synced selectedIncident should match highlighted row")
+
+	// A command should be returned
+	assert.NotNil(t, cmd,
+		"Silence key should return a command when a row is highlighted")
+}
+
+func TestTableMode_UnAckKeyWithNoSelectedIncident(t *testing.T) {
+	// Scenario: The table has rows with incidents highlighted, but
+	// selectedIncident is nil. Pressing UnAck key should sync the highlighted
+	// row and proceed.
+
+	incidents := []pagerduty.Incident{
+		{
+			APIObject:          pagerduty.APIObject{ID: "Q111", HTMLURL: "https://example.pagerduty.com/incidents/Q111"},
+			Title:              "Test Alert",
+			Service:            pagerduty.APIObject{ID: "SVC1", Summary: "test-service"},
+			LastStatusChangeAt: time.Now().Format(time.RFC3339),
+		},
+	}
+
+	m := createTestModelWithTableRows(incidents)
+	m.selectedIncident = nil
+
+	// Press the UnAck key
+	result, cmd := m.Update(unAckKeyMsg())
+	updatedModel := result.(model)
+
+	// After pressing UnAck, selectedIncident should have been synced
+	assert.NotNil(t, updatedModel.selectedIncident,
+		"UnAck key should sync selectedIncident to highlighted row")
+	assert.Equal(t, "Q111", updatedModel.selectedIncident.ID,
+		"Synced selectedIncident should match highlighted row")
+
+	// A command should be returned
+	assert.NotNil(t, cmd,
+		"UnAck key should return a command when a row is highlighted")
 }


### PR DESCRIPTION
## Summary

- **Fixes Open key bug**: Pressing 'o' immediately after startup (without navigating) failed with "no incident selected" even though a row was highlighted. Same bug class as the Note fix in PR #149.
- **Normalizes all incident action handlers** in `switchTableFocusMode` to use a consistent 3-step pattern: check `SelectedRow() == nil`, call `syncSelectedIncidentToHighlightedRow()`, check `selectedIncident == nil`.
- **Affected handlers**: Ack ('a'), Silence (ctrl+s), UnAck (ctrl+e), Note ('n'), Open ('o'). Login ('l') retains its `doIfIncidentSelected()` pattern because it needs a full API fetch before proceeding -- a comment documents why.
- **Adds 5 new tests** covering the no-selected-incident scenario for Open, Ack, Silence, UnAck, plus the empty-table edge case for Open.

## Test plan

- [x] `make test` -- all tests pass (existing + 5 new)
- [x] `make vet` -- no issues
- [x] `make fmt-check` -- formatting clean
- [ ] Manual: open srepd, do NOT press any navigation keys, press 'o' -- incident should open in browser
- [ ] Manual: open srepd, do NOT press any navigation keys, press 'a' -- incident should be acknowledged
- [ ] Manual: verify 'n', ctrl+s, ctrl+e also work without prior navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)