### PR TITLE
Add test coverage for pkg/deprecation and pkg/rand

### DIFF
--- a/docs/plans/030-utility-package-tests.md
+++ b/docs/plans/030-utility-package-tests.md
@@ -1,0 +1,49 @@
+# 030 - Utility Package Test Coverage
+
+## Context
+
+The `pkg/deprecation` and `pkg/rand` utility packages both have 0% test
+coverage. These are small, self-contained packages with pure functions that
+are straightforward to test. Adding coverage here improves overall project
+test health and prevents regressions in deprecation key checks and random
+string generation.
+
+Predecessor: [018-bump-cobra-config-tests.md](018-bump-cobra-config-tests.md)
+(similar test-addition pattern).
+
+## Plan
+
+1. Read `pkg/deprecation/deprecation.go` and `pkg/rand/rand.go` to
+   understand the API surface.
+2. Create `pkg/deprecation/deprecation_test.go` with tests for:
+   - Known deprecated keys ("shell", "silentuser") return true
+   - Unknown keys ("token") return false
+   - Empty string returns false
+3. Create `pkg/rand/rand_test.go` with tests for:
+   - `StringWithCharset` produces correct length output
+   - `StringWithCharset` output contains only charset characters
+   - `StringWithCharset` with zero length returns empty string
+   - `String` produces correct length output
+   - `String` output contains only uppercase alphanumeric characters
+   - `ID` output starts with the given prefix
+   - `ID` output has correct total length (prefix + 13)
+4. Run `make test-all` to verify all checks pass.
+5. Run `go vet ./...` and `gofmt -s -l cmd pkg` for additional validation.
+6. Create this plan document.
+7. Commit, push, and open PR against main.
+
+## Files Modified
+
+- `pkg/deprecation/deprecation_test.go` -- new test file (4 tests)
+- `pkg/rand/rand_test.go` -- new test file (7 tests)
+- `docs/plans/030-utility-package-tests.md` -- this plan document
+
+## Verification
+
+- `make test` passes with all 11 new tests green
+- `make fmt-check` clean (no formatting drift)
+- `make vet` clean (no issues)
+- `gofmt -s -l cmd pkg` clean (no output)
+- `golangci-lint run` reports 0 issues on the new files
+- `make lint` skipped due to pre-existing BIN_DIR path mismatch in
+  worktree environment; CI will run this check

--- a/pkg/deprecation/deprecation_test.go
+++ b/pkg/deprecation/deprecation_test.go
@@ -1,0 +1,23 @@
+package deprecation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeprecated_KnownKey_Shell(t *testing.T) {
+	assert.True(t, Deprecated("shell"), "expected 'shell' to be deprecated")
+}
+
+func TestDeprecated_KnownKey_Silentuser(t *testing.T) {
+	assert.True(t, Deprecated("silentuser"), "expected 'silentuser' to be deprecated")
+}
+
+func TestDeprecated_UnknownKey(t *testing.T) {
+	assert.False(t, Deprecated("token"), "expected 'token' to not be deprecated")
+}
+
+func TestDeprecated_EmptyString(t *testing.T) {
+	assert.False(t, Deprecated(""), "expected empty string to not be deprecated")
+}

--- a/pkg/rand/rand_test.go
+++ b/pkg/rand/rand_test.go
@@ -1,0 +1,62 @@
+package rand
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStringWithCharset_CorrectLength(t *testing.T) {
+	lengths := []int{1, 5, 10, 50, 100}
+	for _, length := range lengths {
+		result := StringWithCharset(length, "abc")
+		assert.Equal(t, length, len(result), "expected length %d, got %d", length, len(result))
+	}
+}
+
+func TestStringWithCharset_OnlyCharsetChars(t *testing.T) {
+	customCharset := "XYZ"
+	result := StringWithCharset(100, customCharset)
+	for _, ch := range result {
+		assert.True(t, strings.ContainsRune(customCharset, ch),
+			"character %q is not in charset %q", ch, customCharset)
+	}
+}
+
+func TestStringWithCharset_ZeroLength(t *testing.T) {
+	result := StringWithCharset(0, "abc")
+	assert.Equal(t, "", result, "expected empty string for zero length")
+}
+
+func TestString_CorrectLength(t *testing.T) {
+	lengths := []int{1, 5, 10, 50}
+	for _, length := range lengths {
+		result := String(length)
+		assert.Equal(t, length, len(result), "expected length %d, got %d", length, len(result))
+	}
+}
+
+func TestString_DefaultCharset(t *testing.T) {
+	defaultCharset := "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	result := String(200)
+	for _, ch := range result {
+		assert.True(t, strings.ContainsRune(defaultCharset, ch),
+			"character %q is not in the default charset %q", ch, defaultCharset)
+	}
+}
+
+func TestID_HasPrefix(t *testing.T) {
+	prefix := "TEST-"
+	result := ID(prefix)
+	assert.True(t, strings.HasPrefix(result, prefix),
+		"expected ID %q to start with prefix %q", result, prefix)
+}
+
+func TestID_CorrectTotalLength(t *testing.T) {
+	prefix := "PRE"
+	result := ID(prefix)
+	expectedLength := len(prefix) + 13
+	assert.Equal(t, expectedLength, len(result),
+		"expected total length %d (prefix %d + 13), got %d", expectedLength, len(prefix), len(result))
+}


### PR DESCRIPTION
## Summary

- Add 4 unit tests for `pkg/deprecation` (known deprecated keys, unknown key, empty string edge case)
- Add 7 unit tests for `pkg/rand` (length correctness, charset membership, zero-length edge case, ID prefix and total length)
- Both packages previously had 0% test coverage

## Test plan

- [x] `make test` passes with all 11 new tests green
- [x] `make fmt-check` clean
- [x] `make vet` clean
- [x] `gofmt -s -l cmd pkg` clean
- [x] `golangci-lint run` reports 0 issues on the new files
- [ ] CI passes all checks

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>