### PR TITLE
Fix removeCommentsFromBytes bug and add pure function tests

### DIFF
--- a/docs/plans/027-bug-fixes-pure-function-tests.md
+++ b/docs/plans/027-bug-fixes-pure-function-tests.md
@@ -1,0 +1,74 @@
+# Plan 027: Bug Fixes and Pure Function Test Coverage
+
+## Summary
+
+Fix two known bugs and add table-driven test coverage for six pure functions
+in the TUI commands package.
+
+## Bug Fixes
+
+### Bug 1: removeCommentsFromBytes() line duplication (pkg/tui/commands.go)
+
+**Problem**: The nested loop iterated over prefixes inside the lines loop. When
+multiple prefixes were provided, non-comment lines were written once per
+non-matching prefix, causing content duplication. Comment lines matching only
+some prefixes would also be partially preserved.
+
+**Root cause**: The inner loop wrote the line immediately when a prefix did not
+match, rather than checking all prefixes first.
+
+**Fix**: Introduce a boolean flag (`isComment`) that is set when any prefix
+matches, with a `break` to short-circuit. The line is only written if no prefix
+matched.
+
+### Bug 2: PostNote() missing error context (pkg/pd/pd.go)
+
+**Problem**: `PostNote` returned the raw error from
+`CreateIncidentNoteWithContext` without wrapping it, unlike every other function
+in the pd package which wraps errors with function name and context.
+
+**Fix**: Wrap the error with `fmt.Errorf("pd.PostNote(): failed to create note
+for incident %v: %w", id, err)` to match the established pattern. Uses `%w` for
+error chain preservation.
+
+## New Tests
+
+### Pure function tests (pkg/tui/commands_test.go)
+
+All tests are table-driven using testify/assert:
+
+| Function | Test Cases |
+|---|---|
+| `stateShorthand` | Acked by user (A), acked by other (a), not acked (dot), multi-ack |
+| `acknowledged` | Has acks, multiple acks, empty, nil |
+| `AssignedToUser` | Assigned, not assigned, no assignments, multi-assignee |
+| `AcknowledgedByUser` | User acked, other acked, none, multi-ack |
+| `AssignedToAnyUsers` | Match, no match, no assignments, empty IDs, nil IDs, multi-both |
+| `removeCommentsFromBytes` | Single prefix, multi-prefix, no-duplication, all-comments, no-match, empty, no-prefixes, three-prefix mix |
+
+### PostNote test (pkg/pd/pd_test.go)
+
+Table-driven test covering success path and error wrapping verification.
+
+### Mock additions (pkg/pd/mock.go)
+
+Added mock implementations for:
+- `CreateIncidentNoteWithContext` (uses "err" sentinel pattern)
+- `GetCurrentUserWithContext`
+- `GetEscalationPolicyWithContext`
+- `GetUserWithContext`
+
+## Verification
+
+- `go test ./... -count=1` -- all pass
+- `go vet ./...` -- clean
+- `gofmt -s -l cmd pkg` -- clean
+
+## Files Changed
+
+- `pkg/tui/commands.go` -- removeCommentsFromBytes bug fix
+- `pkg/tui/commands_test.go` -- 6 new table-driven test functions
+- `pkg/pd/pd.go` -- PostNote error wrapping
+- `pkg/pd/pd_test.go` -- PostNote test
+- `pkg/pd/mock.go` -- 4 new mock methods
+- `docs/plans/027-bug-fixes-pure-function-tests.md` -- this plan

--- a/pkg/pd/mock.go
+++ b/pkg/pd/mock.go
@@ -183,6 +183,47 @@ func (m *MockPagerDutyClient) ListMembersWithContext(ctx context.Context, id str
 	}, nil
 }
 
