### PR TITLE
Add config validation and view/render test coverage

### DIFF
--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -125,3 +125,52 @@ func TestValidateConfig_OptionalKeysGetDefaults(t *testing.T) {
 	assert.Equal(t, "gnome-terminal --", viper.GetString("terminal"), "terminal should default to 'gnome-terminal --'")
 	assert.Equal(t, "ocm backplane login %%CLUSTER_ID%%", viper.GetString("cluster_login_command"), "cluster_login_command should get default value")
 }
+
+func TestValidateConfig_InvalidEscalationPoliciesType(t *testing.T) {
+	viper.Reset()
+	viper.Set("token", "test-pagerduty-token")
+	viper.Set("teams", []string{"TEAM1", "TEAM2"})
+	// Set service_escalation_policies as a string instead of a map
+	viper.Set("service_escalation_policies", "not-a-map")
+
+	err := validateConfig()
+
+	assert.Error(t, err, "validateConfig should return an error when service_escalation_policies is a string instead of a map")
+	assert.Contains(t, err.Error(), "not a valid map", "error should indicate the value is not a valid map")
+}
+
+func TestValidateConfig_DeprecatedKeyDetected(t *testing.T) {
+	viper.Reset()
+	setValidConfig()
+	// Add a deprecated key
+	viper.Set("shell", "/bin/bash")
+
+	err := validateConfig()
+
+	// Deprecated keys should not cause an error; they are logged as informational
+	assert.NoError(t, err, "validateConfig should not return an error for deprecated keys")
+}
+
+func TestValidateConfig_CaseSensitiveEscalationKeys(t *testing.T) {
+	// The validateConfig code looks up escalation policy keys using
+	// strings.ToLower(), so it always searches for lowercase "default" and
+	// "silent_default" in the settings map. Viper also normalizes keys to
+	// lowercase. This test verifies that when the inner map keys do NOT
+	// contain the lowercase forms that the code expects, validation fails.
+	//
+	// We simulate this by providing a map where neither "default" nor
+	// "silent_default" exists -- only unrelated keys -- to prove the
+	// lookup is case-sensitive at the Go map level.
+	viper.Reset()
+	viper.Set("token", "test-pagerduty-token")
+	viper.Set("teams", []string{"TEAM1", "TEAM2"})
+	viper.Set("service_escalation_policies", map[string]interface{}{
+		"some_other_service": "ESCALATION_POLICY_1",
+	})
+
+	err := validateConfig()
+
+	assert.Error(t, err, "validateConfig should return an error when required escalation policy keys (default, silent_default) are missing")
+	assert.Contains(t, err.Error(), "DEFAULT", "error should mention the missing 'DEFAULT' key")
+	assert.Contains(t, err.Error(), "SILENT_DEFAULT", "error should mention the missing 'SILENT_DEFAULT' key")
+}

