### PR TITLE
Fix error popup help message

### DIFF
--- a/docs/plans/031-fix-error-help.md
+++ b/docs/plans/031-fix-error-help.md
@@ -1,0 +1,39 @@
+# Fix error popup help message
+
+> Fixes #17.
+
+## Context
+
+The error view displayed the full `errorViewKeyMap` help text via the
+bubbles help renderer, which produced multi-line keymap output that
+was confusing in context.  Users seeing an error only need to know
+how to dismiss it.
+
+Additionally, dismissing the error with ESC left the app in a stale
+state because no incident list refresh was triggered, so the user had
+to manually refresh to recover.
+
+## Plan
+
+1. Replace the `help.New().View(errorViewKeyMap)` call in the error
+   view rendering with a simple "Press ESC to dismiss" string
+2. In `switchErrorFocusMode`, return an `updateIncidentListMsg`
+   command when the error is dismissed so the app recovers gracefully
+3. Add tests for both behaviors
+
+## Files Modified
+
+- `pkg/tui/views.go` -- replaced help renderer with plain dismiss text
+- `pkg/tui/msgHandlers.go` -- `switchErrorFocusMode` now triggers
+  incident list refresh on error dismiss
+- `pkg/tui/msgHandlers_test.go` -- added `TestErrorView_BackClearsError`
+  and `TestErrorView_BackTriggersRefresh`
+
+## Verification
+
+- `TestErrorView_BackClearsError` confirms ESC clears `m.err`
+- `TestErrorView_BackTriggersRefresh` confirms ESC returns a command
+  that produces an `updateIncidentListMsg`
+- `make fmt-check` passes
+- `make vet` passes
+- `make test` passes (all tests green)

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -587,6 +587,8 @@ func switchErrorFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch {
 		case key.Matches(msg, defaultKeyMap.Back):
 			m.err = nil
+			// Trigger an incident list refresh so the app recovers gracefully
+			return m, func() tea.Msg { return updateIncidentListMsg("sender: switchErrorFocusMode") }
 		}
 	}
 	return m, nil

--- a/pkg/tui/msgHandlers_test.go
+++ b/pkg/tui/msgHandlers_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -260,6 +261,49 @@ func TestTableMode_SilenceKeyWithNoSelectedIncident(t *testing.T) {
 		"Silence key should set pendingConfirmation")
 	assert.Nil(t, cmd,
 		"Silence key should not return a command before confirmation")
+}
+
+// escKeyMsg returns a tea.KeyMsg that matches the Back/ESC key binding.
+func escKeyMsg() tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyEscape}
+}
+
+func TestErrorView_BackClearsError(t *testing.T) {
+	// Scenario: The model has an error set. Pressing ESC should clear the error.
+	m := createTestModel()
+	m.err = fmt.Errorf("test error: something went wrong")
+
+	// Press ESC
+	result, _ := m.Update(escKeyMsg())
+	updatedModel := result.(model)
+
+	assert.Nil(t, updatedModel.err,
+		"ESC should clear the error in error view mode")
+}
+
+func TestErrorView_BackTriggersRefresh(t *testing.T) {
+	// Scenario: The model has an error set. Pressing ESC should clear the error
+	// AND trigger an incident list refresh so the app recovers gracefully.
+	m := createTestModel()
+	m.err = fmt.Errorf("test error: API failure")
+
+	// Press ESC
+	result, cmd := m.Update(escKeyMsg())
+	updatedModel := result.(model)
+
+	assert.Nil(t, updatedModel.err,
+		"ESC should clear the error")
+
+	if !assert.NotNil(t, cmd,
+		"ESC in error mode should return a command to trigger incident list refresh") {
+		t.FailNow()
+	}
+
+	// Execute the command and verify it produces an updateIncidentListMsg
+	msg := cmd()
+	_, ok := msg.(updateIncidentListMsg)
+	assert.True(t, ok,
+		"Command returned from error dismiss should produce an updateIncidentListMsg, got %T", msg)
 }
 
 func TestTableMode_UnAckKeyWithNoSelectedIncident(t *testing.T) {

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -136,9 +136,6 @@ var (
 func (m model) View() string {
 	var s strings.Builder
 
-	// errHelpView := helpStyle.Render(help.New().View(errorViewKeyMap))
-	errHelpView := help.New().View(errorViewKeyMap)
-
 	s.WriteString(m.renderHeader())
 
 	switch {
@@ -150,8 +147,8 @@ func (m model) View() string {
 		s.WriteString(dot)
 		s.WriteString("\n\n")
 		s.WriteString(m.err.Error())
-		s.WriteString("\n")
-		s.WriteString(errHelpView)
+		s.WriteString("\n\n")
+		s.WriteString("Press ESC to dismiss")
 
 		return errorStyle.Render(s.String())
 


### PR DESCRIPTION
## Summary

- Replace full keymap help text in error view with "Press ESC to dismiss"
- Trigger incident list refresh when error is dismissed so the app recovers gracefully
- Add tests for both behaviors (`TestErrorView_BackClearsError`, `TestErrorView_BackTriggersRefresh`)

Fixes #17

## Test plan

- [x] `TestErrorView_BackClearsError` -- ESC clears `m.err`
- [x] `TestErrorView_BackTriggersRefresh` -- ESC returns `updateIncidentListMsg` command
- [x] `make fmt-check` passes
- [x] `make vet` passes
- [x] `make test` passes (all tests green)
- [x] `make plan-check` passes

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>