### PR TITLE
Standardize log messages and fix logging inconsistencies

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -184,7 +184,7 @@ func validateConfig() error {
 	for k := range optionalKeys {
 		_, ok := settings[k]
 		if !ok {
-			log.Warn("missing optional key: " + k + "; using default value " + defaultOptionalKeys[k])
+			log.Warn("cmd.validateConfig()", "msg", "missing optional key", "key", k, "default_value", defaultOptionalKeys[k])
 			viper.Set(k, defaultOptionalKeys[k])
 		}
 	}

--- a/docs/plans/037-logging-cleanup.md
+++ b/docs/plans/037-logging-cleanup.md
@@ -1,0 +1,49 @@
+# Plan 037: Logging Cleanup
+
+## Problem
+
+The codebase had several logging inconsistencies that hurt debuggability:
+
+1. A typo: `defaultIncidentStatues` instead of `defaultIncidentStatuses` in `pkg/pd/pd.go`
+2. Inconsistent error key names (`"err"`, `"tea.errMsg"`) instead of the standard `"error"`
+3. `fmt.Sprintf` used inside `log.Debug()` calls instead of native key-value pairs
+4. `log.Printf` used instead of structured `log.Info` with key-value pairs
+5. `log.Warn` used for actual errors in `login()` (pipe failures, process start failures)
+6. Inconsistent log prefix formats (missing package name, missing parens)
+7. String concatenation in log messages instead of key-value pairs
+
+## Changes
+
+### pkg/pd/pd.go
+- Renamed `defaultIncidentStatues` to `defaultIncidentStatuses` (typo fix)
+
+### pkg/tui/commands.go
+- Fixed all `fmt.Sprintf` inside `log.Debug()` calls to use native key-value format
+- Changed `log.Printf` to `log.Info` with key-value pairs in `silenceIncidents()`
+- Changed `log.Warn` to `log.Error` for actual errors in `login()` (pipe creation, process start, I/O read failures, process exit errors)
+- Standardized prefix format from `"commands.ShouldBeAcknowledged"` to `"tui.ShouldBeAcknowledged()"`
+- Standardized prefix format from `"commands.UserIsOnCall"` to `"tui.UserIsOnCall()"`
+- Fixed misformatted key-value pairs (error messages used as keys)
+- Standardized `silenceIncidents` log prefixes to `"tui.silenceIncidents()"`
+
+### pkg/tui/msgHandlers.go
+- Changed `"tea.errMsg"` key to `"error"` in `errMsgHandler`
+- Updated prefix to `"tui.errMsgHandler()"`
+
+### pkg/tui/model.go
+- Fixed misformatted key-value pair in `InitialModel` markdown renderer error log
+
+### pkg/launcher/launcher.go
+- Standardized prefix from `"launcher.ClusterLauncher()"` to `"launcher.BuildLoginCommand()"`
+- Fixed `fmt.Sprintf` used as key format in argument logging
+- Fixed `"ClusterLauncher():"` prefix in `replaceVars` to `"launcher.replaceVars()"`
+- Standardized key names in replaceVars logging
+
+### cmd/config.go
+- Replaced string concatenation in `log.Warn` with key-value pairs
+
+## Validation
+
+- `make fmt-check` -- passes (no formatting issues)
+- `make vet` -- passes (no vet warnings)
+- `make test` -- all tests pass (no regressions)

--- a/pkg/launcher/launcher.go
+++ b/pkg/launcher/launcher.go
@@ -71,7 +71,7 @@ func (l *ClusterLauncher) BuildLoginCommand(vars map[string]string) []string {
 	// Handle the Terminal command
 	// The first arg should not be something replaceable, as checked in the
 	// validate function
-	log.Debug("launcher.ClusterLauncher(): building command from terminal", "terminal", l.terminal[0])
+	log.Debug("launcher.BuildLoginCommand()", "terminal", l.terminal[0])
 	command = append(command, l.terminal[0])
 
 	// If there are more than one terminal arguments, replace the vars
@@ -81,9 +81,9 @@ func (l *ClusterLauncher) BuildLoginCommand(vars map[string]string) []string {
 		command = append(command, replaceVars(l.terminal[1:], vars)...)
 	}
 	command = append(command, replaceVars(l.clusterLoginCommand, vars)...)
-	log.Debug("launcher.ClusterLauncher(): built command", "command", command)
+	log.Debug("launcher.BuildLoginCommand()", "command", command)
 	for x, i := range command {
-		log.Debug("launcher.ClusterLauncher(): build command argument", fmt.Sprintf("[%d]", x), i)
+		log.Debug("launcher.BuildLoginCommand()", "index", x, "arg", i)
 	}
 
 	return command
@@ -97,11 +97,11 @@ func replaceVars(args []string, vars map[string]string) []string {
 	str := strings.Join(args, " ")
 
 	for k, v := range vars {
-		log.Debug("ClusterLauncher():", "Replacing vars in string", str, k, v)
+		log.Debug("launcher.replaceVars()", "string", str, "key", k, "value", v)
 		str = strings.ReplaceAll(str, k, v)
 	}
 
-	log.Debug("launcher.replaceVars(): Replaced vars in string", "string", str)
+	log.Debug("launcher.replaceVars()", "result", str)
 
 	transformedArgs := strings.Split(str, " ")
 	return transformedArgs

--- a/pkg/pd/pd.go
+++ b/pkg/pd/pd.go
@@ -16,7 +16,7 @@ const (
 	defaultAPITimeout = 30 * time.Second
 )
 
-var defaultIncidentStatues = []string{"triggered", "acknowledged"}
+var defaultIncidentStatuses = []string{"triggered", "acknowledged"}
 
 // contextWithTimeout returns a context with the default API timeout and its cancel func.
 func contextWithTimeout() (context.Context, context.CancelFunc) {
@@ -121,7 +121,7 @@ func NewListIncidentOptsFromDefaults() pagerduty.ListIncidentsOptions {
 	return pagerduty.ListIncidentsOptions{
 		Limit:    defaultPageLimit,
 		Offset:   defaultOffset,
-		Statuses: defaultIncidentStatues,
+		Statuses: defaultIncidentStatuses,
 	}
 
 }

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -246,7 +246,7 @@ func ShouldBeAcknowledged(p *pd.Config, i pagerduty.Incident, id string, autoAck
 	userIsOnCall := UserIsOnCall(p, id)
 	doIt := assigned && !acknowledged && autoAcknowledge && userIsOnCall
 	log.Debug(
-		"commands.ShouldBeAcknowledged",
+		"tui.ShouldBeAcknowledged()",
 		"assigned", assigned,
 		"acknowledged", acknowledged,
 		"autoAcknowledge", autoAcknowledge,
@@ -293,21 +293,21 @@ func UserIsOnCall(p *pd.Config, id string) bool {
 
 	onCalls, err := pd.GetUserOnCalls(p.Client, id, opts)
 	if err != nil {
-		log.Debug("commands.UserIsOnCall", "error", err)
+		log.Debug("tui.UserIsOnCall()", "error", err)
 		return false
 	}
 
 	for _, o := range onCalls {
-		log.Debug("commands.UserIsOnCall", "on-call", o)
+		log.Debug("tui.UserIsOnCall()", "on-call", o)
 
 		start, err := time.Parse(timeLayout, o.Start)
 		if err != nil {
-			log.Debug("commands.UserIsOnCall", "error parsing on-call start time", err)
+			log.Debug("tui.UserIsOnCall()", "msg", "error parsing on-call start time", "error", err)
 			return false
 		}
 		end, err := time.Parse(timeLayout, o.End)
 		if err != nil {
-			log.Debug("commands.UserIsOnCall", "error parsing on-call end time", err)
+			log.Debug("tui.UserIsOnCall()", "msg", "error parsing on-call end time", "error", err)
 			return false
 		}
 
@@ -329,19 +329,18 @@ type openBrowserMsg string
 type openSOPMsg string
 
 func openBrowserCmd(browser []string, url string) tea.Cmd {
-	log.Debug("tui.openBrowserCmd(): opening browser")
-	log.Debug(fmt.Sprintf("tui.openBrowserCmd(): %v %v", browser, url))
+	log.Debug("tui.openBrowserCmd()", "msg", "opening browser", "browser", browser, "url", url)
 
 	var args []string
 	args = append(args, browser[1:]...)
 	args = append(args, url)
 
 	c := exec.Command(browser[0], args...)
-	log.Debug(fmt.Sprintf("tui.openBrowserCmd(): %v", c.String()))
+	log.Debug("tui.openBrowserCmd()", "command", c.String())
 
 	err := c.Start()
 	if err != nil {
-		log.Debug(fmt.Sprintf("tui.openBrowserCmd(): %v", err.Error()))
+		log.Debug("tui.openBrowserCmd()", "error", err)
 		return func() tea.Msg {
 			return browserFinishedMsg{err}
 		}
@@ -366,7 +365,7 @@ func openEditorCmd(editor []string, initialMsg ...string) tea.Cmd {
 
 	file, err := os.CreateTemp(os.TempDir(), "")
 	if err != nil {
-		log.Debug(fmt.Sprintf("tui.openEditorCmd(): error: %v", err))
+		log.Debug("tui.openEditorCmd()", "error", err)
 		return func() tea.Msg {
 			return errMsg{error: err}
 		}
@@ -376,7 +375,7 @@ func openEditorCmd(editor []string, initialMsg ...string) tea.Cmd {
 		for _, msg := range initialMsg {
 			_, err = file.WriteString(msg)
 			if err != nil {
-				log.Debug(fmt.Sprintf("tui.openEditorCmd(): error: %v", err))
+				log.Debug("tui.openEditorCmd()", "error", err)
 				return func() tea.Msg {
 					return errMsg{error: err}
 				}
@@ -389,10 +388,10 @@ func openEditorCmd(editor []string, initialMsg ...string) tea.Cmd {
 
 	c := exec.Command(editor[0], args...)
 
-	log.Debug(fmt.Sprintf("%+v", c))
+	log.Debug("tui.openEditorCmd()", "command", c)
 	return tea.ExecProcess(c, func(err error) tea.Msg {
 		if err != nil {
-			log.Debug(fmt.Sprintf("tui.openEditorCmd(): error: %v", err))
+			log.Debug("tui.openEditorCmd()", "error", err)
 			return errMsg{error: err}
 		}
 		return editorFinishedMsg{err, file}
@@ -518,7 +517,7 @@ func login(vars map[string]string, launcher launcher.ClusterLauncher, incident *
 		}
 	} else {
 		// No separator found or no env flags, use command as-is
-		log.Debug("tui.login(): using command as-is", "reason", fmt.Sprintf("insertPosition=%d, envFlagsLen=%d", insertPosition, len(envFlags)))
+		log.Debug("tui.login(): using command as-is", "insertPosition", insertPosition, "envFlagsLen", len(envFlags))
 		finalCommand = command
 	}
 
@@ -527,13 +526,13 @@ func login(vars map[string]string, launcher launcher.ClusterLauncher, incident *
 	log.Debug("tui.login(): original command", "command", command)
 	log.Debug("tui.login(): env flags", "envFlags", envFlags)
 	log.Debug("tui.login(): final command", "finalCommand", finalCommand)
-	log.Debug(fmt.Sprintf("tui.login(): %v", c.String()))
+	log.Debug("tui.login()", "command", c.String())
 
 	var stdOut io.ReadCloser
 	var stdOutPipeErr error
 	stdOut, stdOutPipeErr = c.StdoutPipe()
 	if stdOutPipeErr != nil {
-		log.Warn("tui.login():", "stdOutPipeErr", stdOutPipeErr.Error())
+		log.Error("tui.login()", "error", stdOutPipeErr)
 		return func() tea.Msg {
 			return loginFinishedMsg{stdOutPipeErr}
 		}
@@ -543,7 +542,7 @@ func login(vars map[string]string, launcher launcher.ClusterLauncher, incident *
 	var stdErrPipeErr error
 	stdErr, stdErrPipeErr = c.StderrPipe()
 	if stdErrPipeErr != nil {
-		log.Warn("tui.login():", "stdErrErr", stdErrPipeErr.Error())
+		log.Error("tui.login()", "error", stdErrPipeErr)
 		return func() tea.Msg {
 			return loginFinishedMsg{stdErrPipeErr}
 		}
@@ -551,7 +550,7 @@ func login(vars map[string]string, launcher launcher.ClusterLauncher, incident *
 
 	startCmdErr := c.Start()
 	if startCmdErr != nil {
-		log.Warn("tui.login():", "startCmdErr", startCmdErr.Error())
+		log.Error("tui.login()", "error", startCmdErr)
 		return func() tea.Msg {
 			return loginFinishedMsg{startCmdErr}
 		}
@@ -561,7 +560,7 @@ func login(vars map[string]string, launcher launcher.ClusterLauncher, incident *
 	var stdOutReadErr error
 	out, stdOutReadErr = io.ReadAll(stdOut)
 	if stdOutReadErr != nil {
-		log.Warn("tui.login():", "stdOutReadErr", stdOutReadErr.Error())
+		log.Error("tui.login()", "error", stdOutReadErr)
 		return func() tea.Msg {
 			return loginFinishedMsg{stdOutReadErr}
 		}
@@ -571,7 +570,7 @@ func login(vars map[string]string, launcher launcher.ClusterLauncher, incident *
 	var stdErrReadErr error
 	errOut, stdErrReadErr = io.ReadAll(stdErr)
 	if stdErrReadErr != nil {
-		log.Warn("tui.login():", "stdErrReadErr", stdErrReadErr.Error())
+		log.Error("tui.login()", "error", stdErrReadErr)
 		return func() tea.Msg {
 			return loginFinishedMsg{stdErrReadErr}
 		}
@@ -591,19 +590,19 @@ func login(vars map[string]string, launcher launcher.ClusterLauncher, incident *
 				ExitErr:    exitError,
 				ExecStdErr: string(errOut),
 			}
-			log.Warn("tui.login():", "processErr", execExitErr)
+			log.Error("tui.login()", "error", execExitErr)
 			return func() tea.Msg {
 				return loginFinishedMsg{execExitErr}
 			}
 		}
-		log.Warn("tui.login():", "processErr", processErr.Error())
+		log.Error("tui.login()", "error", processErr)
 		return func() tea.Msg {
 			return loginFinishedMsg{processErr}
 		}
 	}
 
 	if err != nil {
-		log.Warn("tui.login():", "execStdErr", err.Error())
+		log.Warn("tui.login()", "execStdErr", err.Error())
 		return func() tea.Msg {
 			// Do not return the execStdErr as an error
 			return loginFinishedMsg{}
@@ -613,7 +612,7 @@ func login(vars map[string]string, launcher launcher.ClusterLauncher, incident *
 	var stdOutAsErr error
 	if len(out) > 0 {
 		stdOutAsErr = errors.New(string(out))
-		log.Warn("tui.login():", "stdOutAsErr", stdOutAsErr.Error())
+		log.Warn("tui.login()", "stdOutAsErr", stdOutAsErr.Error())
 		return func() tea.Msg {
 			return loginFinishedMsg{stdOutAsErr}
 		}
@@ -687,7 +686,7 @@ func fetchEscalationPolicyAndReEscalate(p *pd.Config, incidents []pagerduty.Inci
 		// Fetch the full escalation policy details
 		policy, err := pd.GetEscalationPolicy(p.Client, policyID, pagerduty.GetEscalationPolicyOptions{})
 		if err != nil {
-			log.Error("tui.fetchEscalationPolicyAndReEscalate", "failed to fetch escalation policy", "policy_id", policyID, "error", err)
+			log.Error("tui.fetchEscalationPolicyAndReEscalate()", "msg", "failed to fetch escalation policy", "policy_id", policyID, "error", err)
 			return errMsg{err}
 		}
 
@@ -710,21 +709,21 @@ var errSilenceIncidentInvalidArgs = errors.New("silenceIncidents: invalid argume
 func silenceIncidents(incidents []pagerduty.Incident, policy *pagerduty.EscalationPolicy, level uint) tea.Cmd {
 	// SilenceIncidents doesn't have it's own "silencedIncidentsMessage" because it's really just a re-escalation
 	if policy == nil {
-		log.Debug("silenceIncidents: nil escalation policy provided")
+		log.Debug("tui.silenceIncidents()", "msg", "nil escalation policy provided")
 		return func() tea.Msg {
 			return errMsg{errSilenceIncidentInvalidArgs}
 		}
 	}
 
 	if len(incidents) == 0 {
-		log.Debug("silenceIncidents: no incidents provided")
+		log.Debug("tui.silenceIncidents()", "msg", "no incidents provided")
 		return func() tea.Msg {
 			return errMsg{errSilenceIncidentInvalidArgs}
 		}
 	}
 
 	if policy.Name == "" || policy.ID == "" || level == 0 {
-		log.Debug("silenceIncidents: invalid arguments", "incident(s) count: %d; policy: %s(%s), level: %d", len(incidents), policy.Name, policy.ID, level)
+		log.Debug("tui.silenceIncidents()", "msg", "invalid arguments", "incident_count", len(incidents), "policy_name", policy.Name, "policy_id", policy.ID, "level", level)
 		return func() tea.Msg {
 			return errMsg{errSilenceIncidentInvalidArgs}
 		}
@@ -732,7 +731,7 @@ func silenceIncidents(incidents []pagerduty.Incident, policy *pagerduty.Escalati
 
 	incidentIDs := getIDsFromIncidents(incidents)
 
-	log.Printf("silence requested for incident(s) %v; reassigning to %s(%s), level %d", incidentIDs, policy.Name, policy.ID, level)
+	log.Info("tui.silenceIncidents()", "msg", "silence requested", "incidents", incidentIDs, "policy_name", policy.Name, "policy_id", policy.ID, "level", level)
 
 	return func() tea.Msg {
 		return reEscalateIncidentsMsg{incidents, policy, level}

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -125,7 +125,7 @@ func InitialModel(
 		glamour.WithWordWrap(100), // Default width, will be adjusted on window resize
 	)
 	if err != nil {
-		log.Error("InitialModel", "failed to create markdown renderer", err)
+		log.Error("tui.InitialModel()", "msg", "failed to create markdown renderer", "error", err)
 		// Continue without renderer - rendering will fall back to plain text
 		renderer = nil
 	}

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -20,7 +20,7 @@ func (m model) setStatusMsgHandler(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 // errMsgHandler is the message handler for the errMsg message
 func (m model) errMsgHandler(msg tea.Msg) (tea.Model, tea.Cmd) {
-	log.Error("errMsgHandler", "tea.errMsg", msg)
+	log.Error("tui.errMsgHandler()", "error", msg)
 	m.setStatus(msg.(errMsg).Error())
 	m.err = msg.(errMsg)
 	return m, nil

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -551,7 +551,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		if len(m.selectedIncidentAlerts) == 0 {
-			log.Debug("Update", reflect.TypeOf(msg), fmt.Sprintf("no alerts found for incident %s - requeuing", m.selectedIncident.ID))
+			log.Debug("tui.Update()", "msg_type", reflect.TypeOf(msg), "msg", "no alerts found for incident - requeuing", "incident", m.selectedIncident.ID)
 			return m, func() tea.Msg { return loginMsg("sender: loginMsg; requeue") }
 		}
 


### PR DESCRIPTION
## Summary
- Fix typo `defaultIncidentStatues` -> `defaultIncidentStatuses` in `pkg/pd/pd.go`
- Standardize all error log keys to `"error"` (was `"err"`, `"tea.errMsg"`, or error messages used as keys)
- Replace `fmt.Sprintf()` inside log calls with native charmbracelet/log key-value pairs
- Replace `log.Printf` with `log.Info` using structured key-value format
- Promote `log.Warn` to `log.Error` for actual errors in `login()` (pipe creation, process start, I/O read, process exit failures)
- Standardize log prefixes to `"package.FunctionName()"` format (e.g., `"commands.UserIsOnCall"` -> `"tui.UserIsOnCall()"`)
- Replace string concatenation in `cmd/config.go` log call with proper key-value pairs
- Fix misformatted key-value pairs in `silenceIncidents()` and `fetchEscalationPolicyAndReEscalate()` where descriptive messages were used as keys, misaligning subsequent key-value pairs

## Test plan
- [x] `make fmt-check` passes (no formatting issues)
- [x] `make vet` passes (no vet warnings)
- [x] `make test` passes (all unit tests green, no regressions)
- [ ] Manual smoke test: run srepd with debug logging and verify log output is structured correctly

Created with assistance from Claude 🤖 <claude@anthropic.com>

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>