### PR TITLE
Detect Fedora Toolbox and auto-prefix terminal commands

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -56,7 +56,11 @@ editor: vim
 terminal: gnome-terminal --
 
 # Cluster login command
-cluster-login-command: ocm backplane login %%CLUSTER_ID%%`
+cluster-login-command: ocm backplane login %%CLUSTER_ID%%
+
+# Toolbox mode: auto-detect Fedora Toolbox and prefix terminal commands
+# with flatpak-spawn --host. Values: "auto" (default), "true", "false"
+toolbox_mode: auto`
 )
 
 const description = `The config command is used to create or validate the SREPD config file.
@@ -73,12 +77,14 @@ var (
 		"editor":                "vim",
 		"terminal":              "gnome-terminal --",
 		"cluster_login_command": "ocm backplane login %%CLUSTER_ID%%",
+		"toolbox_mode":          "auto",
 	}
 	optionalKeys = map[string]string{
 		"ignoredusers":          fmt.Sprintf("PagerDuty user IDs to ignore (default: %v)", "None"),
 		"editor":                fmt.Sprintf("Editor to use for notes (default: %v)", defaultOptionalKeys["editor"]),
 		"terminal":              fmt.Sprintf("Terminal to use for exec commands (default: %v)", defaultOptionalKeys["terminal"]),
 		"cluster_login_command": fmt.Sprintf("Cluster login command (default: %v)", defaultOptionalKeys["cluster-login-command"]),
+		"toolbox_mode":          fmt.Sprintf("Toolbox detection mode: auto, true, false (default: %v)", defaultOptionalKeys["toolbox_mode"]),
 	}
 )
 

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -124,4 +124,5 @@ func TestValidateConfig_OptionalKeysGetDefaults(t *testing.T) {
 	assert.Equal(t, "vim", viper.GetString("editor"), "editor should default to 'vim'")
 	assert.Equal(t, "gnome-terminal --", viper.GetString("terminal"), "terminal should default to 'gnome-terminal --'")
 	assert.Equal(t, "ocm backplane login %%CLUSTER_ID%%", viper.GetString("cluster_login_command"), "cluster_login_command should get default value")
+	assert.Equal(t, "auto", viper.GetString("toolbox_mode"), "toolbox_mode should default to 'auto'")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -70,7 +70,7 @@ but rather a simple tool to make on-call tasks easier.`,
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 
-		launcher, err := launcher.NewClusterLauncher(viper.GetString("terminal"), viper.GetString("cluster_login_command"))
+		launcher, err := launcher.NewClusterLauncher(viper.GetString("terminal"), viper.GetString("cluster_login_command"), viper.GetString("toolbox_mode"))
 		if err != nil {
 			fmt.Println(err)
 			log.Fatal(err)

--- a/docs/plans/038-toolbox-detection.md
+++ b/docs/plans/038-toolbox-detection.md
@@ -1,0 +1,88 @@
+# Toolbox container detection
+
+> Fixes #174.
+
+## Context
+
+When srepd runs inside a Fedora Toolbox container, terminal launch
+commands (like `gnome-terminal --`) fail because the terminal emulator
+binary does not exist inside the container. The fix is to detect the
+toolbox environment and automatically prefix commands with
+`flatpak-spawn --host` so they execute on the host system.
+
+## Plan
+
+1. Create `pkg/container/` package with `IsRunningInToolbox()` function
+   that checks three indicators in priority order:
+   - `/run/.toolboxenv` file exists
+   - `TOOLBOX_PATH` environment variable is set
+   - `container` environment variable equals `"toolbox"`
+
+2. Make detection testable by using an internal `checkToolbox()` function
+   that accepts the file path and an env-getter function as parameters,
+   allowing tests to inject mocks without touching real environment state.
+
+3. Modify `pkg/launcher/launcher.go`:
+   - Add `runInToolbox` field to `ClusterLauncher`
+   - Add `toolboxMode` parameter to `NewClusterLauncher()` (values:
+     "auto", "true", "false")
+   - Add `NewClusterLauncherWithToolbox()` for testing with injectable
+     detection function
+   - In `BuildLoginCommand()`, prepend `flatpak-spawn --host` when
+     `runInToolbox` is true
+
+4. Modify `cmd/config.go`:
+   - Add `toolbox_mode` optional config key with default `"auto"`
+   - Add to example config documentation
+
+5. Update `cmd/root.go` call site to pass the new `toolboxMode`
+   parameter
+
+## Lessons Learned
+
+From plan 029 (login-decomposition): keeping launcher logic testable
+with injectable dependencies avoids environment-dependent test flakiness.
+The `checkToolbox()` / `NewClusterLauncherWithToolbox()` pattern follows
+this same principle.
+
+## Files Modified
+
+- `pkg/container/container.go` -- new package: `IsRunningInToolbox()`,
+  `checkToolbox()`
+- `pkg/container/container_test.go` -- 6 tests for detection logic
+- `pkg/launcher/launcher.go` -- `runInToolbox` field,
+  `NewClusterLauncherWithToolbox()`, `resolveToolboxMode()`,
+  `flatpak-spawn --host` prefix in `BuildLoginCommand()`
+- `pkg/launcher/launcher_test.go` -- 10 new tests for toolbox wrapping
+  and mode resolution
+- `cmd/config.go` -- `toolbox_mode` optional key with default `"auto"`
+- `cmd/config_test.go` -- verify `toolbox_mode` defaults
+- `cmd/root.go` -- pass `toolbox_mode` to `NewClusterLauncher()`
+
+## Verification
+
+Container detection tests:
+- `TestIsRunningInToolbox_FileExists` -- temp file simulates
+  `/run/.toolboxenv`
+- `TestIsRunningInToolbox_ToolboxPathEnvVar` -- TOOLBOX_PATH env var
+- `TestIsRunningInToolbox_ContainerEnvVar` -- container=toolbox
+- `TestIsRunningInToolbox_ContainerEnvVarWrongValue` -- container=podman
+- `TestIsRunningInToolbox_NotInToolbox` -- no indicators present
+- `TestIsRunningInToolbox_PriorityOrder` -- file check short-circuits
+
+Launcher toolbox tests:
+- `TestNewClusterLauncher_ToolboxDetection` -- 6 subtests for mode
+  resolution (auto/true/false/empty)
+- `TestBuildLoginCommand_ToolboxWrapping` -- flatpak-spawn prepended
+- `TestBuildLoginCommand_NoWrappingNormal` -- no wrapping without
+  toolbox
+- `TestBuildLoginCommand_ToolboxWrappingWithTmux` -- works with tmux
+
+Config test:
+- `TestValidateConfig_OptionalKeysGetDefaults` -- toolbox_mode defaults
+  to "auto"
+
+CI checks:
+- `make fmt-check` -- passes
+- `make vet` -- passes
+- `make test` -- all tests pass

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -1,0 +1,43 @@
+package container
+
+import (
+	"os"
+
+	"github.com/charmbracelet/log"
+)
+
+const defaultToolboxEnvPath = "/run/.toolboxenv"
+
+// IsRunningInToolbox detects whether the current process is running inside
+// a Fedora Toolbox container. It checks three indicators in priority order:
+//  1. The /run/.toolboxenv file exists
+//  2. The TOOLBOX_PATH environment variable is set
+//  3. The "container" environment variable equals "toolbox"
+func IsRunningInToolbox() bool {
+	return checkToolbox(defaultToolboxEnvPath, os.Getenv)
+}
+
+// checkToolbox is the internal, testable implementation of the toolbox
+// detection logic. It accepts the file path to check and a function for
+// looking up environment variables, allowing tests to inject mocks.
+func checkToolbox(toolboxEnvPath string, getenv func(string) string) bool {
+	// Check 1: /run/.toolboxenv file exists
+	if _, err := os.Stat(toolboxEnvPath); err == nil {
+		log.Debug("container.checkToolbox", "detected", "toolboxenv file exists", "path", toolboxEnvPath)
+		return true
+	}
+
+	// Check 2: TOOLBOX_PATH environment variable is set
+	if getenv("TOOLBOX_PATH") != "" {
+		log.Debug("container.checkToolbox", "detected", "TOOLBOX_PATH env var set")
+		return true
+	}
+
+	// Check 3: container environment variable equals "toolbox"
+	if getenv("container") == "toolbox" {
+		log.Debug("container.checkToolbox", "detected", "container env var equals toolbox")
+		return true
+	}
+
+	return false
+}

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -1,0 +1,94 @@
+package container
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsRunningInToolbox_FileExists(t *testing.T) {
+	// Create a temporary file to simulate /run/.toolboxenv
+	tmpDir := t.TempDir()
+	toolboxEnvFile := filepath.Join(tmpDir, ".toolboxenv")
+	err := os.WriteFile(toolboxEnvFile, []byte(""), 0644)
+	assert.NoError(t, err, "failed to create temp .toolboxenv file")
+
+	// Use the internal function with injected dependencies
+	result := checkToolbox(
+		toolboxEnvFile,
+		func(key string) string { return "" },
+	)
+	assert.True(t, result, "should detect toolbox when .toolboxenv file exists")
+}
+
+func TestIsRunningInToolbox_ToolboxPathEnvVar(t *testing.T) {
+	// No file exists, but TOOLBOX_PATH is set
+	result := checkToolbox(
+		"/nonexistent/path/.toolboxenv",
+		func(key string) string {
+			if key == "TOOLBOX_PATH" {
+				return "/usr/bin/toolbox"
+			}
+			return ""
+		},
+	)
+	assert.True(t, result, "should detect toolbox when TOOLBOX_PATH env var is set")
+}
+
+func TestIsRunningInToolbox_ContainerEnvVar(t *testing.T) {
+	// No file exists, TOOLBOX_PATH is not set, but container=toolbox
+	result := checkToolbox(
+		"/nonexistent/path/.toolboxenv",
+		func(key string) string {
+			if key == "container" {
+				return "toolbox"
+			}
+			return ""
+		},
+	)
+	assert.True(t, result, "should detect toolbox when container env var equals 'toolbox'")
+}
+
+func TestIsRunningInToolbox_ContainerEnvVarWrongValue(t *testing.T) {
+	// No file, no TOOLBOX_PATH, but container is set to something other than "toolbox"
+	result := checkToolbox(
+		"/nonexistent/path/.toolboxenv",
+		func(key string) string {
+			if key == "container" {
+				return "podman"
+			}
+			return ""
+		},
+	)
+	assert.False(t, result, "should not detect toolbox when container env var is not 'toolbox'")
+}
+
+func TestIsRunningInToolbox_NotInToolbox(t *testing.T) {
+	// None of the detection methods match
+	result := checkToolbox(
+		"/nonexistent/path/.toolboxenv",
+		func(key string) string { return "" },
+	)
+	assert.False(t, result, "should not detect toolbox when no indicators are present")
+}
+
+func TestIsRunningInToolbox_PriorityOrder(t *testing.T) {
+	// When file exists, env vars should not matter (file check is first)
+	tmpDir := t.TempDir()
+	toolboxEnvFile := filepath.Join(tmpDir, ".toolboxenv")
+	err := os.WriteFile(toolboxEnvFile, []byte(""), 0644)
+	assert.NoError(t, err)
+
+	envCalled := false
+	result := checkToolbox(
+		toolboxEnvFile,
+		func(key string) string {
+			envCalled = true
+			return ""
+		},
+	)
+	assert.True(t, result, "should detect toolbox from file")
+	assert.False(t, envCalled, "env lookup should not be called when file check succeeds")
+}

--- a/pkg/launcher/launcher.go
+++ b/pkg/launcher/launcher.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/log"
+	"github.com/clcollins/srepd/pkg/container"
 )
 
 const clusterLoginCommandFlag = "cluster_login_command"
