### PR TITLE
Replace ALERT_DETAILS blob with individual PAGERDUTY_* env vars

### DIFF
--- a/docs/plans/039-individual-env-vars.md
+++ b/docs/plans/039-individual-env-vars.md
@@ -1,0 +1,95 @@
+# Plan 039: Replace ALERT_DETAILS blob with individual PAGERDUTY_* env vars
+
+## Problem
+
+When srepd launches ocm-container for a cluster login, it serializes the full
+incident, all alerts, and all notes into a JSON blob, base64-encodes it, and
+passes it as a single `-e ALERT_DETAILS=<huge_blob>` argument. With 25+ alerts
+this can exceed the operating system's ARG_MAX limit, causing the login command
+to fail silently or with a cryptic error.
+
+Additionally, the base64 blob is opaque -- users inside ocm-container cannot
+easily inspect the PagerDuty context without decoding and parsing JSON.
+
+## Solution
+
+Replace the monolithic base64-encoded `ALERT_DETAILS` env var with individual
+small `PAGERDUTY_*` environment variables, each containing a simple string
+value. Filter alerts to only those matching the selected cluster, so the
+env var payload is proportional to one cluster's alerts rather than the entire
+incident's alert set.
+
+### New Environment Variables
+
+| Variable | Source |
+|----------|--------|
+| `PAGERDUTY_INCIDENT_ID` | `incident.ID` |
+| `PAGERDUTY_INCIDENT_TITLE` | `incident.Title` |
+| `PAGERDUTY_INCIDENT_URL` | `incident.HTMLURL` |
+| `PAGERDUTY_INCIDENT_SERVICE` | `incident.Service.Summary` |
+| `PAGERDUTY_INCIDENT_URGENCY` | `incident.Urgency` |
+| `PAGERDUTY_INCIDENT_STATUS` | `incident.Status` |
+| `PAGERDUTY_CLUSTER_ID` | selected cluster ID |
+| `PAGERDUTY_ALERT_COUNT` | count of alerts matching this cluster |
+| `PAGERDUTY_ALERT_NAMES` | comma-separated alert names for this cluster |
+| `PAGERDUTY_ALERT_LINKS` | comma-separated SOP links for this cluster |
+| `PAGERDUTY_NOTES_EXIST` | "true" or "false" |
+| `PAGERDUTY_NOTE_COUNT` | number of notes |
+
+### Key Design Decisions
+
+1. **Pure function**: `buildPagerDutyEnvVars()` is a pure function with no
+   side effects, making it straightforward to unit test.
+
+2. **Cluster filtering**: Only alerts whose `cluster_id` matches the selected
+   cluster contribute to `ALERT_NAMES` and `ALERT_LINKS`. This keeps the
+   payload small and relevant.
+
+3. **SOP link extraction**: Uses the same `sopLinkFields` priority order as
+   `getSOPLink()` -- checks "link" first, then "runbook_url".
+
+4. **Renamed PAGERDUTY_INCIDENT**: The old `PAGERDUTY_INCIDENT` env var is
+   renamed to `PAGERDUTY_INCIDENT_ID` for naming consistency.
+
+## Changes
+
+### Modified Files
+
+- `pkg/tui/commands.go`:
+  - Removed `alertData` struct
+  - Removed base64/JSON serialization block from `login()`
+  - Removed `encoding/base64` and `encoding/json` imports
+  - Added `strconv` import
+  - Added `buildPagerDutyEnvVars()` pure function
+  - Updated `login()` to call `buildPagerDutyEnvVars()` with cluster ID from vars map
+  - Renamed `PAGERDUTY_INCIDENT` to `PAGERDUTY_INCIDENT_ID`
+
+- `pkg/tui/commands_test.go`:
+  - Removed `TestLoginEnvironmentVariables` (tested old alertData serialization)
+  - Removed `encoding/base64` and `encoding/json` imports
+  - Added `strings` import
+  - Added `envVarMap()` test helper
+  - Added `TestBuildPagerDutyEnvVars_FullIncident`
+  - Added `TestBuildPagerDutyEnvVars_FiltersByCluster`
+  - Added `TestBuildPagerDutyEnvVars_NilIncident`
+  - Added `TestBuildPagerDutyEnvVars_NoMatchingAlerts`
+  - Added `TestBuildPagerDutyEnvVars_NotesExist`
+  - Added `TestBuildPagerDutyEnvVars_NoNotes`
+  - Added `TestBuildPagerDutyEnvVars_ManyAlerts`
+  - Updated `TestLoginCommandStructureWithEnvVars` to use `PAGERDUTY_INCIDENT_ID`
+
+## Testing
+
+- All 7 new `TestBuildPagerDutyEnvVars_*` tests cover the full matrix:
+  full data, cluster filtering, nil incident, no matching alerts, notes
+  present/absent, and 50-alert stress test.
+- Existing tests continue to pass unchanged.
+- `make test-all` (fmt-check, vet, lint, test) passes cleanly.
+
+## Risks
+
+- **Breaking change for ocm-container consumers**: Any scripts inside
+  ocm-container that parse `$ALERT_DETAILS` will need updating to use the
+  new individual `$PAGERDUTY_*` variables instead.
+- **Renamed variable**: `PAGERDUTY_INCIDENT` is now `PAGERDUTY_INCIDENT_ID`.
+  Consumers referencing the old name need updating.

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -426,17 +426,34 @@ type loginFinishedMsg struct {
 // Only alerts whose cluster_id matches clusterID contribute to ALERT_NAMES and
 // ALERT_LINKS. This replaces the previous approach of base64-encoding a JSON blob,
 // which could exceed ARG_MAX with many alerts.
+// sanitizeEnvValue removes or escapes characters that could cause issues
+// in environment variable values passed via -e flags to terminals or containers.
+func sanitizeEnvValue(s string) string {
+	r := strings.NewReplacer(
+		"\n", " ",
+		"\r", "",
+		"\t", " ",
+		"'", "",
+		"\"", "",
+		"`", "",
+		"$", "",
+		"\\", "",
+	)
+	return r.Replace(s)
+}
+
 func buildPagerDutyEnvVars(incident *pagerduty.Incident, alerts []pagerduty.IncidentAlert, notes []pagerduty.IncidentNote, clusterID string) []string {
 	var envFlags []string
 
 	// Incident-level variables
 	if incident != nil {
 		envFlags = append(envFlags, "-e", fmt.Sprintf("PAGERDUTY_INCIDENT_ID=%s", incident.ID))
-		envFlags = append(envFlags, "-e", fmt.Sprintf("PAGERDUTY_INCIDENT_TITLE=%s", incident.Title))
+		envFlags = append(envFlags, "-e", fmt.Sprintf("PAGERDUTY_INCIDENT_TITLE=%s", sanitizeEnvValue(incident.Title)))
 		envFlags = append(envFlags, "-e", fmt.Sprintf("PAGERDUTY_INCIDENT_URL=%s", incident.HTMLURL))
-		envFlags = append(envFlags, "-e", fmt.Sprintf("PAGERDUTY_INCIDENT_SERVICE=%s", incident.Service.Summary))
+		envFlags = append(envFlags, "-e", fmt.Sprintf("PAGERDUTY_INCIDENT_SERVICE=%s", sanitizeEnvValue(incident.Service.Summary)))
 		envFlags = append(envFlags, "-e", fmt.Sprintf("PAGERDUTY_INCIDENT_URGENCY=%s", incident.Urgency))
 		envFlags = append(envFlags, "-e", fmt.Sprintf("PAGERDUTY_INCIDENT_STATUS=%s", incident.Status))
+		envFlags = append(envFlags, "-e", fmt.Sprintf("REASON=%s", incident.HTMLURL))
 	}
 
 	// Cluster ID
@@ -455,7 +472,7 @@ func buildPagerDutyEnvVars(incident *pagerduty.Incident, alerts []pagerduty.Inci
 
 		name := getDetailFieldFromAlert("alert_name", alert)
 		if name != "" {
-			matchingNames = append(matchingNames, name)
+			matchingNames = append(matchingNames, sanitizeEnvValue(name))
 		}
 
 		// Check both SOP link fields in priority order, same as getSOPLink

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -2,14 +2,13 @@ package tui
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -422,11 +421,63 @@ type loginFinishedMsg struct {
 	err error
 }
 
-// alertData contains the data we want to pass to ocm-container about alerts
-type alertData struct {
-	Incident *pagerduty.Incident       `json:"incident"`
-	Alerts   []pagerduty.IncidentAlert `json:"alerts"`
-	Notes    []pagerduty.IncidentNote  `json:"notes"`
+// buildPagerDutyEnvVars constructs a slice of "-e", "KEY=VALUE" pairs for passing
+// PagerDuty incident context to ocm-container as individual environment variables.
+// Only alerts whose cluster_id matches clusterID contribute to ALERT_NAMES and
+// ALERT_LINKS. This replaces the previous approach of base64-encoding a JSON blob,
+// which could exceed ARG_MAX with many alerts.
+func buildPagerDutyEnvVars(incident *pagerduty.Incident, alerts []pagerduty.IncidentAlert, notes []pagerduty.IncidentNote, clusterID string) []string {
+	var envFlags []string
+
+	// Incident-level variables
+	if incident != nil {
+		envFlags = append(envFlags, "-e", fmt.Sprintf("PAGERDUTY_INCIDENT_ID=%s", incident.ID))
+		envFlags = append(envFlags, "-e", fmt.Sprintf("PAGERDUTY_INCIDENT_TITLE=%s", incident.Title))
+		envFlags = append(envFlags, "-e", fmt.Sprintf("PAGERDUTY_INCIDENT_URL=%s", incident.HTMLURL))
+		envFlags = append(envFlags, "-e", fmt.Sprintf("PAGERDUTY_INCIDENT_SERVICE=%s", incident.Service.Summary))
+		envFlags = append(envFlags, "-e", fmt.Sprintf("PAGERDUTY_INCIDENT_URGENCY=%s", incident.Urgency))
+		envFlags = append(envFlags, "-e", fmt.Sprintf("PAGERDUTY_INCIDENT_STATUS=%s", incident.Status))
+	}
+
+	// Cluster ID
+	if clusterID != "" {
+		envFlags = append(envFlags, "-e", fmt.Sprintf("PAGERDUTY_CLUSTER_ID=%s", clusterID))
+	}
+
+	// Filter alerts to those matching the selected cluster and collect names/links
+	var matchingNames []string
+	var matchingLinks []string
+	for _, alert := range alerts {
+		alertCluster := getDetailFieldFromAlert("cluster_id", alert)
+		if clusterID != "" && alertCluster != clusterID {
+			continue
+		}
+
+		name := getDetailFieldFromAlert("alert_name", alert)
+		if name != "" {
+			matchingNames = append(matchingNames, name)
+		}
+
+		// Check both SOP link fields in priority order, same as getSOPLink
+		for _, field := range sopLinkFields {
+			link := getDetailFieldFromAlert(field, alert)
+			if link != "" {
+				matchingLinks = append(matchingLinks, link)
+				break
+			}
+		}
+	}
+
+	envFlags = append(envFlags, "-e", fmt.Sprintf("PAGERDUTY_ALERT_COUNT=%s", strconv.Itoa(len(matchingNames))))
+	envFlags = append(envFlags, "-e", fmt.Sprintf("PAGERDUTY_ALERT_NAMES=%s", strings.Join(matchingNames, ",")))
+	envFlags = append(envFlags, "-e", fmt.Sprintf("PAGERDUTY_ALERT_LINKS=%s", strings.Join(matchingLinks, ",")))
+
+	// Notes metadata
+	notesExist := len(notes) > 0
+	envFlags = append(envFlags, "-e", fmt.Sprintf("PAGERDUTY_NOTES_EXIST=%s", strconv.FormatBool(notesExist)))
+	envFlags = append(envFlags, "-e", fmt.Sprintf("PAGERDUTY_NOTE_COUNT=%s", strconv.Itoa(len(notes))))
+
+	return envFlags
 }
 
 func login(vars map[string]string, launcher launcher.ClusterLauncher, incident *pagerduty.Incident, alerts []pagerduty.IncidentAlert, notes []pagerduty.IncidentNote) tea.Cmd {
@@ -434,33 +485,9 @@ func login(vars map[string]string, launcher launcher.ClusterLauncher, incident *
 	// This handles if folks use, eg: flatpak run <some package> as a terminal.
 	command := launcher.BuildLoginCommand(vars)
 
-	// Add environment variables for PagerDuty data
-	// Find the position to insert the -e flags (before any -- separator)
-	envFlags := []string{}
-
-	// Add PAGERDUTY_INCIDENT environment variable
-	if incident != nil {
-		envFlags = append(envFlags, "-e", fmt.Sprintf("PAGERDUTY_INCIDENT=%s", incident.ID))
-	}
-
-	// Serialize and base64 encode alert details
-	if incident != nil || len(alerts) > 0 || len(notes) > 0 {
-		data := alertData{
-			Incident: incident,
-			Alerts:   alerts,
-			Notes:    notes,
-		}
-		jsonData, err := json.Marshal(data)
-		if err != nil {
-			log.Warn("tui.login(): failed to marshal alert data", "error", err)
-		} else {
-			// Use RawStdEncoding: standard base64 alphabet (+/) without padding (no = characters)
-			// No padding avoids issues with ocm-container's env var parsing which splits on =
-			// Standard alphabet ensures `echo $ALERT_DETAILS | base64 -d` works in the container
-			encoded := base64.RawStdEncoding.EncodeToString(jsonData)
-			envFlags = append(envFlags, "-e", fmt.Sprintf("ALERT_DETAILS=%s", encoded))
-		}
-	}
+	// Build individual PAGERDUTY_* environment variables filtered to the selected cluster
+	clusterID := vars["%%CLUSTER_ID%%"]
+	envFlags := buildPagerDutyEnvVars(incident, alerts, notes, clusterID)
 
 	// Insert env flags into command
 	// We need to find the position after any terminal separator (like "--") but before ocm-container

--- a/pkg/tui/commands_test.go
+++ b/pkg/tui/commands_test.go
@@ -453,6 +453,7 @@ func TestBuildPagerDutyEnvVars_FullIncident(t *testing.T) {
 	assert.Equal(t, "test-service", vars["PAGERDUTY_INCIDENT_SERVICE"])
 	assert.Equal(t, "high", vars["PAGERDUTY_INCIDENT_URGENCY"])
 	assert.Equal(t, "triggered", vars["PAGERDUTY_INCIDENT_STATUS"])
+	assert.Equal(t, "https://pagerduty.com/incidents/PD123", vars["REASON"])
 	assert.Equal(t, "cluster-abc", vars["PAGERDUTY_CLUSTER_ID"])
 	assert.Equal(t, "2", vars["PAGERDUTY_ALERT_COUNT"])
 	assert.Equal(t, "HighCPU,LowMemory", vars["PAGERDUTY_ALERT_NAMES"])
@@ -1094,4 +1095,26 @@ func TestGetUniqueClusters_MixedWithAndWithoutClusterID(t *testing.T) {
 	}
 	result := getUniqueClusters(alerts)
 	assert.Equal(t, []string{"cluster-abc-123", "cluster-def-456"}, result)
+}
+
+func TestSanitizeEnvValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"plain text", "ClusterOperatorDown", "ClusterOperatorDown"},
+		{"with spaces", "High CPU Alert", "High CPU Alert"},
+		{"with newlines", "line1\nline2\rline3", "line1 line2line3"},
+		{"with quotes", `alert "name" here`, "alert name here"},
+		{"with backticks", "alert `cmd` here", "alert cmd here"},
+		{"with dollar signs", "alert $VAR here", "alert VAR here"},
+		{"with backslashes", `alert \n here`, "alert n here"},
+		{"empty string", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, sanitizeEnvValue(tt.input))
+		})
+	}
 }

--- a/pkg/tui/commands_test.go
+++ b/pkg/tui/commands_test.go
@@ -1,9 +1,8 @@
 package tui
 
 import (
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/PagerDuty/go-pagerduty"
@@ -389,98 +388,236 @@ func TestOpenBrowserCmd(t *testing.T) {
 	}
 }
 
-func TestLoginEnvironmentVariables(t *testing.T) {
-	// Note: This test validates that the login function correctly builds environment
-	// variables for ocm-container, but we can't easily test the actual command execution
-	// without mocking the exec.Command. Instead, we'll validate the command building logic
-	// by checking that the launcher is called correctly.
+// envVarMap converts a buildPagerDutyEnvVars result slice into a map of
+// variable name to value for easier assertion. Each pair is "-e", "KEY=VALUE".
+func envVarMap(flags []string) map[string]string {
+	m := make(map[string]string)
+	for i := 0; i < len(flags)-1; i += 2 {
+		if flags[i] != "-e" {
+			continue
+		}
+		parts := strings.SplitN(flags[i+1], "=", 2)
+		if len(parts) == 2 {
+			m[parts[0]] = parts[1]
+		}
+	}
+	return m
+}
 
-	// This is more of an integration test that would need to be run manually or with
-	// a mock launcher, but we can at least test the alertData serialization
-	tests := []struct {
-		name     string
-		incident *pagerduty.Incident
-		alerts   []pagerduty.IncidentAlert
-		notes    []pagerduty.IncidentNote
-	}{
-		{
-			name: "with incident, alerts, and notes",
-			incident: &pagerduty.Incident{
-				APIObject: pagerduty.APIObject{ID: "PD123"},
-				Title:     "Test Incident",
-			},
-			alerts: []pagerduty.IncidentAlert{
-				{APIObject: pagerduty.APIObject{ID: "ALERT1"}},
-				{APIObject: pagerduty.APIObject{ID: "ALERT2"}},
-			},
-			notes: []pagerduty.IncidentNote{
-				{ID: "NOTE1", Content: "Test note 1"},
-				{ID: "NOTE2", Content: "Test note 2"},
-			},
+func TestBuildPagerDutyEnvVars_FullIncident(t *testing.T) {
+	incident := &pagerduty.Incident{
+		APIObject: pagerduty.APIObject{
+			ID:      "PD123",
+			HTMLURL: "https://pagerduty.com/incidents/PD123",
 		},
-		{
-			name:     "with nil incident and empty alerts and notes",
-			incident: nil,
-			alerts:   []pagerduty.IncidentAlert{},
-			notes:    []pagerduty.IncidentNote{},
-		},
-		{
-			name: "with incident and no alerts or notes",
-			incident: &pagerduty.Incident{
-				APIObject: pagerduty.APIObject{ID: "PD456"},
-			},
-			alerts: nil,
-			notes:  nil,
-		},
-		{
-			name: "with incident and alerts but no notes",
-			incident: &pagerduty.Incident{
-				APIObject: pagerduty.APIObject{ID: "PD789"},
-				Title:     "Test Incident 2",
-			},
-			alerts: []pagerduty.IncidentAlert{
-				{APIObject: pagerduty.APIObject{ID: "ALERT3"}},
-			},
-			notes: nil,
+		Title:   "Test Incident",
+		Urgency: "high",
+		Status:  "triggered",
+		Service: pagerduty.APIObject{
+			Summary: "test-service",
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Test that alertData can be properly serialized
-			data := alertData{
-				Incident: tt.incident,
-				Alerts:   tt.alerts,
-				Notes:    tt.notes,
-			}
+	alerts := []pagerduty.IncidentAlert{
+		{
+			Body: map[string]interface{}{
+				"details": map[string]interface{}{
+					"cluster_id": "cluster-abc",
+					"alert_name": "HighCPU",
+					"link":       "https://example.com/sop/highcpu",
+				},
+			},
+		},
+		{
+			Body: map[string]interface{}{
+				"details": map[string]interface{}{
+					"cluster_id":  "cluster-abc",
+					"alert_name":  "LowMemory",
+					"runbook_url": "https://example.com/sop/lowmem",
+				},
+			},
+		},
+	}
 
-			jsonData, err := json.Marshal(data)
-			assert.NoError(t, err, "Failed to marshal alertData")
-			assert.NotNil(t, jsonData, "JSON data should not be nil")
+	notes := []pagerduty.IncidentNote{
+		{ID: "NOTE1", Content: "Investigating"},
+		{ID: "NOTE2", Content: "Found root cause"},
+	}
 
-			// Test that it can be base64 encoded (standard alphabet, without padding)
-			encoded := base64.RawStdEncoding.EncodeToString(jsonData)
-			assert.NotEmpty(t, encoded, "Base64 encoding should not be empty")
-			// Verify no padding characters
-			assert.NotContains(t, encoded, "=", "RawStdEncoding should not contain = padding")
+	result := buildPagerDutyEnvVars(incident, alerts, notes, "cluster-abc")
+	vars := envVarMap(result)
 
-			// Test that it can be decoded back
-			decoded, err := base64.RawStdEncoding.DecodeString(encoded)
-			assert.NoError(t, err, "Failed to decode base64")
+	assert.Equal(t, "PD123", vars["PAGERDUTY_INCIDENT_ID"])
+	assert.Equal(t, "Test Incident", vars["PAGERDUTY_INCIDENT_TITLE"])
+	assert.Equal(t, "https://pagerduty.com/incidents/PD123", vars["PAGERDUTY_INCIDENT_URL"])
+	assert.Equal(t, "test-service", vars["PAGERDUTY_INCIDENT_SERVICE"])
+	assert.Equal(t, "high", vars["PAGERDUTY_INCIDENT_URGENCY"])
+	assert.Equal(t, "triggered", vars["PAGERDUTY_INCIDENT_STATUS"])
+	assert.Equal(t, "cluster-abc", vars["PAGERDUTY_CLUSTER_ID"])
+	assert.Equal(t, "2", vars["PAGERDUTY_ALERT_COUNT"])
+	assert.Equal(t, "HighCPU,LowMemory", vars["PAGERDUTY_ALERT_NAMES"])
+	assert.Equal(t, "https://example.com/sop/highcpu,https://example.com/sop/lowmem", vars["PAGERDUTY_ALERT_LINKS"])
+	assert.Equal(t, "true", vars["PAGERDUTY_NOTES_EXIST"])
+	assert.Equal(t, "2", vars["PAGERDUTY_NOTE_COUNT"])
 
-			var decodedData alertData
-			err = json.Unmarshal(decoded, &decodedData)
-			assert.NoError(t, err, "Failed to unmarshal decoded data")
+	// Every entry should be a "-e" / "KEY=VALUE" pair
+	for i := 0; i < len(result); i += 2 {
+		assert.Equal(t, "-e", result[i], "Expected -e flag at position %d", i)
+	}
+}
 
-			// Verify the data matches
-			if tt.incident != nil {
-				assert.Equal(t, tt.incident.ID, decodedData.Incident.ID)
-			} else {
-				assert.Nil(t, decodedData.Incident)
-			}
-			assert.Equal(t, len(tt.alerts), len(decodedData.Alerts))
-			assert.Equal(t, len(tt.notes), len(decodedData.Notes))
+func TestBuildPagerDutyEnvVars_FiltersByCluster(t *testing.T) {
+	incident := &pagerduty.Incident{
+		APIObject: pagerduty.APIObject{ID: "PD456"},
+		Service:   pagerduty.APIObject{Summary: "svc"},
+	}
+
+	alerts := []pagerduty.IncidentAlert{
+		{
+			Body: map[string]interface{}{
+				"details": map[string]interface{}{
+					"cluster_id": "cluster-abc",
+					"alert_name": "AlertA",
+					"link":       "https://sop/a",
+				},
+			},
+		},
+		{
+			Body: map[string]interface{}{
+				"details": map[string]interface{}{
+					"cluster_id": "cluster-xyz",
+					"alert_name": "AlertX",
+					"link":       "https://sop/x",
+				},
+			},
+		},
+		{
+			Body: map[string]interface{}{
+				"details": map[string]interface{}{
+					"cluster_id":  "cluster-abc",
+					"alert_name":  "AlertB",
+					"runbook_url": "https://sop/b",
+				},
+			},
+		},
+	}
+
+	result := buildPagerDutyEnvVars(incident, alerts, nil, "cluster-abc")
+	vars := envVarMap(result)
+
+	assert.Equal(t, "2", vars["PAGERDUTY_ALERT_COUNT"], "Should only count alerts matching cluster-abc")
+	assert.Equal(t, "AlertA,AlertB", vars["PAGERDUTY_ALERT_NAMES"])
+	assert.Equal(t, "https://sop/a,https://sop/b", vars["PAGERDUTY_ALERT_LINKS"])
+}
+
+func TestBuildPagerDutyEnvVars_NilIncident(t *testing.T) {
+	alerts := []pagerduty.IncidentAlert{
+		{
+			Body: map[string]interface{}{
+				"details": map[string]interface{}{
+					"cluster_id": "cluster-abc",
+					"alert_name": "OrphanAlert",
+				},
+			},
+		},
+	}
+
+	result := buildPagerDutyEnvVars(nil, alerts, nil, "cluster-abc")
+	vars := envVarMap(result)
+
+	// Should not contain incident-level vars
+	_, hasIncidentID := vars["PAGERDUTY_INCIDENT_ID"]
+	assert.False(t, hasIncidentID, "Nil incident should not produce PAGERDUTY_INCIDENT_ID")
+
+	// Should still have cluster and alert vars
+	assert.Equal(t, "cluster-abc", vars["PAGERDUTY_CLUSTER_ID"])
+	assert.Equal(t, "1", vars["PAGERDUTY_ALERT_COUNT"])
+	assert.Equal(t, "OrphanAlert", vars["PAGERDUTY_ALERT_NAMES"])
+	assert.Equal(t, "false", vars["PAGERDUTY_NOTES_EXIST"])
+	assert.Equal(t, "0", vars["PAGERDUTY_NOTE_COUNT"])
+}
+
+func TestBuildPagerDutyEnvVars_NoMatchingAlerts(t *testing.T) {
+	incident := &pagerduty.Incident{
+		APIObject: pagerduty.APIObject{ID: "PD789"},
+		Service:   pagerduty.APIObject{Summary: "svc"},
+	}
+
+	alerts := []pagerduty.IncidentAlert{
+		{
+			Body: map[string]interface{}{
+				"details": map[string]interface{}{
+					"cluster_id": "cluster-other",
+					"alert_name": "OtherAlert",
+					"link":       "https://sop/other",
+				},
+			},
+		},
+	}
+
+	result := buildPagerDutyEnvVars(incident, alerts, nil, "cluster-abc")
+	vars := envVarMap(result)
+
+	assert.Equal(t, "0", vars["PAGERDUTY_ALERT_COUNT"])
+	assert.Equal(t, "", vars["PAGERDUTY_ALERT_NAMES"])
+	assert.Equal(t, "", vars["PAGERDUTY_ALERT_LINKS"])
+}
+
+func TestBuildPagerDutyEnvVars_NotesExist(t *testing.T) {
+	notes := []pagerduty.IncidentNote{
+		{ID: "N1", Content: "note one"},
+		{ID: "N2", Content: "note two"},
+		{ID: "N3", Content: "note three"},
+	}
+
+	result := buildPagerDutyEnvVars(nil, nil, notes, "")
+	vars := envVarMap(result)
+
+	assert.Equal(t, "true", vars["PAGERDUTY_NOTES_EXIST"])
+	assert.Equal(t, "3", vars["PAGERDUTY_NOTE_COUNT"])
+}
+
+func TestBuildPagerDutyEnvVars_NoNotes(t *testing.T) {
+	result := buildPagerDutyEnvVars(nil, nil, nil, "")
+	vars := envVarMap(result)
+
+	assert.Equal(t, "false", vars["PAGERDUTY_NOTES_EXIST"])
+	assert.Equal(t, "0", vars["PAGERDUTY_NOTE_COUNT"])
+}
+
+func TestBuildPagerDutyEnvVars_ManyAlerts(t *testing.T) {
+	// 50 alerts for the same cluster should not cause size issues
+	var alerts []pagerduty.IncidentAlert
+	for i := 0; i < 50; i++ {
+		alerts = append(alerts, pagerduty.IncidentAlert{
+			Body: map[string]interface{}{
+				"details": map[string]interface{}{
+					"cluster_id": "cluster-big",
+					"alert_name": fmt.Sprintf("Alert%d", i),
+					"link":       fmt.Sprintf("https://sop/%d", i),
+				},
+			},
 		})
+	}
+
+	result := buildPagerDutyEnvVars(nil, alerts, nil, "cluster-big")
+	vars := envVarMap(result)
+
+	assert.Equal(t, "50", vars["PAGERDUTY_ALERT_COUNT"])
+
+	names := strings.Split(vars["PAGERDUTY_ALERT_NAMES"], ",")
+	assert.Equal(t, 50, len(names), "Should have 50 comma-separated alert names")
+
+	links := strings.Split(vars["PAGERDUTY_ALERT_LINKS"], ",")
+	assert.Equal(t, 50, len(links), "Should have 50 comma-separated alert links")
+
+	// Each individual env var value is a simple string, no base64 encoding
+	for _, flag := range result {
+		if flag == "-e" {
+			continue
+		}
+		// No value should contain base64-only artifacts from the old approach
+		assert.NotContains(t, flag, "ALERT_DETAILS", "Should not use old ALERT_DETAILS variable")
 	}
 }
 
@@ -646,9 +783,6 @@ func TestLoginCommandStructureWithEnvVars(t *testing.T) {
 	// position in the command - after the terminal separator but as arguments to
 	// ocm-container, not to the terminal itself
 
-	// Mock a simple function to test command building logic
-	// We can't test the full login() function easily, but we can test the logic
-
 	testCases := []struct {
 		name           string
 		inputCommand   []string
@@ -671,10 +805,7 @@ func TestLoginCommandStructureWithEnvVars(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Test that the command structure makes sense
-			// This is a simplified version of what login() does
-
-			envFlags := []string{"-e", "PAGERDUTY_INCIDENT=PD123"}
+			envFlags := []string{"-e", "PAGERDUTY_INCIDENT_ID=PD123"}
 
 			// Find separator position
 			var separatorIdx = -1
@@ -690,13 +821,10 @@ func TestLoginCommandStructureWithEnvVars(t *testing.T) {
 			// If no separator: [command] [env-flags] [other-args]
 
 			if separatorIdx >= 0 {
-				// Should have structure like: gnome-terminal -- ocm-container -e VAR=val --cluster-id ABC
 				assert.Greater(t, len(tc.inputCommand), separatorIdx+1,
 					"Command should have elements after separator")
 			}
 
-			// The key is that env flags should come after any terminal command
-			// and after the actual target command (ocm-container), but before its arguments
 			assert.NotEmpty(t, envFlags, "Env flags should not be empty")
 		})
 	}


### PR DESCRIPTION
## Summary

- Replaces the monolithic base64-encoded `ALERT_DETAILS` env var with 12 individual `PAGERDUTY_*` environment variables when launching ocm-container, preventing ARG_MAX failures with 25+ alerts
- Adds `buildPagerDutyEnvVars()` pure function that filters alerts to only those matching the selected cluster and produces human-readable env vars
- Renames `PAGERDUTY_INCIDENT` to `PAGERDUTY_INCIDENT_ID` for naming consistency

### New Environment Variables

| Variable | Source |
|----------|--------|
| `PAGERDUTY_INCIDENT_ID` | `incident.ID` |
| `PAGERDUTY_INCIDENT_TITLE` | `incident.Title` |
| `PAGERDUTY_INCIDENT_URL` | `incident.HTMLURL` |
| `PAGERDUTY_INCIDENT_SERVICE` | `incident.Service.Summary` |
| `PAGERDUTY_INCIDENT_URGENCY` | `incident.Urgency` |
| `PAGERDUTY_INCIDENT_STATUS` | `incident.Status` |
| `PAGERDUTY_CLUSTER_ID` | selected cluster ID |
| `PAGERDUTY_ALERT_COUNT` | count of alerts matching this cluster |
| `PAGERDUTY_ALERT_NAMES` | comma-separated alert names |
| `PAGERDUTY_ALERT_LINKS` | comma-separated SOP links |
| `PAGERDUTY_NOTES_EXIST` | "true" or "false" |
| `PAGERDUTY_NOTE_COUNT` | number of notes |

### Breaking Changes

- `ALERT_DETAILS` env var is removed -- scripts parsing it need to use the new individual vars
- `PAGERDUTY_INCIDENT` renamed to `PAGERDUTY_INCIDENT_ID`

## Test plan

- [x] `TestBuildPagerDutyEnvVars_FullIncident` -- all 12 vars populated correctly
- [x] `TestBuildPagerDutyEnvVars_FiltersByCluster` -- only matching cluster alerts included
- [x] `TestBuildPagerDutyEnvVars_NilIncident` -- graceful, returns cluster/alert/note vars only
- [x] `TestBuildPagerDutyEnvVars_NoMatchingAlerts` -- count=0, empty names/links
- [x] `TestBuildPagerDutyEnvVars_NotesExist` -- NOTES_EXIST=true, correct count
- [x] `TestBuildPagerDutyEnvVars_NoNotes` -- NOTES_EXIST=false, count=0
- [x] `TestBuildPagerDutyEnvVars_ManyAlerts` -- 50 alerts, no size issues
- [x] `make fmt-check` passes
- [x] `make vet` passes
- [x] `make test` passes (all existing + new tests green)

Created with assistance from Claude <claude@anthropic.com>