### PR TITLE
Refactor terminal launcher with multi-terminal profiles

### DIFF
--- a/docs/plans/040-multi-terminal-profiles.md
+++ b/docs/plans/040-multi-terminal-profiles.md
@@ -1,0 +1,76 @@
+# Plan 040: Multi-Terminal Profiles
+
+## Problem
+
+The current `ClusterLauncher` in `pkg/launcher/launcher.go` concatenates
+terminal args and login-command args with no awareness of how different
+terminal emulators expect the boundary between their own flags and the
+command to execute. Terminals fall into three categories:
+
+- **Separator terminals** (gnome-terminal, ptyxis, wezterm, BlackBox,
+  tmux): expect a `--` separator between terminal flags and the
+  executed command.
+- **Flag terminals** (konsole `-e`, alacritty `-e`, terminator
+  `--execute`): use a specific flag to introduce the executed command.
+- **Direct terminals** (kitty, foot, Contour): the executed command
+  follows terminal flags directly with no separator or flag.
+
+Users must currently encode the separator or flag into their terminal
+config string, which is error-prone and undocumented.
+
+## Solution
+
+Introduce a `TerminalProfile` strategy interface with concrete
+implementations for each category, plus a `GenericProfile` fallback
+that preserves the current concatenation behavior.
+
+A `DetectTerminalProfile` function auto-detects the correct profile
+from the terminal command string (executable name or Flatpak app ID).
+
+The `ClusterLauncher.BuildLoginCommand` method delegates to the
+detected profile's `BuildCommand` method, keeping full backward
+compatibility.
+
+## Implementation
+
+### New file: `pkg/launcher/profiles.go`
+
+- `TerminalProfile` interface: `Name() string`,
+  `BuildCommand(terminalArgs, loginCmd []string) ([]string, error)`
+- `SeparatorProfile` — inserts `--` between terminal args and command
+- `FlagProfile` — inserts a configurable flag (e.g., `-e`)
+- `DirectProfile` — concatenates without any separator
+- `GenericProfile` — identical to `DirectProfile`, used as fallback
+- `DetectTerminalProfile(terminalCmd string) TerminalProfile`
+
+### New file: `pkg/launcher/profiles_test.go`
+
+Table-driven tests covering detection and command building for each
+profile type, including Flatpak app IDs.
+
+### Modified file: `pkg/launcher/launcher.go`
+
+- `ClusterLauncher` gains a `profile TerminalProfile` field
+- `NewClusterLauncher` calls `DetectTerminalProfile` during
+  construction
+- `BuildLoginCommand` delegates to `profile.BuildCommand` after
+  variable replacement
+
+## Backward Compatibility
+
+- Existing configs that manually include `--` or `-e` in the terminal
+  string continue to work because `GenericProfile` preserves the
+  current concatenation behavior.
+- Detection only activates when the executable name matches a known
+  terminal; unknown terminals fall through to `GenericProfile`.
+
+## Testing
+
+- `make test-all` must pass
+- All existing launcher tests must remain green
+- New tests cover every profile type and the detection function
+
+## Risks
+
+- None significant. The refactor is additive and the fallback
+  preserves exact existing behavior.

--- a/pkg/launcher/launcher.go
+++ b/pkg/launcher/launcher.go
@@ -16,6 +16,7 @@ type ClusterLauncher struct {
 	terminal            []string
 	clusterLoginCommand []string
 	runInToolbox        bool
+	profile             TerminalProfile
 	settings            launcherSettings
 }
 
@@ -43,6 +44,7 @@ func NewClusterLauncherWithToolbox(terminal string, clusterLoginCommand string, 
 		terminal:            strings.Split(terminal, " "),
 		clusterLoginCommand: strings.Split(clusterLoginCommand, " "),
 		runInToolbox:        inToolbox,
+		profile:             DetectTerminalProfile(terminal),
 		settings:            launcherSettings{},
 	}
 
