### PR TITLE
Add drop counter and reporting to async log writer

### DIFF
--- a/docs/plans/032-async-log-writer.md
+++ b/docs/plans/032-async-log-writer.md
@@ -1,0 +1,63 @@
+# 032 - Async Log Writer Drop Mitigation
+
+## Context
+
+The `asyncWriter` in `main.go` silently drops log messages when its
+internal channel buffer is full (the non-blocking `select`/`default`
+path). Users have no indication that messages are being lost, making
+it harder to diagnose issues in high-volume logging scenarios.
+
+Additionally, the `newAsyncWriter` constructor accepted `*os.File`
+instead of `io.Writer`, which made the component unnecessarily
+coupled to file I/O and impossible to unit test without touching the
+filesystem.
+
+Prior plans consulted: 004 (panic handling), 005 (unsafe type
+assertions) -- both emphasize observable failure modes over silent
+behavior.
+
+## Plan / Solution
+
+1. **Add an atomic drop counter** (`dropped uint64`) to `asyncWriter`
+   using `sync/atomic` for lock-free concurrent access.
+
+2. **Increment the counter** in the `Write` method's `default` case
+   when the buffer is full and a message must be dropped.
+
+3. **Periodic drop reporting**: The background consumer goroutine
+   checks the counter after every successful write. When the
+   cumulative count crosses a multiple of 100, a synthetic
+   `[asyncWriter] dropped N log messages due to full buffer` entry is
+   written to the underlying writer.
+
+4. **Final flush on Close**: If there are unreported drops (count not
+   a clean multiple of 100) when the channel is drained, a final
+   report with the total is written before the goroutine exits.
+
+5. **Increase default buffer** from 1,000 to 5,000 to reduce drop
+   frequency under normal operation.
+
+6. **Refactor `newAsyncWriter` to accept `io.Writer`** instead of
+   `*os.File`, enabling testability with `bytes.Buffer` and custom
+   writers.
+
+7. **Add a `Dropped() uint64` method** for programmatic access to the
+   drop count (used by tests, potentially useful for future TUI
+   status display).
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `main.go` | Refactored `asyncWriter`: added `dropped` counter, `Dropped()` method, periodic/final drop reporting, `io.Writer` parameter, 5000 buffer size |
+| `main_test.go` | New file with 6 test cases covering normal writes, buffer-full drops, close semantics, counter accuracy, final reports, and input-copy safety |
+| `docs/plans/032-async-log-writer.md` | This plan document |
+
+## Verification
+
+- `make test` -- all tests pass including 6 new asyncWriter tests
+- `make vet` -- no issues
+- `make fmt-check` -- no formatting issues
+- `golangci-lint run` -- zero issues
+- Manual review: drop counter uses `sync/atomic` for thread safety,
+  `io.Writer` interface enables dependency injection for tests