+func (m *MockPagerDutyClient) CreateIncidentNoteWithContext(ctx context.Context, id string, note pagerduty.IncidentNote) (*pagerduty.IncidentNote, error) {
+	m.recordCall("CreateIncidentNoteWithContext")
+	if id == "err" {
+		return nil, ErrMockError
+	}
+	return &pagerduty.IncidentNote{
+		ID:      "NOTE_MOCK_001",
+		Content: note.Content,
+		User:    note.User,
+	}, nil
+}
+
+func (m *MockPagerDutyClient) GetCurrentUserWithContext(ctx context.Context, opts pagerduty.GetCurrentUserOptions) (*pagerduty.User, error) {
+	m.recordCall("GetCurrentUserWithContext")
+	return &pagerduty.User{
+		APIObject: pagerduty.APIObject{ID: "MOCK_USER"},
+		Email:     "mock@example.com",
+	}, nil
+}
+
+func (m *MockPagerDutyClient) GetEscalationPolicyWithContext(ctx context.Context, id string, opts *pagerduty.GetEscalationPolicyOptions) (*pagerduty.EscalationPolicy, error) {
+	m.recordCall("GetEscalationPolicyWithContext")
+	if id == "err" {
+		return nil, ErrMockError
+	}
+	return &pagerduty.EscalationPolicy{
+		APIObject: pagerduty.APIObject{ID: id},
+		Name:      "Mock Policy",
+	}, nil
+}
+
+func (m *MockPagerDutyClient) GetUserWithContext(ctx context.Context, id string, opts pagerduty.GetUserOptions) (*pagerduty.User, error) {
+	m.recordCall("GetUserWithContext")
+	if id == "err" {
+		return nil, ErrMockError
+	}
+	return &pagerduty.User{
+		APIObject: pagerduty.APIObject{ID: id},
+	}, nil
+}
+
 func (m *MockPagerDutyClient) ListOnCallsWithContext(ctx context.Context, opts pagerduty.ListOnCallOptions) (*pagerduty.ListOnCallsResponse, error) {
 	m.recordCall("ListOnCallsWithContext")
 

--- a/pkg/pd/pd.go
+++ b/pkg/pd/pd.go
@@ -402,7 +402,7 @@ func PostNote(client PagerDutyClient, id string, user *pagerduty.User, content s
 
 	n, err := client.CreateIncidentNoteWithContext(ctx, id, note)
 	if err != nil {
-		return n, err
+		return n, fmt.Errorf("pd.PostNote(): failed to create note for incident %v: %w", id, err)
 	}
 
 	return n, nil

--- a/pkg/pd/pd_test.go
+++ b/pkg/pd/pd_test.go
@@ -236,6 +236,52 @@ func TestGetTeamMemberIDs_PaginatedTeam(t *testing.T) {
 		"offset should reset to 0 for each new team")
 }
 
+func TestPostNote(t *testing.T) {
+	mockClient := new(MockPagerDutyClient)
+	user := &pagerduty.User{
+		APIObject: pagerduty.APIObject{ID: "USER1", Type: "user_reference"},
+	}
+
+	tests := []struct {
+		name        string
+		id          string
+		content     string
+		expectErr   bool
+		errContains string
+	}{
+		{
+			name:      "successfully creates a note",
+			id:        "INCIDENT1",
+			content:   "Test note content",
+			expectErr: false,
+		},
+		{
+			name:        "returns wrapped error on failure",
+			id:          "err",
+			content:     "Test note content",
+			expectErr:   true,
+			errContains: "pd.PostNote()",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			note, err := PostNote(mockClient, tt.id, user, tt.content)
+			if tt.expectErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains,
+					"error should be wrapped with function context")
+				assert.Contains(t, err.Error(), tt.id,
+					"error should include the incident ID")
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, note)
+				assert.Equal(t, tt.content, note.Content)
+			}
+		})
+	}
+}
+
 func TestGetUserOnCalls_MultiplePages(t *testing.T) {
 	// Test that GetUserOnCalls appends results across pages instead of
 	// overwriting them.

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -773,10 +773,15 @@ func removeCommentsFromBytes(b []byte, prefixes ...string) string {
 	lines := strings.Split(string(b[:]), "\n")
 
 	for _, c := range lines {
+		isComment := false
 		for _, a := range prefixes {
-			if !strings.HasPrefix(c, a) {
-				content.WriteString(c)
+			if strings.HasPrefix(c, a) {
+				isComment = true
+				break
 			}
+		}
+		if !isComment {
+			content.WriteString(c)
 		}
 	}
 

--- a/pkg/tui/commands_test.go
+++ b/pkg/tui/commands_test.go
@@ -702,6 +702,345 @@ func TestLoginCommandStructureWithEnvVars(t *testing.T) {
 	}
 }
 
+func TestStateShorthand(t *testing.T) {
+	userID := "USER1"
+
+	tests := []struct {
+		name     string
+		incident pagerduty.Incident
+		id       string
+		expected string
+	}{
+		{
+			name: "returns A when acknowledged by the given user",
+			incident: pagerduty.Incident{
+				Acknowledgements: []pagerduty.Acknowledgement{
+					{Acknowledger: pagerduty.APIObject{ID: "USER1"}},
+				},
+			},
+			id:       userID,
+			expected: "A",
+		},
+		{
+			name: "returns a when acknowledged by someone else",
+			incident: pagerduty.Incident{
+				Acknowledgements: []pagerduty.Acknowledgement{
+					{Acknowledger: pagerduty.APIObject{ID: "OTHER_USER"}},
+				},
+			},
+			id:       userID,
+			expected: "a",
+		},
+		{
+			name:     "returns dot when not acknowledged at all",
+			incident: pagerduty.Incident{},
+			id:       userID,
+			expected: dot,
+		},
+		{
+			name: "returns A when acknowledged by user and also by someone else",
+			incident: pagerduty.Incident{
+				Acknowledgements: []pagerduty.Acknowledgement{
+					{Acknowledger: pagerduty.APIObject{ID: "OTHER_USER"}},
+					{Acknowledger: pagerduty.APIObject{ID: "USER1"}},
+				},
+			},
+			id:       userID,
+			expected: "A",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := stateShorthand(tt.incident, tt.id)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestAcknowledged(t *testing.T) {
+	tests := []struct {
+		name            string
+		acknowledgments []pagerduty.Acknowledgement
+		expected        bool
+	}{
+		{
+			name:            "returns true when there are acknowledgements",
+			acknowledgments: []pagerduty.Acknowledgement{{Acknowledger: pagerduty.APIObject{ID: "USER1"}}},
+			expected:        true,
+		},
+		{
+			name:            "returns true with multiple acknowledgements",
+			acknowledgments: []pagerduty.Acknowledgement{{Acknowledger: pagerduty.APIObject{ID: "U1"}}, {Acknowledger: pagerduty.APIObject{ID: "U2"}}},
+			expected:        true,
+		},
+		{
+			name:            "returns false when there are no acknowledgements",
+			acknowledgments: []pagerduty.Acknowledgement{},
+			expected:        false,
+		},
+		{
+			name:            "returns false when acknowledgements is nil",
+			acknowledgments: nil,
+			expected:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := acknowledged(tt.acknowledgments)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestAssignedToUser(t *testing.T) {
+	tests := []struct {
+		name     string
+		incident pagerduty.Incident
+		id       string
+		expected bool
+	}{
+		{
+			name: "returns true when user is assigned",
+			incident: pagerduty.Incident{
+				Assignments: []pagerduty.Assignment{
+					{Assignee: pagerduty.APIObject{ID: "USER1"}},
+				},
+			},
+			id:       "USER1",
+			expected: true,
+		},
+		{
+			name: "returns false when different user is assigned",
+			incident: pagerduty.Incident{
+				Assignments: []pagerduty.Assignment{
+					{Assignee: pagerduty.APIObject{ID: "OTHER_USER"}},
+				},
+			},
+			id:       "USER1",
+			expected: false,
+		},
+		{
+			name:     "returns false when no assignments",
+			incident: pagerduty.Incident{},
+			id:       "USER1",
+			expected: false,
+		},
+		{
+			name: "returns true when user is among multiple assignees",
+			incident: pagerduty.Incident{
+				Assignments: []pagerduty.Assignment{
+					{Assignee: pagerduty.APIObject{ID: "OTHER_USER"}},
+					{Assignee: pagerduty.APIObject{ID: "USER1"}},
+				},
+			},
+			id:       "USER1",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := AssignedToUser(tt.incident, tt.id)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestAcknowledgedByUser(t *testing.T) {
+	tests := []struct {
+		name     string
+		incident pagerduty.Incident
+		id       string
+		expected bool
+	}{
+		{
+			name: "returns true when user has acknowledged",
+			incident: pagerduty.Incident{
+				Acknowledgements: []pagerduty.Acknowledgement{
+					{Acknowledger: pagerduty.APIObject{ID: "USER1"}},
+				},
+			},
+			id:       "USER1",
+			expected: true,
+		},
+		{
+			name: "returns false when different user acknowledged",
+			incident: pagerduty.Incident{
+				Acknowledgements: []pagerduty.Acknowledgement{
+					{Acknowledger: pagerduty.APIObject{ID: "OTHER_USER"}},
+				},
+			},
+			id:       "USER1",
+			expected: false,
+		},
+		{
+			name:     "returns false when no acknowledgements",
+			incident: pagerduty.Incident{},
+			id:       "USER1",
+			expected: false,
+		},
+		{
+			name: "returns true when user is among multiple acknowledgers",
+			incident: pagerduty.Incident{
+				Acknowledgements: []pagerduty.Acknowledgement{
+					{Acknowledger: pagerduty.APIObject{ID: "OTHER_USER"}},
+					{Acknowledger: pagerduty.APIObject{ID: "USER1"}},
+				},
+			},
+			id:       "USER1",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := AcknowledgedByUser(tt.incident, tt.id)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestAssignedToAnyUsers(t *testing.T) {
+	tests := []struct {
+		name     string
+		incident pagerduty.Incident
+		ids      []string
+		expected bool
+	}{
+		{
+			name: "returns true when one of the given users is assigned",
+			incident: pagerduty.Incident{
+				Assignments: []pagerduty.Assignment{
+					{Assignee: pagerduty.APIObject{ID: "USER2"}},
+				},
+			},
+			ids:      []string{"USER1", "USER2", "USER3"},
+			expected: true,
+		},
+		{
+			name: "returns false when none of the given users are assigned",
+			incident: pagerduty.Incident{
+				Assignments: []pagerduty.Assignment{
+					{Assignee: pagerduty.APIObject{ID: "OTHER_USER"}},
+				},
+			},
+			ids:      []string{"USER1", "USER2", "USER3"},
+			expected: false,
+		},
+		{
+			name:     "returns false when no assignments",
+			incident: pagerduty.Incident{},
+			ids:      []string{"USER1", "USER2"},
+			expected: false,
+		},
+		{
+			name: "returns false with empty user list",
+			incident: pagerduty.Incident{
+				Assignments: []pagerduty.Assignment{
+					{Assignee: pagerduty.APIObject{ID: "USER1"}},
+				},
+			},
+			ids:      []string{},
+			expected: false,
+		},
+		{
+			name: "returns false with nil user list",
+			incident: pagerduty.Incident{
+				Assignments: []pagerduty.Assignment{
+					{Assignee: pagerduty.APIObject{ID: "USER1"}},
+				},
+			},
+			ids:      nil,
+			expected: false,
+		},
+		{
+			name: "returns true with multiple assignments and multiple users",
+			incident: pagerduty.Incident{
+				Assignments: []pagerduty.Assignment{
+					{Assignee: pagerduty.APIObject{ID: "OTHER1"}},
+					{Assignee: pagerduty.APIObject{ID: "USER3"}},
+				},
+			},
+			ids:      []string{"USER1", "USER2", "USER3"},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := AssignedToAnyUsers(tt.incident, tt.ids)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestRemoveCommentsFromBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []byte
+		prefixes []string
+		expected string
+	}{
+		{
+			name:     "removes lines starting with single prefix",
+			input:    []byte("# comment\nreal content\n# another comment\nmore content"),
+			prefixes: []string{"#"},
+			expected: "real contentmore content",
+		},
+		{
+			name:     "removes lines with multiple prefixes",
+			input:    []byte("# hash comment\n// slash comment\nreal content\n# another\nkeep this"),
+			prefixes: []string{"#", "//"},
+			expected: "real contentkeep this",
+		},
+		{
+			name:     "does not duplicate non-comment lines with multiple prefixes",
+			input:    []byte("line1\nline2\nline3"),
+			prefixes: []string{"#", "//"},
+			expected: "line1line2line3",
+		},
+		{
+			name:     "returns empty string for all-comment input",
+			input:    []byte("# comment1\n# comment2\n# comment3"),
+			prefixes: []string{"#"},
+			expected: "",
+		},
+		{
+			name:     "returns all content when no lines match any prefix",
+			input:    []byte("hello\nworld"),
+			prefixes: []string{"#"},
+			expected: "helloworld",
+		},
+		{
+			name:     "handles empty input",
+			input:    []byte(""),
+			prefixes: []string{"#"},
+			expected: "",
+		},
+		{
+			name:     "handles no prefixes",
+			input:    []byte("# some text\nmore text"),
+			prefixes: []string{},
+			expected: "# some textmore text",
+		},
+		{
+			name:     "handles mixed comment and non-comment lines with three prefixes",
+			input:    []byte("# hash\n// slash\n; semicolon\nkeep me"),
+			prefixes: []string{"#", "//", ";"},
+			expected: "keep me",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := removeCommentsFromBytes(tt.input, tt.prefixes...)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
 func TestGetSOPLink_HasLink(t *testing.T) {
 	alerts := []pagerduty.IncidentAlert{
 		{


### PR DESCRIPTION
## Summary
- Fix `removeCommentsFromBytes()` nested loop bug that duplicated non-comment lines when multiple prefixes were provided (e.g., 3 prefixes = 3 copies of each line)
- Fix `PostNote()` missing error context wrapping, bringing it in line with every other pd package function
- Add table-driven tests for 6 pure functions: `stateShorthand`, `acknowledged`, `AssignedToUser`, `AcknowledgedByUser`, `AssignedToAnyUsers`, `removeCommentsFromBytes`
- Add `PostNote` error-wrapping test and 4 mock methods (`CreateIncidentNoteWithContext`, `GetCurrentUserWithContext`, `GetEscalationPolicyWithContext`, `GetUserWithContext`)

## Test plan
- [x] All new tests written first (TDD) -- removeCommentsFromBytes multi-prefix tests confirmed failing before fix
- [x] PostNote error-wrapping test confirmed failing before fix
- [x] Both bugs fixed, all tests pass
- [x] `go vet ./...` clean
- [x] `gofmt -s -l cmd pkg` clean
- [x] Full `go test ./... -count=1` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)