@@ -101,36 +103,88 @@ func (l *ClusterLauncher) validate() error {
 	return nil
 }
 
+// Profile returns the detected TerminalProfile for this launcher.
+func (l *ClusterLauncher) Profile() TerminalProfile {
+	return l.profile
+}
+
 func (l *ClusterLauncher) BuildLoginCommand(vars map[string]string) []string {
-	command := []string{}
+	// Ensure a profile is set; default to GenericProfile if nil (e.g.,
+	// when ClusterLauncher was constructed directly without NewClusterLauncher).
+	profile := l.profile
+	if profile == nil {
+		profile = &GenericProfile{}
+	}
+
+	log.Debug("launcher.ClusterLauncher(): building command", "terminal", l.terminal[0], "profile", profile.Name())
+
+	// Replace variables in terminal args (skip the first arg, which is
+	// the executable and must not be a replaceable value).
+	terminalArgs := []string{l.terminal[0]}
+	if len(l.terminal) > 1 {
+		terminalArgs = append(terminalArgs, replaceVars(l.terminal[1:], vars)...)
+	}
+
+	loginCmd := replaceVars(l.clusterLoginCommand, vars)
+
+	var command []string
+
+	// If the terminal args already contain the separator or flag that
+	// the profile would insert, fall back to simple concatenation to
+	// preserve backward compatibility for users who manually specified
+	// the separator in their config.
+	if alreadyHasSeparator(profile, terminalArgs) {
+		command = append(terminalArgs, loginCmd...)
+	} else {
+		// Use the profile to build the command with the correct separator.
+		var err error
+		command, err = profile.BuildCommand(terminalArgs, loginCmd)
+		if err != nil {
+			// Fallback to simple concatenation on error.
+			log.Debug("launcher.ClusterLauncher(): profile.BuildCommand failed, falling back", "error", err)
+			command = append(terminalArgs, loginCmd...)
+		}
+	}
 
 	// When running in a Fedora Toolbox container, prepend flatpak-spawn --host
 	// so the terminal emulator command executes on the host system rather than
 	// inside the container where it does not exist.
 	if l.runInToolbox {
 		log.Debug("launcher.ClusterLauncher(): prepending flatpak-spawn --host for toolbox")
-		command = append(command, "flatpak-spawn", "--host")
+		command = append([]string{"flatpak-spawn", "--host"}, command...)
 	}
 
-	// Handle the Terminal command
-	// The first arg should not be something replaceable, as checked in the
-	// validate function
-	log.Debug("launcher.BuildLoginCommand()", "terminal", l.terminal[0])
-	command = append(command, l.terminal[0])
+	l.logCommand(command)
+	return command
+}
 