--- a/main.go
+++ b/main.go
@@ -22,7 +22,10 @@ THE SOFTWARE.
 package main
 
 import (
+	"fmt"
+	"io"
 	"os"
+	"sync/atomic"
 
 	"github.com/charmbracelet/log"
 	"github.com/clcollins/srepd/cmd"
@@ -43,7 +46,7 @@ func main() {
 	defer f.Close() //nolint:errcheck
 
 	// Use async writer to prevent log I/O from blocking the UI
-	asyncWriter := newAsyncWriter(f, 1000) // Buffer up to 1000 log messages
+	asyncWriter := newAsyncWriter(f, 5000) // Buffer up to 5000 log messages
 	defer asyncWriter.Close() //nolint:errcheck
 
 	log.SetOutput(asyncWriter)
@@ -51,14 +54,23 @@ func main() {
 	cmd.Execute()
 }
 
-// asyncWriter wraps an io.Writer and writes asynchronously via a channel
+// asyncWriter wraps an io.Writer and writes asynchronously via a channel.
+// When the internal buffer is full, messages are dropped and counted.
+// The background goroutine periodically emits a synthetic log entry
+// reporting how many messages were dropped.
 type asyncWriter struct {
-	out    chan []byte
-	done   chan struct{}
-	closed bool
+	out     chan []byte
+	done    chan struct{}
+	closed  bool
+	dropped uint64 // accessed atomically
 }
 
-func newAsyncWriter(w *os.File, bufferSize int) *asyncWriter {
+// dropReportInterval controls how often a synthetic "dropped N messages"
+// entry is written to the underlying writer. A report is emitted every
+// time the cumulative drop count crosses a multiple of this value.
+const dropReportInterval uint64 = 100
+
+func newAsyncWriter(w io.Writer, bufferSize int) *asyncWriter {
 	aw := &asyncWriter{
 		out:  make(chan []byte, bufferSize),
 		done: make(chan struct{}),
@@ -66,9 +78,27 @@ func newAsyncWriter(w *os.File, bufferSize int) *asyncWriter {
 
 	// Start background goroutine to write logs
 	go func() {
+		var lastReported uint64
 		for msg := range aw.out {
 			w.Write(msg) //nolint:errcheck
+
+			// Check for dropped messages and emit a report periodically
+			current := atomic.LoadUint64(&aw.dropped)
+			if current > 0 && current/dropReportInterval > lastReported/dropReportInterval {
+				notice := fmt.Sprintf("[asyncWriter] dropped %d log messages due to full buffer\n", current)
+				w.Write([]byte(notice)) //nolint:errcheck
+				lastReported = current
+			}
 		}
+
+		// Flush any remaining drop count on shutdown that wasn't
+		// covered by the last periodic report
+		finalDropped := atomic.LoadUint64(&aw.dropped)
+		if finalDropped > 0 && finalDropped%dropReportInterval != 0 {
+			notice := fmt.Sprintf("[asyncWriter] dropped %d log messages total (final)\n", finalDropped)
+			w.Write([]byte(notice)) //nolint:errcheck
+		}
+
 		close(aw.done)
 	}()
 
@@ -91,8 +121,14 @@ func (aw *asyncWriter) Write(p []byte) (n int, err error) {
 		return len(p), nil
 	default:
 		// Buffer full - drop message to avoid blocking
+		atomic.AddUint64(&aw.dropped, 1)
 		return len(p), nil
 	}
+}
+
+// Dropped returns the number of messages dropped due to a full buffer.
+func (aw *asyncWriter) Dropped() uint64 {
+	return atomic.LoadUint64(&aw.dropped)
 }
 
 func (aw *asyncWriter) Close() error {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// slowWriter is an io.Writer that blocks for a configurable duration
+// on each Write call, simulating slow I/O to force buffer saturation.
+type slowWriter struct {
+	mu      sync.Mutex
+	buf     bytes.Buffer
+	delay   time.Duration
+	written int
+}
+
+func (sw *slowWriter) Write(p []byte) (int, error) {
+	if sw.delay > 0 {
+		time.Sleep(sw.delay)
+	}
+	sw.mu.Lock()
+	defer sw.mu.Unlock()
+	sw.written++
+	return sw.buf.Write(p)
+}
+
+func (sw *slowWriter) String() string {
+	sw.mu.Lock()
+	defer sw.mu.Unlock()
+	return sw.buf.String()
+}
+
+func TestAsyncWriter_NormalWrite(t *testing.T) {
+	var buf bytes.Buffer
+	aw := newAsyncWriter(&buf, 100)
+
+	messages := []string{
+		"hello world\n",
+		"second message\n",
+		"third message\n",
+	}
+
+	for _, msg := range messages {
+		n, err := aw.Write([]byte(msg))
+		require.NoError(t, err)
+		assert.Equal(t, len(msg), n)
+	}
+
+	err := aw.Close()
+	require.NoError(t, err)
+
+	output := buf.String()
+	for _, msg := range messages {
+		assert.Contains(t, output, msg, "output should contain the written message")
+	}
+
+	assert.Equal(t, uint64(0), aw.Dropped(), "no messages should have been dropped")
+}
+
+func TestAsyncWriter_BufferFull_Drops(t *testing.T) {
+	// Use a slow writer and tiny buffer to force drops
+	sw := &slowWriter{delay: 10 * time.Millisecond}
+	bufferSize := 5
+	aw := newAsyncWriter(sw, bufferSize)
+
+	// Write many more messages than the buffer can hold.
+	// The slow writer ensures the consumer goroutine cannot drain
+	// the buffer fast enough, so the non-blocking send will hit
+	// the default case and increment the dropped counter.
+	totalMessages := 200
+	for i := 0; i < totalMessages; i++ {
+		aw.Write([]byte("msg\n")) //nolint:errcheck
+	}
+
+	err := aw.Close()
+	require.NoError(t, err)
+
+	dropped := aw.Dropped()
+	assert.Greater(t, dropped, uint64(0), "some messages should have been dropped")
+
+	// Verify that the drop report notice was written
+	output := sw.String()
+	assert.Contains(t, output, "[asyncWriter] dropped", "drop notice should appear in output")
+}
+
+func TestAsyncWriter_Close(t *testing.T) {
+	var buf bytes.Buffer
+	aw := newAsyncWriter(&buf, 100)
+
+	// Write one message before close
+	n, err := aw.Write([]byte("before close\n"))
+	require.NoError(t, err)
+	assert.Equal(t, len("before close\n"), n)
+
+	err = aw.Close()
+	require.NoError(t, err)
+
+	// Subsequent writes should return os.ErrClosed
+	n, err = aw.Write([]byte("after close\n"))
+	assert.Equal(t, 0, n)
+	assert.ErrorIs(t, err, os.ErrClosed)
+
+	// Double close should be safe
+	err = aw.Close()
+	assert.NoError(t, err)
+}
+
+func TestAsyncWriter_DroppedCounter(t *testing.T) {
+	// Verify Dropped() returns zero for a fresh writer
+	var buf bytes.Buffer
+	aw := newAsyncWriter(&buf, 100)
+	assert.Equal(t, uint64(0), aw.Dropped())
+	err := aw.Close()
+	require.NoError(t, err)
+}
+
+func TestAsyncWriter_FinalDropReport(t *testing.T) {
+	// Use a slow writer and tiny buffer to force drops, but fewer than
+	// dropReportInterval so the final flush branch is exercised.
+	sw := &slowWriter{delay: 5 * time.Millisecond}
+	bufferSize := 2
+	aw := newAsyncWriter(sw, bufferSize)
+
+	// Send enough to drop some, but aim for fewer than 100 drops
+	// so the final report fires (drops % 100 != 0).
+	for i := 0; i < 50; i++ {
+		aw.Write([]byte("msg\n")) //nolint:errcheck
+	}
+
+	err := aw.Close()
+	require.NoError(t, err)
+
+	dropped := aw.Dropped()
+	if dropped > 0 && dropped%dropReportInterval != 0 {
+		output := sw.String()
+		assert.True(t, strings.Contains(output, "total (final)"),
+			"final drop report should be written when drops are not a multiple of the interval")
+	}
+}
+
+func TestAsyncWriter_CopiesInput(t *testing.T) {
+	// Verify that the writer copies the input buffer so callers
+	// can safely reuse the slice.
+	var buf bytes.Buffer
+	aw := newAsyncWriter(&buf, 100)
+
+	data := []byte("original")
+	_, err := aw.Write(data)
+	require.NoError(t, err)
+
+	// Mutate the original slice after writing
+	copy(data, "modified")
+
+	err = aw.Close()
+	require.NoError(t, err)
+
+	assert.Contains(t, buf.String(), "original",
+		"writer should have used a copy, not the original slice")
+	assert.NotContains(t, buf.String(), "modified",
+		"mutation of input slice should not affect written data")
+}


### PR DESCRIPTION
## Summary

- Adds an atomic drop counter to `asyncWriter` so dropped log messages are tracked instead of silently lost
- Background goroutine emits periodic `[asyncWriter] dropped N log messages` entries every 100 drops and a final count on shutdown
- Increases default buffer size from 1,000 to 5,000 to reduce drop frequency
- Refactors `newAsyncWriter` to accept `io.Writer` instead of `*os.File` for testability
- Adds 6 unit tests covering normal writes, buffer-full drops, close semantics, counter accuracy, final drop reports, and input-copy safety

## Test plan

- [x] `make test` -- all tests pass (6 new asyncWriter tests + existing suite)
- [x] `make vet` -- no issues
- [x] `make fmt-check` -- no formatting issues
- [x] `golangci-lint run` -- zero issues
- [ ] CI passes all checks

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>