@@ -14,6 +15,7 @@ type ClusterLauncher struct {
 	Enabled             bool
 	terminal            []string
 	clusterLoginCommand []string
+	runInToolbox        bool
 	settings            launcherSettings
 }
 
@@ -21,12 +23,31 @@ type launcherSettings struct {
 	// Future Usage Possibly
 }
 
-func NewClusterLauncher(terminal string, clusterLoginCommand string) (ClusterLauncher, error) {
+// NewClusterLauncher creates a new ClusterLauncher with automatic toolbox
+// detection using the default "auto" mode. When running inside a Fedora
+// Toolbox container, terminal commands are automatically prefixed with
+// "flatpak-spawn --host" so they execute on the host system.
+func NewClusterLauncher(terminal string, clusterLoginCommand string, toolboxMode string) (ClusterLauncher, error) {
+	return NewClusterLauncherWithToolbox(terminal, clusterLoginCommand, toolboxMode, container.IsRunningInToolbox)
+}
+
+// NewClusterLauncherWithToolbox creates a new ClusterLauncher with an
+// injectable toolbox detection function, enabling unit testing without
+// relying on actual environment state. The toolboxMode parameter controls
+// behavior: "auto" (or "") uses detectFn, "true" forces toolbox mode on,
+// "false" forces it off.
+func NewClusterLauncherWithToolbox(terminal string, clusterLoginCommand string, toolboxMode string, detectFn func() bool) (ClusterLauncher, error) {
+	inToolbox := resolveToolboxMode(toolboxMode, detectFn)
 
 	launcher := ClusterLauncher{
 		terminal:            strings.Split(terminal, " "),
 		clusterLoginCommand: strings.Split(clusterLoginCommand, " "),
+		runInToolbox:        inToolbox,
 		settings:            launcherSettings{},
+	}
+
+	if inToolbox {
+		log.Info("Toolbox detected: terminal commands will be prefixed with flatpak-spawn --host")
 	}
 
 	err := launcher.validate()
@@ -35,6 +56,22 @@ func NewClusterLauncher(terminal string, clusterLoginCommand string) (ClusterLau
 	}
 
 	return launcher, nil
+}
+
+// resolveToolboxMode determines whether toolbox wrapping should be enabled
+// based on the configuration mode and the detection function result.
+func resolveToolboxMode(mode string, detectFn func() bool) bool {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "true":
+		return true
+	case "false":
+		return false
+	case "auto", "":
+		return detectFn()
+	default:
+		log.Warn("Unknown toolbox_mode value, falling back to auto", "value", mode)
+		return detectFn()
+	}
 }
 
 func (l *ClusterLauncher) validate() error {
@@ -65,8 +102,15 @@ func (l *ClusterLauncher) validate() error {
 }
 
 func (l *ClusterLauncher) BuildLoginCommand(vars map[string]string) []string {
-	///func (l *ClusterLauncher) BuildLoginCommand() []string {
 	command := []string{}
+
+	// When running in a Fedora Toolbox container, prepend flatpak-spawn --host
+	// so the terminal emulator command executes on the host system rather than
+	// inside the container where it does not exist.
+	if l.runInToolbox {
+		log.Debug("launcher.ClusterLauncher(): prepending flatpak-spawn --host for toolbox")
+		command = append(command, "flatpak-spawn", "--host")
+	}
 
 	// Handle the Terminal command
 	// The first arg should not be something replaceable, as checked in the

--- a/pkg/launcher/launcher_test.go
+++ b/pkg/launcher/launcher_test.go
@@ -3,7 +3,119 @@ package launcher
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
+
+func TestNewClusterLauncher_ToolboxDetection(t *testing.T) {
+	tests := []struct {
+		name          string
+		toolboxMode   string
+		detectToolbox bool
+		expectToolbox bool
+	}{
+		{
+			name:          "auto mode with detection true",
+			toolboxMode:   "auto",
+			detectToolbox: true,
+			expectToolbox: true,
+		},
+		{
+			name:          "auto mode with detection false",
+			toolboxMode:   "auto",
+			detectToolbox: false,
+			expectToolbox: false,
+		},
+		{
+			name:          "forced true overrides detection",
+			toolboxMode:   "true",
+			detectToolbox: false,
+			expectToolbox: true,
+		},
+		{
+			name:          "forced false overrides detection",
+			toolboxMode:   "false",
+			detectToolbox: true,
+			expectToolbox: false,
+		},
+		{
+			name:          "empty string defaults to auto with detection true",
+			toolboxMode:   "",
+			detectToolbox: true,
+			expectToolbox: true,
+		},
+		{
+			name:          "empty string defaults to auto with detection false",
+			toolboxMode:   "",
+			detectToolbox: false,
+			expectToolbox: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			launcher, err := NewClusterLauncherWithToolbox(
+				"gnome-terminal --",
+				"ocm backplane login %%CLUSTER_ID%%",
+				test.toolboxMode,
+				func() bool { return test.detectToolbox },
+			)
+			assert.NoError(t, err, "expected no error creating launcher")
+			assert.Equal(t, test.expectToolbox, launcher.runInToolbox, "toolbox mode mismatch")
+		})
+	}
+}
+
+func TestBuildLoginCommand_ToolboxWrapping(t *testing.T) {
+	launcher := ClusterLauncher{
+		terminal:            []string{"gnome-terminal", "--"},
+		clusterLoginCommand: []string{"ocm-container", "-C", "%%CLUSTER_ID%%"},
+		runInToolbox:        true,
+	}
+
+	vars := map[string]string{
+		"%%CLUSTER_ID%%": "test-cluster-123",
+	}
+
+	cmd := launcher.BuildLoginCommand(vars)
+	expected := []string{"flatpak-spawn", "--host", "gnome-terminal", "--", "ocm-container", "-C", "test-cluster-123"}
+
+	assert.Equal(t, expected, cmd, "toolbox wrapping should prepend flatpak-spawn --host to entire command")
+}
+
+func TestBuildLoginCommand_NoWrappingNormal(t *testing.T) {
+	launcher := ClusterLauncher{
+		terminal:            []string{"gnome-terminal", "--"},
+		clusterLoginCommand: []string{"ocm-container", "-C", "%%CLUSTER_ID%%"},
+		runInToolbox:        false,
+	}
+
+	vars := map[string]string{
+		"%%CLUSTER_ID%%": "test-cluster-123",
+	}
+
+	cmd := launcher.BuildLoginCommand(vars)
+	expected := []string{"gnome-terminal", "--", "ocm-container", "-C", "test-cluster-123"}
+
+	assert.Equal(t, expected, cmd, "without toolbox mode, command should not be wrapped")
+}
+
+func TestBuildLoginCommand_ToolboxWrappingWithTmux(t *testing.T) {
+	launcher := ClusterLauncher{
+		terminal:            []string{"tmux", "new-window", "-n", "%%CLUSTER_ID%%"},
+		clusterLoginCommand: []string{"ocm-container", "-C", "%%CLUSTER_ID%%"},
+		runInToolbox:        true,
+	}
+
+	vars := map[string]string{
+		"%%CLUSTER_ID%%": "my-cluster",
+	}
+
+	cmd := launcher.BuildLoginCommand(vars)
+	expected := []string{"flatpak-spawn", "--host", "tmux", "new-window", "-n", "my-cluster", "ocm-container", "-C", "my-cluster"}
+
+	assert.Equal(t, expected, cmd, "toolbox wrapping should work with tmux terminal commands")
+}
 
 func TestClusterLauncherValidation(t *testing.T) {
 	tests := []struct {
@@ -46,7 +158,7 @@ func TestClusterLauncherValidation(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := NewClusterLauncher(test.terminalArg, test.loginCommandArg)
+			_, err := NewClusterLauncher(test.terminalArg, test.loginCommandArg, "auto")
 			if test.expectErr && err == nil {
 				t.Fatalf("Expected error but none fired")
 			}


### PR DESCRIPTION
## Summary

- Adds `pkg/container` package with `IsRunningInToolbox()` that detects Fedora Toolbox via `/run/.toolboxenv` file, `TOOLBOX_PATH` env var, or `container=toolbox` env var
- Modifies `pkg/launcher` to prepend `flatpak-spawn --host` to terminal commands when running inside a toolbox, so terminal emulators execute on the host system
- Adds `toolbox_mode` config key with values "auto" (default), "true", "false" to allow overriding auto-detection

Fixes #174

## Test plan

- [x] 6 unit tests for container detection (file exists, env vars, priority order, negative cases)
- [x] 6 subtests for toolbox mode resolution (auto/true/false/empty string)
- [x] 3 tests for BuildLoginCommand with/without toolbox wrapping (gnome-terminal, tmux)
- [x] 1 config test for toolbox_mode default value
- [x] `make fmt-check` passes
- [x] `make vet` passes
- [x] `make test` passes (all packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)