### PR TITLE
Add urgency filter toggle (Closes #5)

### DIFF
--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -861,6 +861,23 @@ func runScheduledJobs(m *model) []tea.Cmd {
 	return cmds
 }
 
+// filterByUrgency returns a filtered copy of incidents based on urgency.
+// When showLow is true, all incidents are returned unchanged.
+// When showLow is false, only high-urgency incidents are returned.
+func filterByUrgency(incidents []pagerduty.Incident, showLow bool) []pagerduty.Incident {
+	if showLow {
+		return incidents
+	}
+
+	var filtered []pagerduty.Incident
+	for _, i := range incidents {
+		if i.Urgency == "high" {
+			filtered = append(filtered, i)
+		}
+	}
+	return filtered
+}
+
 func getIDsFromIncidents(incidents []pagerduty.Incident) []string {
 	var ids []string
 	for _, i := range incidents {

--- a/pkg/tui/commands_test.go
+++ b/pkg/tui/commands_test.go
@@ -579,6 +579,68 @@ func TestGetDetailFieldFromAlert_HappyPath(t *testing.T) {
 	assert.Equal(t, "https://example.com/sop", getDetailFieldFromAlert("link", alert))
 }
 
+func TestFilterByUrgency_ShowAll(t *testing.T) {
+	incidents := []pagerduty.Incident{
+		{APIObject: pagerduty.APIObject{ID: "Q001"}, Urgency: "high"},
+		{APIObject: pagerduty.APIObject{ID: "Q002"}, Urgency: "low"},
+		{APIObject: pagerduty.APIObject{ID: "Q003"}, Urgency: "high"},
+	}
+
+	result := filterByUrgency(incidents, true)
+	assert.Equal(t, 3, len(result), "showLow=true should return all incidents unchanged")
+	assert.Equal(t, "Q001", result[0].ID)
+	assert.Equal(t, "Q002", result[1].ID)
+	assert.Equal(t, "Q003", result[2].ID)
+}
+
+func TestFilterByUrgency_HighOnly(t *testing.T) {
+	incidents := []pagerduty.Incident{
+		{APIObject: pagerduty.APIObject{ID: "Q001"}, Urgency: "high"},
+		{APIObject: pagerduty.APIObject{ID: "Q002"}, Urgency: "low"},
+		{APIObject: pagerduty.APIObject{ID: "Q003"}, Urgency: "high"},
+		{APIObject: pagerduty.APIObject{ID: "Q004"}, Urgency: "low"},
+	}
+
+	result := filterByUrgency(incidents, false)
+	assert.Equal(t, 2, len(result), "showLow=false should return only high-urgency incidents")
+	assert.Equal(t, "Q001", result[0].ID)
+	assert.Equal(t, "Q003", result[1].ID)
+}
+
+func TestFilterByUrgency_EmptyList(t *testing.T) {
+	var incidents []pagerduty.Incident
+
+	result := filterByUrgency(incidents, true)
+	assert.Empty(t, result, "empty input should return empty result")
+
+	result = filterByUrgency(incidents, false)
+	assert.Empty(t, result, "empty input should return empty result regardless of filter")
+}
+
+func TestFilterByUrgency_AllLow(t *testing.T) {
+	incidents := []pagerduty.Incident{
+		{APIObject: pagerduty.APIObject{ID: "Q001"}, Urgency: "low"},
+		{APIObject: pagerduty.APIObject{ID: "Q002"}, Urgency: "low"},
+	}
+
+	result := filterByUrgency(incidents, false)
+	assert.Empty(t, result, "all low urgency with filter on should return empty")
+}
+
+func TestFilterByUrgency_AllHigh(t *testing.T) {
+	incidents := []pagerduty.Incident{
+		{APIObject: pagerduty.APIObject{ID: "Q001"}, Urgency: "high"},
+		{APIObject: pagerduty.APIObject{ID: "Q002"}, Urgency: "high"},
+		{APIObject: pagerduty.APIObject{ID: "Q003"}, Urgency: "high"},
+	}
+
+	result := filterByUrgency(incidents, false)
+	assert.Equal(t, 3, len(result), "all high urgency with filter on should return all")
+	assert.Equal(t, "Q001", result[0].ID)
+	assert.Equal(t, "Q002", result[1].ID)
+	assert.Equal(t, "Q003", result[2].ID)
+}
+
 func TestLoginCommandStructureWithEnvVars(t *testing.T) {
 	// This test validates that environment variables are inserted at the correct
 	// position in the command - after the terminal separator but as arguments to

--- a/pkg/tui/keymap.go
+++ b/pkg/tui/keymap.go
@@ -18,7 +18,7 @@ func (k keymap) FullHelp() [][]key.Binding {
 		// Column 2: Primary incident actions
 		{k.Ack, k.Note, k.Login, k.Open, k.UnAck, k.Silence},
 		// Column 3: Settings & toggles, Quit at bottom
-		{k.Team, k.Refresh, k.AutoRefresh, k.AutoAck, k.ToggleActionLog, k.Quit},
+		{k.Team, k.Refresh, k.AutoRefresh, k.AutoAck, k.Urgency, k.ToggleActionLog, k.Quit},
 	}
 }
 
@@ -40,6 +40,7 @@ type keymap struct {
 	UnAck           key.Binding
 	AutoAck         key.Binding
 	ToggleActionLog key.Binding
+	Urgency         key.Binding
 	Input           key.Binding
 	Login           key.Binding
 	Open            key.Binding
@@ -146,6 +147,10 @@ var defaultKeyMap = keymap{
 	ToggleActionLog: key.NewBinding(
 		key.WithKeys("ctrl+l"),
 		key.WithHelp("ctrl+l", "toggle action log"),
+	),
+	Urgency: key.NewBinding(
+		key.WithKeys("u"),
+		key.WithHelp("u", "toggle urgency filter"),
 	),
 	Input: key.NewBinding(
 		key.WithKeys("i", ":"),

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -84,6 +84,7 @@ type model struct {
 	autoRefresh     bool
 	teamMode        bool
 	showActionLog   bool
+	showLowUrgency  bool
 	debug           bool
 }
 
@@ -131,6 +132,7 @@ func InitialModel(
 		incidentCache:    make(map[string]*cachedIncidentData),
 		scheduledJobs:    append([]*scheduledJob{}, initialScheduledJobs...),
 		autoRefresh:      true, // Start watching for updates on startup
+		showLowUrgency:   true, // Show all urgencies by default
 	}
 
 	// This is an ugly way to handle this error

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -164,6 +164,11 @@ func (m model) keyMsgHandler(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	if key.Matches(msg.(tea.KeyMsg), defaultKeyMap.Urgency) {
+		m.showLowUrgency = !m.showLowUrgency
+		return m, func() tea.Msg { return updatedIncidentListMsg{m.incidentList, nil} }
+	}
+
 	// Commands for any focus mode
 	if key.Matches(msg.(tea.KeyMsg), defaultKeyMap.Input) {
 		return m, tea.Sequence(

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -461,11 +461,14 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			highlightedID = currentRow[1]
 		}
 
-		var totalIncidentCount int
+		totalIncidentCount := len(m.incidentList)
+
+		// Apply urgency filter before building table rows
+		filteredIncidents := filterByUrgency(m.incidentList, m.showLowUrgency)
+
 		var rows []table.Row
 
-		for _, i := range m.incidentList {
-			totalIncidentCount++
+		for _, i := range filteredIncidents {
 			state := stateShorthand(i, m.config.CurrentUser.ID)
 			if AssignedToUser(i, m.config.CurrentUser.ID) || m.teamMode {
 				rows = append(rows, table.Row{state, i.ID, i.Title, i.Service.Summary})
@@ -481,10 +484,16 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 
+		// Build status message with filter and count info
+		var filterSuffix string
+		if !m.showLowUrgency {
+			filterSuffix = " (high only)"
+		}
+
 		if totalIncidentCount == 1 {
-			m.setStatus(fmt.Sprintf("showing %d/%d incident...", len(m.table.Rows()), totalIncidentCount))
+			m.setStatus(fmt.Sprintf("showing %d/%d incident%s...", len(m.table.Rows()), totalIncidentCount, filterSuffix))
 		} else {
-			m.setStatus(fmt.Sprintf("showing %d/%d incidents...", len(m.table.Rows()), totalIncidentCount))
+			m.setStatus(fmt.Sprintf("showing %d/%d incidents%s...", len(m.table.Rows()), totalIncidentCount, filterSuffix))
 		}
 
 		// Re-sync selectedIncident to match highlighted row

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -221,7 +221,7 @@ func (m model) renderFooter() string {
 	s.WriteString(
 		lipgloss.JoinHorizontal(
 			0.2,
-			paddedStyle.Render(refreshArea(m.autoRefresh, m.autoAcknowledge)),
+			paddedStyle.Render(refreshArea(m.autoRefresh, m.autoAcknowledge, m.showLowUrgency)),
 		),
 	)
 
@@ -297,13 +297,17 @@ func statusArea(s string, showSpinner bool, spinnerView string) string {
 	return fmt.Sprintf(fstring, prefix, s)
 }
 
-func refreshArea(autoRefresh bool, autoAck bool) string {
+func refreshArea(autoRefresh bool, autoAck bool, showLowUrgency bool) string {
 	var fstring = "Watching for updates... "
 
 	if autoRefresh && autoAck {
 		fstring = fstring + " [auto-acknowledge]"
 	} else if !autoRefresh {
 		fstring = fstring + " [PAUSED]"
+	}
+
+	if !showLowUrgency {
+		fstring = fstring + " [high urgency only]"
 	}
 
 	fstring = strings.TrimSuffix(fstring, "\n")

--- a/pkg/tui/views_test.go
+++ b/pkg/tui/views_test.go
@@ -86,40 +86,66 @@ func TestStatusArea(t *testing.T) {
 
 func TestRefreshArea(t *testing.T) {
 	tests := []struct {
-		name        string
-		autoRefresh bool
-		autoAck     bool
-		expected    string
+		name           string
+		autoRefresh    bool
+		autoAck        bool
+		showLowUrgency bool
+		expected       string
 	}{
 		{
-			name:        "both enabled",
-			autoRefresh: true,
-			autoAck:     true,
-			expected:    "Watching for updates...  [auto-acknowledge]",
+			name:           "both enabled, all urgencies",
+			autoRefresh:    true,
+			autoAck:        true,
+			showLowUrgency: true,
+			expected:       "Watching for updates...  [auto-acknowledge]",
 		},
 		{
-			name:        "auto-refresh enabled, auto-ack disabled",
-			autoRefresh: true,
-			autoAck:     false,
-			expected:    "Watching for updates... ",
+			name:           "auto-refresh enabled, auto-ack disabled, all urgencies",
+			autoRefresh:    true,
+			autoAck:        false,
+			showLowUrgency: true,
+			expected:       "Watching for updates... ",
 		},
 		{
-			name:        "auto-refresh disabled",
-			autoRefresh: false,
-			autoAck:     false,
-			expected:    "Watching for updates...  [PAUSED]",
+			name:           "auto-refresh disabled, all urgencies",
+			autoRefresh:    false,
+			autoAck:        false,
+			showLowUrgency: true,
+			expected:       "Watching for updates...  [PAUSED]",
 		},
 		{
-			name:        "auto-refresh disabled, auto-ack enabled (paused takes precedence)",
-			autoRefresh: false,
-			autoAck:     true,
-			expected:    "Watching for updates...  [PAUSED]",
+			name:           "auto-refresh disabled, auto-ack enabled (paused takes precedence), all urgencies",
+			autoRefresh:    false,
+			autoAck:        true,
+			showLowUrgency: true,
+			expected:       "Watching for updates...  [PAUSED]",
+		},
+		{
+			name:           "high urgency only filter shown",
+			autoRefresh:    true,
+			autoAck:        false,
+			showLowUrgency: false,
+			expected:       "Watching for updates...  [high urgency only]",
+		},
+		{
+			name:           "auto-ack and high urgency only",
+			autoRefresh:    true,
+			autoAck:        true,
+			showLowUrgency: false,
+			expected:       "Watching for updates...  [auto-acknowledge] [high urgency only]",
+		},
+		{
+			name:           "paused and high urgency only",
+			autoRefresh:    false,
+			autoAck:        false,
+			showLowUrgency: false,
+			expected:       "Watching for updates...  [PAUSED] [high urgency only]",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result := refreshArea(test.autoRefresh, test.autoAck)
+			result := refreshArea(test.autoRefresh, test.autoAck, test.showLowUrgency)
 			assert.Equal(t, test.expected, result)
 		})
 	}


### PR DESCRIPTION
## Summary

- Add `filterByUrgency()` pure function to filter incidents by urgency level (high/low)
- Add `showLowUrgency` model field (default: true = show all) with 'u' key binding to toggle
- Apply filter in `updatedIncidentListMsg` handler before building table rows, preserving full incident list
- Show filter state in status bar ("showing X/Y incidents (high only)") and footer ("[high urgency only]")

## Test plan

- [x] `TestFilterByUrgency_ShowAll` -- showLow=true returns all incidents unchanged
- [x] `TestFilterByUrgency_HighOnly` -- showLow=false returns only urgency="high" incidents
- [x] `TestFilterByUrgency_EmptyList` -- empty input returns empty
- [x] `TestFilterByUrgency_AllLow` -- all low urgency with filter on returns empty
- [x] `TestFilterByUrgency_AllHigh` -- all high urgency with filter on returns all
- [x] `TestRefreshArea` updated with 7 cases covering urgency filter display combinations
- [x] `go vet ./...` clean
- [x] `gofmt -s` clean
- [x] All existing tests pass (no regressions)

Closes #5

Created with assistance from Claude <claude@anthropic.com>