--- a/docs/plans/041-config-view-test-coverage.md
+++ b/docs/plans/041-config-view-test-coverage.md
@@ -1,0 +1,67 @@
+# 041: Config Validation and View/Render Test Coverage
+
+## Status: Complete
+
+## Objective
+
+Expand test coverage for config validation logic in `cmd/config.go` and
+view/render functions in `pkg/tui/views.go` and `pkg/tui/commands.go`.
+
+## Part 1: Config Validation Tests (`cmd/config_test.go`)
+
+### Tests Added
+
+1. **TestValidateConfig_InvalidEscalationPoliciesType** - Verifies that
+   `validateConfig` returns an error when `service_escalation_policies` is set
+   to a string instead of a map. Exercises the `.(map[string]interface{})`
+   type assertion guard at line 171 of `config.go`.
+
+2. **TestValidateConfig_DeprecatedKeyDetected** - Verifies that deprecated keys
+   (e.g., `"shell"`) do not cause validation errors. The `deprecation.Deprecated`
+   function detects these and the code logs an informational message but continues
+   validation successfully.
+
+3. **TestValidateConfig_CaseSensitiveEscalationKeys** - Verifies that the
+   required inner keys `"default"` and `"silent_default"` must be present in
+   the escalation policies map. The validation code uses `strings.ToLower()`
+   for lookup, and viper normalizes keys to lowercase, so both required keys
+   must resolve to their lowercase forms.
+
+## Part 2: View/Render Function Tests
+
+### `stateShorthand()` (`pkg/tui/commands_test.go`)
+
+4. **TestStateShorthand_Triggered** - Incident with no acknowledgements returns
+   the dot character.
+
+5. **TestStateShorthand_AckedByUser** - Incident acknowledged by the current
+   user returns `"A"` (uppercase).
+
+6. **TestStateShorthand_AckedByOther** - Incident acknowledged by a different
+   user returns `"a"` (lowercase).
+
+### `renderFooter()` (`pkg/tui/views_test.go`)
+
+7. **TestRenderFooter_ContainsRefreshStatus** - Verifies that `renderFooter()`
+   output contains the `refreshArea()` text ("Watching for updates...").
+
+### `renderBottomStatus()` (`pkg/tui/views_test.go`)
+
+8. **TestRenderBottomStatus_ShowsIncidentID** - With a selected incident, the
+   bottom status line includes the incident ID.
+
+9. **TestRenderBottomStatus_ShowsGitSHA** - The bottom status line includes the
+   `GitSHA` variable value.
+
+### `summarizeAlerts()` edge cases (`pkg/tui/views_test.go`)
+
+10. **TestSummarizeAlerts_EmptyAlerts** - Empty alert slice returns nil.
+
+11. **TestSummarizeAlerts_AlertWithNilBody** - Alert with nil Body does not
+    panic and returns a summary with empty name, link, cluster, and nil details.
+
+## Files Changed
+
+- `cmd/config_test.go` - 3 new test functions
+- `pkg/tui/commands_test.go` - 3 new test functions
+- `pkg/tui/views_test.go` - 5 new test functions

--- a/pkg/tui/commands_test.go
+++ b/pkg/tui/commands_test.go
@@ -939,6 +939,43 @@ func TestGetUniqueClusters_NilAlerts(t *testing.T) {
 	assert.Empty(t, result)
 }
 
