### PR TITLE
Add Claude Code detection env var for terminal sessions

### DIFF
--- a/docs/plans/043-claude-code-detection.md
+++ b/docs/plans/043-claude-code-detection.md
@@ -1,0 +1,26 @@
+# Add Claude Code detection env var
+
+## Context
+
+When launching terminal sessions for cluster investigation, signal
+whether Claude Code is available so the investigation environment
+can leverage AI-assisted workflows.
+
+## Plan
+
+1. Add `HasClaudeCode()` in `pkg/launcher/claude.go` using
+   `exec.LookPath("claude")` with injectable stub for testing
+2. Set `PAGERDUTY_CLAUDE_AVAILABLE=true` in `buildPagerDutyEnvVars()`
+   when detected
+
+## Files Modified
+
+- `pkg/launcher/claude.go` — new, detection function
+- `pkg/launcher/claude_test.go` — new, 2 tests
+- `pkg/tui/commands.go` — add env var in buildPagerDutyEnvVars
+
+## Verification
+
+- `TestHasClaudeCode_NotInstalled` passes
+- `TestHasClaudeCode_Installed` passes
+- All tests pass

--- a/pkg/launcher/claude.go
+++ b/pkg/launcher/claude.go
@@ -1,0 +1,27 @@
+package launcher
+
+import (
+	"os/exec"
+
+	"github.com/charmbracelet/log"
+)
+
+// HasClaudeCode reports whether the "claude" binary is available on
+// the system PATH.  It is safe to call unconditionally -- a missing
+// binary simply returns false.
+func HasClaudeCode() bool {
+	return hasClaudeCodeWith(exec.LookPath)
+}
+
+// hasClaudeCodeWith is the testable core: it accepts a lookup function
+// with the same signature as exec.LookPath so callers can inject a
+// stub during tests.
+func hasClaudeCodeWith(lookPath func(string) (string, error)) bool {
+	path, err := lookPath("claude")
+	if err != nil {
+		log.Debug("launcher.HasClaudeCode: claude not found on PATH", "error", err)
+		return false
+	}
+	log.Debug("launcher.HasClaudeCode: claude found", "path", path)
+	return true
+}

--- a/pkg/launcher/claude_test.go
+++ b/pkg/launcher/claude_test.go
@@ -1,0 +1,33 @@
+package launcher
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestHasClaudeCode_NotInstalled(t *testing.T) {
+	// When exec.LookPath cannot find "claude", HasClaudeCode returns false
+	lookPath := func(file string) (string, error) {
+		return "", fmt.Errorf("executable file not found in $PATH")
+	}
+
+	got := hasClaudeCodeWith(lookPath)
+	if got {
+		t.Fatal("expected HasClaudeCode to return false when claude is not on PATH")
+	}
+}
+
+func TestHasClaudeCode_Installed(t *testing.T) {
+	// When exec.LookPath finds "claude", HasClaudeCode returns true
+	lookPath := func(file string) (string, error) {
+		if file == "claude" {
+			return "/usr/local/bin/claude", nil
+		}
+		return "", fmt.Errorf("not found")
+	}
+
+	got := hasClaudeCodeWith(lookPath)
+	if !got {
+		t.Fatal("expected HasClaudeCode to return true when claude is on PATH")
+	}
+}

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -494,6 +494,11 @@ func buildPagerDutyEnvVars(incident *pagerduty.Incident, alerts []pagerduty.Inci
 	envFlags = append(envFlags, "-e", fmt.Sprintf("PAGERDUTY_NOTES_EXIST=%s", strconv.FormatBool(notesExist)))
 	envFlags = append(envFlags, "-e", fmt.Sprintf("PAGERDUTY_NOTE_COUNT=%s", strconv.Itoa(len(notes))))
 
+	// Claude Code detection
+	if launcher.HasClaudeCode() {
+		envFlags = append(envFlags, "-e", "PAGERDUTY_CLAUDE_AVAILABLE=true")
+	}
+
 	return envFlags
 }
 


### PR DESCRIPTION
## Summary

- Add `HasClaudeCode()` function in `pkg/launcher/claude.go` that detects the `claude` binary on PATH via `exec.LookPath`
- When launching terminal sessions for cluster investigation, set `PAGERDUTY_CLAUDE_AVAILABLE=true` env var if Claude Code is detected
- Graceful degradation: when claude is not installed, the var is simply not set (no error)

## Files Changed

| File | Change |
|------|--------|
| `pkg/launcher/claude.go` | New: `HasClaudeCode()` + testable `hasClaudeCodeWith()` |
| `pkg/launcher/claude_test.go` | New: `TestHasClaudeCode_NotInstalled`, `TestHasClaudeCode_Installed` |
| `pkg/tui/commands.go` | Import alias for launcher pkg; add `PAGERDUTY_CLAUDE_AVAILABLE` env flag in `login()` |
| `docs/plans/043-claude-code-detection.md` | Plan document |

## Test plan

- [x] `TestHasClaudeCode_NotInstalled` -- returns false when claude is absent from PATH
- [x] `TestHasClaudeCode_Installed` -- returns true when claude is present on PATH
- [x] All existing tests pass (`go test ./...`)
- [x] `gofmt -s` formatting clean
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)