-	// If there are more than one terminal arguments, replace the vars
-	// If there's not more than one terminal argument, the "replacement"
-	// nil []string{} ends up being appended as a whitespace, so don't append
-	if len(l.terminal) > 1 {
-		command = append(command, replaceVars(l.terminal[1:], vars)...)
+// alreadyHasSeparator checks whether the terminal args already include
+// the separator or flag that the detected profile would inject. This
+// preserves backward compatibility for configs where the user manually
+// placed "--" or "-e" in the terminal string.
+func alreadyHasSeparator(profile TerminalProfile, terminalArgs []string) bool {
+	switch p := profile.(type) {
+	case *SeparatorProfile:
+		for _, arg := range terminalArgs[1:] {
+			if arg == "--" {
+				return true
+			}
+		}
+	case *FlagProfile:
+		for _, arg := range terminalArgs[1:] {
+			if arg == p.flag {
+				return true
+			}
+		}
 	}
-	command = append(command, replaceVars(l.clusterLoginCommand, vars)...)
-	log.Debug("launcher.BuildLoginCommand()", "command", command)
+	return false
+}
+
+func (l *ClusterLauncher) logCommand(command []string) {
+	log.Debug("launcher.ClusterLauncher(): built command", "command", command)
 	for x, i := range command {
 		log.Debug("launcher.BuildLoginCommand()", "index", x, "arg", i)
 	}
-
-	return command
 }
 
 func replaceVars(args []string, vars map[string]string) []string {

--- a/pkg/launcher/profiles.go
+++ b/pkg/launcher/profiles.go
@@ -1,0 +1,206 @@
+package launcher
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// TerminalProfile defines how a terminal emulator expects to receive
+// the command it should execute.
+type TerminalProfile interface {
+	// Name returns a human-readable name for this profile.
+	Name() string
+
+	// BuildCommand constructs the full exec argument slice by combining
+	// the terminal's own arguments with the login command according to
+	// the terminal's expected syntax.
+	BuildCommand(terminalArgs []string, loginCmd []string) ([]string, error)
+}
+
+// SeparatorProfile is used by terminals that expect a "--" separator
+// between their own flags and the executed command (gnome-terminal,
+// ptyxis, wezterm, BlackBox, tmux).
+type SeparatorProfile struct {
+	terminalName string
+}
+
+func (p *SeparatorProfile) Name() string {
+	return fmt.Sprintf("separator (%s)", p.terminalName)
+}
+
+func (p *SeparatorProfile) BuildCommand(terminalArgs []string, loginCmd []string) ([]string, error) {
+	if len(terminalArgs) == 0 {
+		return nil, fmt.Errorf("terminal args must not be empty")
+	}
+	if len(loginCmd) == 0 {
+		return nil, fmt.Errorf("login command must not be empty")
+	}
+
+	cmd := make([]string, 0, len(terminalArgs)+1+len(loginCmd))
+	cmd = append(cmd, terminalArgs...)
+	cmd = append(cmd, "--")
+	cmd = append(cmd, loginCmd...)
+	return cmd, nil
+}
+
+// FlagProfile is used by terminals that require a specific flag before
+// the executed command (konsole -e, alacritty -e, terminator --execute).
+type FlagProfile struct {
+	terminalName string
+	flag         string
+}
+
+func (p *FlagProfile) Name() string {
+	return fmt.Sprintf("flag[%s] (%s)", p.flag, p.terminalName)
+}
+
+func (p *FlagProfile) BuildCommand(terminalArgs []string, loginCmd []string) ([]string, error) {
+	if len(terminalArgs) == 0 {
+		return nil, fmt.Errorf("terminal args must not be empty")
+	}
+	if len(loginCmd) == 0 {
+		return nil, fmt.Errorf("login command must not be empty")
+	}
+
+	cmd := make([]string, 0, len(terminalArgs)+1+len(loginCmd))
+	cmd = append(cmd, terminalArgs...)
+	cmd = append(cmd, p.flag)
+	cmd = append(cmd, loginCmd...)
+	return cmd, nil
+}
+
+// DirectProfile is used by terminals where the executed command follows
+// terminal flags directly with no separator (kitty, foot, Contour).
+type DirectProfile struct {
+	terminalName string
+}
+
+func (p *DirectProfile) Name() string {
+	return fmt.Sprintf("direct (%s)", p.terminalName)
+}
+
+func (p *DirectProfile) BuildCommand(terminalArgs []string, loginCmd []string) ([]string, error) {
+	if len(terminalArgs) == 0 {
+		return nil, fmt.Errorf("terminal args must not be empty")
+	}
+	if len(loginCmd) == 0 {
+		return nil, fmt.Errorf("login command must not be empty")
+	}
+
+	cmd := make([]string, 0, len(terminalArgs)+len(loginCmd))
+	cmd = append(cmd, terminalArgs...)
+	cmd = append(cmd, loginCmd...)
+	return cmd, nil
+}
+
+// GenericProfile is the fallback that preserves the original launcher
+// behavior: terminal args and login command are simply concatenated.
+type GenericProfile struct{}
+
+func (p *GenericProfile) Name() string {
+	return "generic"
+}
+
+func (p *GenericProfile) BuildCommand(terminalArgs []string, loginCmd []string) ([]string, error) {
+	if len(terminalArgs) == 0 {
+		return nil, fmt.Errorf("terminal args must not be empty")
+	}
+	if len(loginCmd) == 0 {
+		return nil, fmt.Errorf("login command must not be empty")
+	}
+
+	cmd := make([]string, 0, len(terminalArgs)+len(loginCmd))
+	cmd = append(cmd, terminalArgs...)
+	cmd = append(cmd, loginCmd...)
+	return cmd, nil
+}
+
+// separatorTerminals maps executable names to their profile category.
+var separatorTerminals = map[string]bool{
+	"gnome-terminal": true,
+	"ptyxis":         true,
+	"wezterm":        true,
+	"blackbox":       true,
+	"tmux":           true,
+}
+
+// flagTerminals maps executable names to the flag they use.
+var flagTerminals = map[string]string{
+	"konsole":    "-e",
+	"alacritty":  "-e",
+	"terminator": "--execute",
+}
+
+// directTerminals maps executable names to their profile category.
+var directTerminals = map[string]bool{
+	"kitty":   true,
+	"foot":    true,
+	"contour": true,
+}
+
+// flatpakAppTerminals maps Flatpak application IDs to executable names
+// so that detection works for flatpak-launched terminals.
+var flatpakAppTerminals = map[string]string{
+	"org.gnome.Terminal":          "gnome-terminal",
+	"org.gnome.Ptyxis":            "ptyxis",
+	"org.wezfurlong.wezterm":      "wezterm",
+	"com.raggesilver.BlackBox":    "blackbox",
+	"org.kde.konsole":             "konsole",
+	"org.codeberg.dnkl.foot":      "foot",
+	"net.kovidgoyal.kitty":        "kitty",
+	"io.github.AtomsDevs.Contour": "contour",
+}
+
+// DetectTerminalProfile inspects the terminal command string and returns
+// the appropriate TerminalProfile. It checks the base executable name
+// first, then checks for Flatpak app IDs. Unknown terminals get the
+// GenericProfile fallback.
+func DetectTerminalProfile(terminalCmd string) TerminalProfile {
+	if terminalCmd == "" {
+		return &GenericProfile{}
+	}
+
+	parts := strings.Fields(terminalCmd)
+	if len(parts) == 0 {
+		return &GenericProfile{}
+	}
+
+	// Extract the executable name (basename, no path).
+	execName := filepath.Base(parts[0])
+
+	// For flatpak commands, try to find the app ID in the arguments.
+	if execName == "flatpak" || execName == "flatpak-spawn" {
+		resolvedName := resolveFlatpakTerminal(parts)
+		if resolvedName != "" {
+			execName = resolvedName
+		}
+	}
+
+	return profileForExecName(execName)
+}
+
+// resolveFlatpakTerminal scans the argument list for a known Flatpak
+// application ID and returns the corresponding executable name.
+func resolveFlatpakTerminal(parts []string) string {
+	for _, arg := range parts {
+		if mapped, ok := flatpakAppTerminals[arg]; ok {
+			return mapped
+		}
+	}
+	return ""
+}
+
+// profileForExecName returns the correct profile for a given executable name.
+func profileForExecName(execName string) TerminalProfile {
+	if separatorTerminals[execName] {
+		return &SeparatorProfile{terminalName: execName}
+	}
+	if flag, ok := flagTerminals[execName]; ok {
+		return &FlagProfile{terminalName: execName, flag: flag}
+	}
+	if directTerminals[execName] {
+		return &DirectProfile{terminalName: execName}
+	}
+	return &GenericProfile{}
+}

--- a/pkg/launcher/profiles_test.go
+++ b/pkg/launcher/profiles_test.go
@@ -1,0 +1,248 @@
+package launcher
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Detection tests ---
+
+func TestDetectProfile_GnomeTerminal(t *testing.T) {
+	profile := DetectTerminalProfile("gnome-terminal --window")
+	assert.IsType(t, &SeparatorProfile{}, profile)
+	assert.Contains(t, profile.Name(), "gnome-terminal")
+}
+
+func TestDetectProfile_Ptyxis(t *testing.T) {
+	profile := DetectTerminalProfile("ptyxis --new-window")
+	assert.IsType(t, &SeparatorProfile{}, profile)
+	assert.Contains(t, profile.Name(), "ptyxis")
+}
+
+func TestDetectProfile_Wezterm(t *testing.T) {
+	profile := DetectTerminalProfile("wezterm start")
+	assert.IsType(t, &SeparatorProfile{}, profile)
+	assert.Contains(t, profile.Name(), "wezterm")
+}
+
+func TestDetectProfile_Tmux(t *testing.T) {
+	profile := DetectTerminalProfile("tmux new-window -n test")
+	assert.IsType(t, &SeparatorProfile{}, profile)
+	assert.Contains(t, profile.Name(), "tmux")
+}
+
+func TestDetectProfile_Konsole(t *testing.T) {
+	profile := DetectTerminalProfile("konsole --new-tab")
+	assert.IsType(t, &FlagProfile{}, profile)
+	assert.Contains(t, profile.Name(), "konsole")
+}
+
+func TestDetectProfile_Alacritty(t *testing.T) {
+	profile := DetectTerminalProfile("alacritty --title test")
+	assert.IsType(t, &FlagProfile{}, profile)
+	assert.Contains(t, profile.Name(), "alacritty")
+}
+
+func TestDetectProfile_Terminator(t *testing.T) {
+	profile := DetectTerminalProfile("terminator")
+	assert.IsType(t, &FlagProfile{}, profile)
+	assert.Contains(t, profile.Name(), "terminator")
+}
+
+func TestDetectProfile_Kitty(t *testing.T) {
+	profile := DetectTerminalProfile("kitty --title test")
+	assert.IsType(t, &DirectProfile{}, profile)
+	assert.Contains(t, profile.Name(), "kitty")
+}
+
+func TestDetectProfile_Foot(t *testing.T) {
+	profile := DetectTerminalProfile("foot")
+	assert.IsType(t, &DirectProfile{}, profile)
+	assert.Contains(t, profile.Name(), "foot")
+}
+
+func TestDetectProfile_Contour(t *testing.T) {
+	profile := DetectTerminalProfile("contour")
+	assert.IsType(t, &DirectProfile{}, profile)
+	assert.Contains(t, profile.Name(), "contour")
+}
+
+func TestDetectProfile_Unknown(t *testing.T) {
+	profile := DetectTerminalProfile("/usr/bin/xterm")
+	assert.IsType(t, &GenericProfile{}, profile)
+	assert.Equal(t, "generic", profile.Name())
+}
+
+func TestDetectProfile_Empty(t *testing.T) {
+	profile := DetectTerminalProfile("")
+	assert.IsType(t, &GenericProfile{}, profile)
+}
+
+func TestDetectProfile_FlatpakPtyxis(t *testing.T) {
+	profile := DetectTerminalProfile("flatpak run org.gnome.Ptyxis --new-window")
+	assert.IsType(t, &SeparatorProfile{}, profile)
+	assert.Contains(t, profile.Name(), "ptyxis")
+}
+
+func TestDetectProfile_FlatpakSpawnPtyxis(t *testing.T) {
+	profile := DetectTerminalProfile("flatpak-spawn --host flatpak run org.gnome.Ptyxis")
+	assert.IsType(t, &SeparatorProfile{}, profile)
+	assert.Contains(t, profile.Name(), "ptyxis")
+}
+
+func TestDetectProfile_FlatpakKonsole(t *testing.T) {
+	profile := DetectTerminalProfile("flatpak run org.kde.konsole")
+	assert.IsType(t, &FlagProfile{}, profile)
+	assert.Contains(t, profile.Name(), "konsole")
+}
+
+func TestDetectProfile_FlatpakKitty(t *testing.T) {
+	profile := DetectTerminalProfile("flatpak run net.kovidgoyal.kitty")
+	assert.IsType(t, &DirectProfile{}, profile)
+	assert.Contains(t, profile.Name(), "kitty")
+}
+
+func TestDetectProfile_FlatpakUnknown(t *testing.T) {
+	profile := DetectTerminalProfile("flatpak run com.unknown.Terminal")
+	assert.IsType(t, &GenericProfile{}, profile)
+}
+
+func TestDetectProfile_FullPath(t *testing.T) {
+	profile := DetectTerminalProfile("/usr/bin/gnome-terminal")
+	assert.IsType(t, &SeparatorProfile{}, profile)
+	assert.Contains(t, profile.Name(), "gnome-terminal")
+}
+
+// --- BuildCommand tests ---
+
+func TestSeparatorProfile_BuildCommand(t *testing.T) {
+	p := &SeparatorProfile{terminalName: "gnome-terminal"}
+	termArgs := []string{"gnome-terminal", "--window"}
+	loginCmd := []string{"ocm-container", "-C", "abc123"}
+
+	cmd, err := p.BuildCommand(termArgs, loginCmd)
+	require.NoError(t, err)
+
+	expected := []string{"gnome-terminal", "--window", "--", "ocm-container", "-C", "abc123"}
+	assert.Equal(t, expected, cmd)
+}
+
+func TestSeparatorProfile_BuildCommand_EmptyTerminalArgs(t *testing.T) {
+	p := &SeparatorProfile{terminalName: "gnome-terminal"}
+	_, err := p.BuildCommand([]string{}, []string{"cmd"})
+	assert.Error(t, err)
+}
+
+func TestSeparatorProfile_BuildCommand_EmptyLoginCmd(t *testing.T) {
+	p := &SeparatorProfile{terminalName: "gnome-terminal"}
+	_, err := p.BuildCommand([]string{"gnome-terminal"}, []string{})
+	assert.Error(t, err)
+}
+
+func TestFlagProfile_BuildCommand(t *testing.T) {
+	p := &FlagProfile{terminalName: "konsole", flag: "-e"}
+	termArgs := []string{"konsole", "--new-tab"}
+	loginCmd := []string{"ocm-container", "-C", "abc123"}
+
+	cmd, err := p.BuildCommand(termArgs, loginCmd)
+	require.NoError(t, err)
+
+	expected := []string{"konsole", "--new-tab", "-e", "ocm-container", "-C", "abc123"}
+	assert.Equal(t, expected, cmd)
+}
+
+func TestFlagProfile_BuildCommand_Execute(t *testing.T) {
+	p := &FlagProfile{terminalName: "terminator", flag: "--execute"}
+	termArgs := []string{"terminator"}
+	loginCmd := []string{"bash", "-c", "echo hello"}
+
+	cmd, err := p.BuildCommand(termArgs, loginCmd)
+	require.NoError(t, err)
+
+	expected := []string{"terminator", "--execute", "bash", "-c", "echo hello"}
+	assert.Equal(t, expected, cmd)
+}
+
+func TestFlagProfile_BuildCommand_EmptyTerminalArgs(t *testing.T) {
+	p := &FlagProfile{terminalName: "konsole", flag: "-e"}
+	_, err := p.BuildCommand([]string{}, []string{"cmd"})
+	assert.Error(t, err)
+}
+
+func TestFlagProfile_BuildCommand_EmptyLoginCmd(t *testing.T) {
+	p := &FlagProfile{terminalName: "konsole", flag: "-e"}
+	_, err := p.BuildCommand([]string{"konsole"}, []string{})
+	assert.Error(t, err)
+}
+
+func TestDirectProfile_BuildCommand(t *testing.T) {
+	p := &DirectProfile{terminalName: "kitty"}
+	termArgs := []string{"kitty", "--title", "cluster"}
+	loginCmd := []string{"ocm-container", "-C", "abc123"}
+
+	cmd, err := p.BuildCommand(termArgs, loginCmd)
+	require.NoError(t, err)
+
+	expected := []string{"kitty", "--title", "cluster", "ocm-container", "-C", "abc123"}
+	assert.Equal(t, expected, cmd)
+}
+
+func TestDirectProfile_BuildCommand_EmptyTerminalArgs(t *testing.T) {
+	p := &DirectProfile{terminalName: "kitty"}
+	_, err := p.BuildCommand([]string{}, []string{"cmd"})
+	assert.Error(t, err)
+}
+
+func TestDirectProfile_BuildCommand_EmptyLoginCmd(t *testing.T) {
+	p := &DirectProfile{terminalName: "kitty"}
+	_, err := p.BuildCommand([]string{"kitty"}, []string{})
+	assert.Error(t, err)
+}
+
+func TestGenericProfile_BuildCommand(t *testing.T) {
+	p := &GenericProfile{}
+	termArgs := []string{"xterm", "-e"}
+	loginCmd := []string{"ocm-container", "-C", "abc123"}
+
+	cmd, err := p.BuildCommand(termArgs, loginCmd)
+	require.NoError(t, err)
+
+	expected := []string{"xterm", "-e", "ocm-container", "-C", "abc123"}
+	assert.Equal(t, expected, cmd)
+}
+
+func TestGenericProfile_BuildCommand_EmptyTerminalArgs(t *testing.T) {
+	p := &GenericProfile{}
+	_, err := p.BuildCommand([]string{}, []string{"cmd"})
+	assert.Error(t, err)
+}
+
+func TestGenericProfile_BuildCommand_EmptyLoginCmd(t *testing.T) {
+	p := &GenericProfile{}
+	_, err := p.BuildCommand([]string{"xterm"}, []string{})
+	assert.Error(t, err)
+}
+
+// --- Profile Name tests ---
+
+func TestSeparatorProfile_Name(t *testing.T) {
+	p := &SeparatorProfile{terminalName: "ptyxis"}
+	assert.Equal(t, "separator (ptyxis)", p.Name())
+}
+
+func TestFlagProfile_Name(t *testing.T) {
+	p := &FlagProfile{terminalName: "alacritty", flag: "-e"}
+	assert.Equal(t, "flag[-e] (alacritty)", p.Name())
+}
+
+func TestDirectProfile_Name(t *testing.T) {
+	p := &DirectProfile{terminalName: "foot"}
+	assert.Equal(t, "direct (foot)", p.Name())
+}
+
+func TestGenericProfile_Name(t *testing.T) {
+	p := &GenericProfile{}
+	assert.Equal(t, "generic", p.Name())
+}


### PR DESCRIPTION
## Summary

- Add `TerminalProfile` strategy interface with four implementations: `SeparatorProfile` (gnome-terminal, ptyxis, wezterm, BlackBox, tmux), `FlagProfile` (konsole, alacritty, terminator), `DirectProfile` (kitty, foot, Contour), and `GenericProfile` fallback
- Auto-detect terminal profile from executable name or Flatpak app ID via `DetectTerminalProfile()`
- Integrate profile into `ClusterLauncher.BuildLoginCommand()` with backward-compatible separator detection so existing configs work unchanged

## Test plan

- [x] All existing launcher tests pass unchanged (backward compatibility verified)
- [x] New detection tests cover all terminal types, Flatpak IDs, full paths, and unknown terminals
- [x] New BuildCommand tests verify correct output structure for each profile type, including error cases
- [x] `make fmt-check` passes
- [x] `make vet` passes
- [x] `make test` passes (all 7 packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>