+func TestStateShorthand_Triggered(t *testing.T) {
+	// Incident with no acknowledgements should return dot
+	incident := pagerduty.Incident{
+		APIObject:        pagerduty.APIObject{ID: "INC001"},
+		Acknowledgements: []pagerduty.Acknowledgement{},
+	}
+
+	result := stateShorthand(incident, "USER123")
+	assert.Equal(t, dot, result, "triggered incident (no acknowledgements) should return dot")
+}
+
+func TestStateShorthand_AckedByUser(t *testing.T) {
+	// Incident acknowledged by the current user should return "A"
+	incident := pagerduty.Incident{
+		APIObject: pagerduty.APIObject{ID: "INC002"},
+		Acknowledgements: []pagerduty.Acknowledgement{
+			{Acknowledger: pagerduty.APIObject{ID: "USER123"}},
+		},
+	}
+
+	result := stateShorthand(incident, "USER123")
+	assert.Equal(t, "A", result, "incident acknowledged by current user should return 'A'")
+}
+
+func TestStateShorthand_AckedByOther(t *testing.T) {
+	// Incident acknowledged by someone else should return "a"
+	incident := pagerduty.Incident{
+		APIObject: pagerduty.APIObject{ID: "INC003"},
+		Acknowledgements: []pagerduty.Acknowledgement{
+			{Acknowledger: pagerduty.APIObject{ID: "OTHER_USER"}},
+		},
+	}
+
+	result := stateShorthand(incident, "USER123")
+	assert.Equal(t, "a", result, "incident acknowledged by another user should return 'a'")
+}
+
 func TestGetUniqueClusters_MixedWithAndWithoutClusterID(t *testing.T) {
 	// Some alerts have cluster_id, some don't - should only return those that do
 	alerts := []pagerduty.IncidentAlert{

--- a/pkg/tui/views_test.go
+++ b/pkg/tui/views_test.go
@@ -338,6 +338,76 @@ func TestSummarizeIncident(t *testing.T) {
 	}
 }
 
+func TestRenderFooter_ContainsRefreshStatus(t *testing.T) {
+	// renderFooter wraps refreshArea output; verify the footer contains it
+	m := model{
+		autoRefresh:     true,
+		autoAcknowledge: false,
+		showLowUrgency:  true,
+	}
+
+	result := m.renderFooter()
+
+	assert.Contains(t, result, "Watching for updates...", "footer should contain the refresh status text from refreshArea")
+}
+
+func TestRenderBottomStatus_ShowsIncidentID(t *testing.T) {
+	// When a selected incident is set, renderBottomStatus should include its ID
+	m := model{
+		selectedIncident: &pagerduty.Incident{
+			APIObject: pagerduty.APIObject{ID: "PABC123456"},
+		},
+	}
+
+	result := m.renderBottomStatus()
+
+	assert.Contains(t, result, "PABC123456", "bottom status should contain the selected incident ID")
+}
+
+func TestRenderBottomStatus_ShowsGitSHA(t *testing.T) {
+	// renderBottomStatus should include the GitSHA variable
+	m := model{}
+
+	result := m.renderBottomStatus()
+
+	assert.Contains(t, result, GitSHA, "bottom status should contain the GitSHA value")
+}
+
+func TestSummarizeAlerts_EmptyAlerts(t *testing.T) {
+	// Empty alert slice should return nil (empty) summary slice
+	result := summarizeAlerts([]pagerduty.IncidentAlert{})
+
+	assert.Nil(t, result, "summarizeAlerts with empty input should return nil")
+}
+
+func TestSummarizeAlerts_AlertWithNilBody(t *testing.T) {
+	// Alert with nil Body should not panic and should return a summary with empty fields
+	alerts := []pagerduty.IncidentAlert{
+		{
+			APIObject: pagerduty.APIObject{
+				ID:      "ALERT_NIL_BODY",
+				HTMLURL: "https://example.pagerduty.com/alerts/ALERT_NIL_BODY",
+			},
+			Service:   pagerduty.APIObject{Summary: "Test Service"},
+			CreatedAt: "2025-06-01T00:00:00Z",
+			Status:    "triggered",
+			Incident:  pagerduty.APIReference{ID: "INC999"},
+			Body:      nil,
+		},
+	}
+
+	// Should not panic
+	result := summarizeAlerts(alerts)
+
+	assert.Len(t, result, 1, "should return exactly one alert summary")
+	assert.Equal(t, "ALERT_NIL_BODY", result[0].ID, "alert ID should be preserved")
+	assert.Equal(t, "", result[0].Name, "name should be empty when body is nil")
+	assert.Equal(t, "", result[0].Link, "link should be empty when body is nil")
+	assert.Equal(t, "", result[0].Cluster, "cluster should be empty when body is nil")
+	assert.Nil(t, result[0].Details, "details should be nil when body is nil")
+	assert.Equal(t, "Test Service", result[0].Service, "service summary should be preserved")
+}
+
 func TestAddNoteTemplate(t *testing.T) {
 	tests := []struct {
 		name             string


### PR DESCRIPTION
## Summary

- Add 3 config validation tests: invalid escalation policy type (string instead of map), deprecated key detection (no error for "shell"), and case-sensitive escalation key lookup (missing required inner keys)
- Add 3 stateShorthand tests: triggered (dot), acknowledged by user ("A"), acknowledged by other ("a")
- Add 5 view/render tests: renderFooter refresh status, renderBottomStatus incident ID and GitSHA, summarizeAlerts empty input, and summarizeAlerts nil body safety

## Test plan

- [x] All new tests pass via `make test`
- [x] `make fmt-check` passes
- [x] `make vet` passes
- [x] No regressions in existing tests across all packages

Generated with [Claude Code](https://claude.com/claude-code)