### PR TITLE
Add confirmation prompts for destructive incident actions

### DIFF
--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -28,6 +28,13 @@ type cachedIncidentData struct {
 	lastFetched  time.Time
 }
 
+// confirmActionState stores the pending confirmation state for destructive actions.
+// When set, the UI shows a prompt and only accepts y/n/Escape.
+type confirmActionState struct {
+	prompt string  // e.g., "Acknowledge P1234567? [y/n]"
+	action tea.Cmd // Command to execute on 'y'
+}
+
 // actionLogEntry stores a record of a write action performed on an incident
 type actionLogEntry struct {
 	key       string    // Keypress that triggered action (e.g., "a", "^e", "n", "%R" for resolved)
@@ -86,6 +93,10 @@ type model struct {
 	showActionLog   bool
 	showLowUrgency  bool
 	debug           bool
+
+	// pendingConfirmation holds the state of a destructive action awaiting user confirmation.
+	// When non-nil, the UI shows the prompt and only accepts y/n/Escape.
+	pendingConfirmation *confirmActionState
 }
 
 func InitialModel(
@@ -168,6 +179,8 @@ func (m *model) clearSelectedIncident(reason interface{}) {
 	m.incidentDataLoaded = false
 	m.incidentNotesLoaded = false
 	m.incidentAlertsLoaded = false
+	// Clear any pending confirmation on view transition
+	m.pendingConfirmation = nil
 	log.Debug("clearSelectedIncident", "selectedIncident", m.selectedIncident, "cleared", true, "reason", reason)
 }
 

--- a/pkg/tui/model_test.go
+++ b/pkg/tui/model_test.go
@@ -951,6 +951,272 @@ func TestFindRowIndex_EmptyRows(t *testing.T) {
 	assert.Equal(t, -1, result, "Expected -1 when rows slice is empty")
 }
 
+// createTestModelWithSelectedIncident creates a model with a table, incident list,
+// and a highlighted/selected incident for testing confirmation prompts and actions
+func createTestModelWithSelectedIncident() model {
+	m := createTestModel()
+	m.config = &pd.Config{
+		EscalationPolicies: map[string]*pagerduty.EscalationPolicy{
+			"SILENT_DEFAULT": {
+				APIObject: pagerduty.APIObject{ID: "SILENT"},
+				Name:      "Silent",
+			},
+		},
+		CurrentUser: &pagerduty.User{
+			APIObject: pagerduty.APIObject{ID: "U123"},
+		},
+	}
+
+	m.incidentList = []pagerduty.Incident{
+		{
+			APIObject:        pagerduty.APIObject{ID: "P1234567"},
+			Title:            "Test Alert Firing",
+			Service:          pagerduty.APIObject{ID: "SVC789", Summary: "test-service"},
+			EscalationPolicy: pagerduty.APIObject{ID: "POL123"},
+		},
+	}
+
+	cols := []table.Column{
+		{Title: dot, Width: dotWidth},
+		{Title: "ID", Width: idWidth - dotWidth},
+		{Title: "Summary", Width: 30},
+		{Title: "Service", Width: 20},
+	}
+	rows := []table.Row{
+		{dot, "P1234567", "Test Alert Firing", "test-service"},
+	}
+	m.table = table.New(
+		table.WithColumns(cols),
+		table.WithRows(rows),
+		table.WithFocused(true),
+	)
+
+	// Sync the selected incident to the highlighted row
+	m.syncSelectedIncidentToHighlightedRow()
+
+	// Set up action log table to prevent panics
+	m.actionLogTable = newActionLogTable()
+	m.actionLogTable.SetColumns([]table.Column{
+		{Title: "", Width: 2},
+		{Title: "", Width: 15},
+		{Title: "", Width: 30},
+		{Title: "", Width: 20},
+	})
+
+	return m
+}
+
+func TestConfirmAction_AckExecutesDirectly(t *testing.T) {
+	t.Run("pressing 'a' in table mode executes immediately without confirmation", func(t *testing.T) {
+		m := createTestModelWithSelectedIncident()
+
+		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}}
+		result, cmd := m.Update(msg)
+		m = result.(model)
+
+		assert.Nil(t, m.pendingConfirmation, "acknowledge should not set pendingConfirmation")
+		assert.NotNil(t, cmd, "acknowledge should return a command immediately")
+	})
+
+	t.Run("pressing 'a' in incident view mode executes immediately without confirmation", func(t *testing.T) {
+		m := createTestModelWithSelectedIncident()
+		m.viewingIncident = true
+
+		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}}
+		result, cmd := m.Update(msg)
+		m = result.(model)
+
+		assert.Nil(t, m.pendingConfirmation, "acknowledge should not set pendingConfirmation in incident view")
+		assert.NotNil(t, cmd, "acknowledge should return a command immediately")
+	})
+}
+
+func TestConfirmAction_ReEscalateShowsPrompt(t *testing.T) {
+	t.Run("pressing ctrl+e sets pendingConfirmation instead of executing", func(t *testing.T) {
+		m := createTestModelWithSelectedIncident()
+
+		msg := tea.KeyMsg{Type: tea.KeyCtrlE}
+		result, cmd := m.Update(msg)
+		m = result.(model)
+
+		assert.NotNil(t, m.pendingConfirmation, "pendingConfirmation should be set after pressing ctrl+e")
+		assert.Contains(t, m.pendingConfirmation.prompt, "P1234567", "prompt should contain incident ID")
+		assert.Contains(t, m.pendingConfirmation.prompt, "Re-escalate", "prompt should describe the action")
+		assert.Nil(t, cmd, "no command should execute before confirmation")
+	})
+}
+
+func TestConfirmAction_SilenceShowsPrompt(t *testing.T) {
+	t.Run("pressing ctrl+s sets pendingConfirmation instead of executing", func(t *testing.T) {
+		m := createTestModelWithSelectedIncident()
+
+		msg := tea.KeyMsg{Type: tea.KeyCtrlS}
+		result, cmd := m.Update(msg)
+		m = result.(model)
+
+		assert.NotNil(t, m.pendingConfirmation, "pendingConfirmation should be set after pressing ctrl+s")
+		assert.Contains(t, m.pendingConfirmation.prompt, "P1234567", "prompt should contain incident ID")
+		assert.Contains(t, m.pendingConfirmation.prompt, "Silence", "prompt should describe the action")
+		assert.Nil(t, cmd, "no command should execute before confirmation")
+	})
+}
+
+func TestConfirmAction_YesExecutes(t *testing.T) {
+	t.Run("pressing 'y' with pendingConfirmation executes the action and clears it", func(t *testing.T) {
+		m := createTestModelWithSelectedIncident()
+
+		// Set up pendingConfirmation by pressing ctrl+s (silence)
+		msg := tea.KeyMsg{Type: tea.KeyCtrlS}
+		result, _ := m.Update(msg)
+		m = result.(model)
+		assert.NotNil(t, m.pendingConfirmation, "precondition: pendingConfirmation should be set")
+
+		// Now press 'y' to confirm
+		confirmMsg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}}
+		result, cmd := m.Update(confirmMsg)
+		m = result.(model)
+
+		// pendingConfirmation should be cleared
+		assert.Nil(t, m.pendingConfirmation, "pendingConfirmation should be cleared after 'y'")
+		// A command should have been returned (the action executes)
+		assert.NotNil(t, cmd, "command should be returned after confirming")
+	})
+}
+
+func TestConfirmAction_NoAborts(t *testing.T) {
+	t.Run("pressing 'n' with pendingConfirmation clears it without executing", func(t *testing.T) {
+		m := createTestModelWithSelectedIncident()
+
+		// Set up pendingConfirmation via ctrl+s (silence)
+		msg := tea.KeyMsg{Type: tea.KeyCtrlS}
+		result, _ := m.Update(msg)
+		m = result.(model)
+		assert.NotNil(t, m.pendingConfirmation, "precondition: pendingConfirmation should be set")
+
+		// Now press 'n' to abort
+		cancelMsg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}}
+		result, cmd := m.Update(cancelMsg)
+		m = result.(model)
+
+		// pendingConfirmation should be cleared
+		assert.Nil(t, m.pendingConfirmation, "pendingConfirmation should be cleared after 'n'")
+		// No command should execute
+		assert.Nil(t, cmd, "no command should execute after aborting")
+		// Status should indicate cancellation
+		assert.Contains(t, m.status, "cancelled", "status should indicate cancellation")
+	})
+}
+
+func TestConfirmAction_EscAborts(t *testing.T) {
+	t.Run("pressing Escape with pendingConfirmation clears it without executing", func(t *testing.T) {
+		m := createTestModelWithSelectedIncident()
+
+		// Set up pendingConfirmation via ctrl+s (silence)
+		msg := tea.KeyMsg{Type: tea.KeyCtrlS}
+		result, _ := m.Update(msg)
+		m = result.(model)
+		assert.NotNil(t, m.pendingConfirmation, "precondition: pendingConfirmation should be set")
+
+		// Now press Escape to abort
+		escMsg := tea.KeyMsg{Type: tea.KeyEscape}
+		result, cmd := m.Update(escMsg)
+		m = result.(model)
+
+		// pendingConfirmation should be cleared
+		assert.Nil(t, m.pendingConfirmation, "pendingConfirmation should be cleared after Escape")
+		// No command should execute
+		assert.Nil(t, cmd, "no command should execute after pressing Escape")
+		// Status should indicate cancellation
+		assert.Contains(t, m.status, "cancelled", "status should indicate cancellation")
+	})
+}
+
+func TestConfirmAction_ClearedOnViewTransition(t *testing.T) {
+	t.Run("clearSelectedIncident clears pendingConfirmation", func(t *testing.T) {
+		m := createTestModelWithSelectedIncident()
+
+		// Set up pendingConfirmation directly
+		m.pendingConfirmation = &confirmActionState{
+			prompt: "Acknowledge P1234567? [y/n]",
+			action: func() tea.Msg { return acknowledgeIncidentsMsg{} },
+		}
+
+		// clearSelectedIncident should also clear pendingConfirmation
+		m.clearSelectedIncident("test")
+
+		assert.Nil(t, m.pendingConfirmation, "pendingConfirmation should be cleared by clearSelectedIncident")
+	})
+
+	t.Run("confirmation blocks other keys including Enter", func(t *testing.T) {
+		m := createTestModelWithSelectedIncident()
+
+		// Set up pendingConfirmation via ctrl+s (silence)
+		msg := tea.KeyMsg{Type: tea.KeyCtrlS}
+		result, _ := m.Update(msg)
+		m = result.(model)
+		assert.NotNil(t, m.pendingConfirmation, "precondition: pendingConfirmation should be set")
+
+		// Press Enter -- should be ignored while confirmation is active
+		enterMsg := tea.KeyMsg{Type: tea.KeyEnter}
+		result, cmd := m.Update(enterMsg)
+		m = result.(model)
+
+		// pendingConfirmation should still be set (Enter is ignored)
+		assert.NotNil(t, m.pendingConfirmation, "pendingConfirmation should remain set when Enter is pressed")
+		assert.Nil(t, cmd, "no command should execute for non-confirmation keys")
+	})
+}
+
+func TestConfirmAction_OtherKeysIgnored(t *testing.T) {
+	t.Run("pressing non-y/n/Escape keys are ignored during confirmation", func(t *testing.T) {
+		m := createTestModelWithSelectedIncident()
+
+		// Set up pendingConfirmation via ctrl+s (silence)
+		msg := tea.KeyMsg{Type: tea.KeyCtrlS}
+		result, _ := m.Update(msg)
+		m = result.(model)
+		assert.NotNil(t, m.pendingConfirmation, "precondition: pendingConfirmation should be set")
+
+		savedPrompt := m.pendingConfirmation.prompt
+
+		// Press an unrelated key like 'x'
+		otherMsg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}}
+		result, cmd := m.Update(otherMsg)
+		m = result.(model)
+
+		// pendingConfirmation should still be set (not cleared)
+		assert.NotNil(t, m.pendingConfirmation, "pendingConfirmation should remain set after unrelated key")
+		assert.Equal(t, savedPrompt, m.pendingConfirmation.prompt, "prompt should not change")
+		assert.Nil(t, cmd, "no command should execute for unrelated keys")
+	})
+}
+
+func TestConfirmAction_PromptRenderedInStatusArea(t *testing.T) {
+	t.Run("View renders confirmation prompt in status area", func(t *testing.T) {
+		m := createTestModelWithSelectedIncident()
+
+		// Need window size for View() to work
+		windowSize = tea.WindowSizeMsg{Width: 120, Height: 50}
+		// Need to handle windowSizeMsgHandler to set columns etc.
+		result, _ := m.windowSizeMsgHandler(windowSize)
+		m = result.(model)
+
+		// Reset table rows after windowSizeMsgHandler
+		m.table.SetRows([]table.Row{
+			{dot, "P1234567", "Test Alert Firing", "test-service"},
+		})
+
+		// Set up a pending confirmation
+		m.pendingConfirmation = &confirmActionState{
+			prompt: "Silence P1234567? [y/n]",
+			action: func() tea.Msg { return silenceSelectedIncidentMsg{} },
+		}
+
+		view := m.View()
+		assert.Contains(t, view, "Silence P1234567? [y/n]", "View should render the confirmation prompt")
+	})
+}
+
 func TestWindowSizeMsgHandler_SmallWindow(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -145,6 +145,11 @@ func (m model) windowSizeMsgHandler(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m model) keyMsgHandler(msg tea.Msg) (tea.Model, tea.Cmd) {
+	// If a confirmation prompt is active, only accept y/n/Escape/quit
+	if m.pendingConfirmation != nil {
+		return m.handleConfirmationInput(msg.(tea.KeyMsg))
+	}
+
 	if key.Matches(msg.(tea.KeyMsg), defaultKeyMap.Quit) {
 		return m, tea.Quit
 	}
@@ -192,6 +197,36 @@ func (m model) keyMsgHandler(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	return m, nil
+}
+
+// handleConfirmationInput processes keypresses while a confirmation prompt is active.
+// Only 'y' (execute), 'n' (cancel), Escape (cancel), and quit keys are accepted.
+func (m model) handleConfirmationInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if key.Matches(msg, defaultKeyMap.Quit) {
+		return m, tea.Quit
+	}
+
+	keyStr := msg.String()
+	switch keyStr {
+	case "y":
+		// Execute the pending action
+		action := m.pendingConfirmation.action
+		m.pendingConfirmation = nil
+		return m, action
+	case "n":
+		// Cancel the pending action
+		m.pendingConfirmation = nil
+		m.setStatus("action cancelled")
+		return m, nil
+	case "esc":
+		// Cancel the pending action
+		m.pendingConfirmation = nil
+		m.setStatus("action cancelled")
+		return m, nil
+	default:
+		// Ignore all other keys while confirmation is active
+		return m, nil
+	}
 }
 
 // tableFocusMode is the main mode for the application
@@ -252,6 +287,8 @@ func switchTableFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 		// fetch full incident data from the API before proceeding.
 
 		case key.Matches(msg, defaultKeyMap.Enter):
+			// Clear any pending confirmation on view transition
+			m.pendingConfirmation = nil
 			// Check if we have cached data for this incident
 			if cached, exists := m.incidentCache[incidentID]; exists {
 				// Use cached data immediately
@@ -314,7 +351,11 @@ func switchTableFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.setStatus("no incident selected")
 				return m, nil
 			}
-			return m, func() tea.Msg { return silenceSelectedIncidentMsg{} }
+			m.pendingConfirmation = &confirmActionState{
+				prompt: fmt.Sprintf("Silence %s? [y/n]", incidentID),
+				action: func() tea.Msg { return silenceSelectedIncidentMsg{} },
+			}
+			return m, nil
 
 		case key.Matches(msg, defaultKeyMap.Ack):
 			if m.table.SelectedRow() == nil {
@@ -338,7 +379,11 @@ func switchTableFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.setStatus("no incident selected")
 				return m, nil
 			}
-			return m, func() tea.Msg { return unAcknowledgeIncidentsMsg{} }
+			m.pendingConfirmation = &confirmActionState{
+				prompt: fmt.Sprintf("Re-escalate %s? [y/n]", incidentID),
+				action: func() tea.Msg { return unAcknowledgeIncidentsMsg{} },
+			}
+			return m, nil
 
 		case key.Matches(msg, defaultKeyMap.Note):
 			if m.table.SelectedRow() == nil {
@@ -469,10 +514,26 @@ func switchIncidentFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, func() tea.Msg { return acknowledgeIncidentsMsg{} }
 
 		case key.Matches(msg, defaultKeyMap.UnAck):
-			return m, func() tea.Msg { return unAcknowledgeIncidentsMsg{} }
+			incidentID := ""
+			if m.selectedIncident != nil {
+				incidentID = m.selectedIncident.ID
+			}
+			m.pendingConfirmation = &confirmActionState{
+				prompt: fmt.Sprintf("Re-escalate %s? [y/n]", incidentID),
+				action: func() tea.Msg { return unAcknowledgeIncidentsMsg{} },
+			}
+			return m, nil
 
 		case key.Matches(msg, defaultKeyMap.Silence):
-			return m, func() tea.Msg { return silenceSelectedIncidentMsg{} }
+			incidentID := ""
+			if m.selectedIncident != nil {
+				incidentID = m.selectedIncident.ID
+			}
+			m.pendingConfirmation = &confirmActionState{
+				prompt: fmt.Sprintf("Silence %s? [y/n]", incidentID),
+				action: func() tea.Msg { return silenceSelectedIncidentMsg{} },
+			}
+			return m, nil
 
 		case key.Matches(msg, defaultKeyMap.Note):
 			// Note template requires full incident data (HTMLURL, Title, Service.Summary)

--- a/pkg/tui/msgHandlers_test.go
+++ b/pkg/tui/msgHandlers_test.go
@@ -255,9 +255,11 @@ func TestTableMode_SilenceKeyWithNoSelectedIncident(t *testing.T) {
 	assert.Equal(t, "Q111", updatedModel.selectedIncident.ID,
 		"Synced selectedIncident should match highlighted row")
 
-	// A command should be returned
-	assert.NotNil(t, cmd,
-		"Silence key should return a command when a row is highlighted")
+	// Silence uses confirmation prompt, so pendingConfirmation should be set
+	assert.NotNil(t, updatedModel.pendingConfirmation,
+		"Silence key should set pendingConfirmation")
+	assert.Nil(t, cmd,
+		"Silence key should not return a command before confirmation")
 }
 
 func TestTableMode_UnAckKeyWithNoSelectedIncident(t *testing.T) {
@@ -287,7 +289,9 @@ func TestTableMode_UnAckKeyWithNoSelectedIncident(t *testing.T) {
 	assert.Equal(t, "Q111", updatedModel.selectedIncident.ID,
 		"Synced selectedIncident should match highlighted row")
 
-	// A command should be returned
-	assert.NotNil(t, cmd,
-		"UnAck key should return a command when a row is highlighted")
+	// Re-escalate uses confirmation prompt, so pendingConfirmation should be set
+	assert.NotNil(t, updatedModel.pendingConfirmation,
+		"UnAck key should set pendingConfirmation")
+	assert.Nil(t, cmd,
+		"UnAck key should not return a command before confirmation")
 }

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -238,11 +238,20 @@ func (m model) renderHeader() string {
 		assignedTo = "Team"
 	}
 
+	// When a confirmation prompt is active, show it in the status area instead of
+	// the normal status text, using the warning style to draw attention
+	var statusContent string
+	if m.pendingConfirmation != nil {
+		statusContent = warningStyle.Render(m.pendingConfirmation.prompt)
+	} else {
+		statusContent = statusArea(m.status, m.apiInProgress, m.spinner.View())
+	}
+
 	s.WriteString(
 		lipgloss.JoinHorizontal(
 			0.2,
 
-			paddedStyle.Width(windowSize.Width-assignedStringWidth-paddedStyle.GetHorizontalPadding()-paddedStyle.GetHorizontalBorderSize()).Render(statusArea(m.status, m.apiInProgress, m.spinner.View())),
+			paddedStyle.Width(windowSize.Width-assignedStringWidth-paddedStyle.GetHorizontalPadding()-paddedStyle.GetHorizontalBorderSize()).Render(statusContent),
 
 			paddedStyle.Render(assigneeArea(assignedTo)),
 		),


### PR DESCRIPTION
## Summary
- Add y/n confirmation prompts for **silence** (ctrl+s) and **re-escalate** (ctrl+e) actions to prevent accidental mispresses
- Acknowledge ('a') executes immediately without confirmation since it's the most common action and easily reversible
- Confirmation prompt renders in the header status area (e.g., "Silence P1234567? [y/n]")
- Press 'y' to execute, 'n' or Escape to cancel
- Confirmation state is cleared on view transitions

Fixes #21

## Test plan
- [x] `TestConfirmAction_AckExecutesDirectly` - ack fires immediately without confirmation (table + incident view)
- [x] `TestConfirmAction_ReEscalateShowsPrompt` - ctrl+e sets pendingConfirmation
- [x] `TestConfirmAction_SilenceShowsPrompt` - ctrl+s sets pendingConfirmation
- [x] `TestConfirmAction_YesExecutes` - 'y' executes action and clears prompt
- [x] `TestConfirmAction_NoAborts` - 'n' cancels without executing
- [x] `TestConfirmAction_EscAborts` - Escape cancels
- [x] `TestConfirmAction_OtherKeysIgnored` - random keys ignored during confirmation
- [x] `TestConfirmAction_ClearedOnViewTransition` - clearSelectedIncident clears prompt
- [x] `TestConfirmAction_ViewRendersPrompt` - view renders confirmation in header
- [x] All tests pass, zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)