### PR TITLE
Add flatpak-spawn --env= flags for toolbox env var passing

### DIFF
--- a/docs/plans/044-toolbox-env-var-passing.md
+++ b/docs/plans/044-toolbox-env-var-passing.md
@@ -1,0 +1,70 @@
+# Plan 044: Toolbox Environment Variable Passing
+
+## Problem
+
+When running inside a Fedora Toolbox container, `exec.Cmd.Env` does not
+propagate environment variables to the host process launched via
+`flatpak-spawn --host`. This means PAGERDUTY_* env vars were lost for
+non-ocm-container flows (e.g., `ocm backplane login`).
+
+Additionally, the original implementation (#185) added BOTH `--env=` flags
+on flatpak-spawn AND `-e` flags on ocm-container, which was redundant.
+
+## Solution
+
+Implement three-way flow detection in `login()` based on the command being
+executed:
+
+1. **ocm-container flow**: Use `-e` flags only. These are ocm-container CLI
+   arguments that get passed through to podman. Detected by checking if any
+   element of the command contains "ocm-container".
+
+2. **Non-ocm-container flow in toolbox**: Use `--env=` flags on
+   flatpak-spawn only. The `--env=` flags cause flatpak-spawn to set
+   environment variables on the host process it spawns. Detected by
+   `launcher.IsToolbox()` returning true and no ocm-container in the command.
+
+3. **Non-ocm-container flow NOT in toolbox**: Use `exec.Cmd.Env` to set
+   environment variables on the spawned process directly.
+
+## Changes
+
+### pkg/launcher/launcher.go
+- Added `IsToolbox()` method to expose toolbox detection state
+- Added `ToolboxEnvFlags()` method to convert `-e KEY=VALUE` pairs to
+  `--env=KEY=VALUE` flags for flatpak-spawn
+- Added `InsertToolboxEnvFlags()` function to insert `--env=` flags at the
+  correct position in the command (after `--host` but before terminal command)
+
+### pkg/tui/commands.go
+- Added `commandContainsOCMContainer()` helper to detect ocm-container flow
+- Added `insertOCMContainerEnvFlags()` to insert `-e` flags after the
+  ocm-container argument in the command
+- Added `extractEnvVarPairs()` to extract `KEY=VALUE` strings from
+  `["-e", "KEY=VALUE", ...]` pairs for `exec.Cmd.Env`
+- Modified `login()` to use three-way flow detection instead of always
+  inserting `-e` flags
+
+### Tests
+
+#### pkg/tui/commands_test.go
+- `TestCommandContainsOCMContainer_True` - ocm-container detected in various
+  command structures
+- `TestCommandContainsOCMContainer_False` - non-ocm-container commands
+- `TestExtractEnvVarPairs` - correct extraction of KEY=VALUE pairs
+- `TestInsertOCMContainerEnvFlags` - correct insertion position
+
+#### pkg/launcher/launcher_test.go
+- `TestIsToolbox` - IsToolbox() returns correct value
+- `TestToolboxEnvFlags_AddsEnvFlags` - correct conversion to --env= format
+- `TestToolboxEnvFlags_NoFlagsWhenNotToolbox` - returns nil when not in toolbox
+- `TestToolboxEnvFlags_EmptyEnvFlags` - handles empty input
+- `TestToolboxEnvFlags_NilEnvFlags` - handles nil input
+- `TestToolboxEnvFlags_OddLengthEnvFlags` - graceful handling of malformed input
+- `TestInsertToolboxEnvFlags_PositionAfterFlatpakSpawn` - correct insertion
+- `TestInsertToolboxEnvFlags_EmptyFlags` - no-op with empty flags
+- `TestInsertToolboxEnvFlags_NoFlatpakSpawn` - no-op without flatpak-spawn
+
+## Post-mortem / Lessons Learned
+
+(To be filled after PR review and merge)

--- a/pkg/launcher/launcher.go
+++ b/pkg/launcher/launcher.go
@@ -74,6 +74,62 @@ func resolveToolboxMode(mode string, detectFn func() bool) bool {
 	}
 }
 
+// IsToolbox returns whether this launcher is configured to run inside a
+// Fedora Toolbox container, meaning commands are prefixed with flatpak-spawn.
+func (l *ClusterLauncher) IsToolbox() bool {
+	return l.runInToolbox
+}
+
+// ToolboxEnvFlags converts a slice of "-e", "VAR=VALUE" pairs (the format
+// produced by buildPagerDutyEnvVars) into "--env=VAR=VALUE" flags suitable
+// for flatpak-spawn. Returns nil if the launcher is not in toolbox mode,
+// or if envFlags is nil/empty.
+func (l *ClusterLauncher) ToolboxEnvFlags(envFlags []string) []string {
+	if !l.runInToolbox {
+		return nil
+	}
+	if len(envFlags) == 0 {
+		return nil
+	}
+
+	var toolboxFlags []string
+	for i := 0; i < len(envFlags)-1; i += 2 {
+		if envFlags[i] == "-e" {
+			toolboxFlags = append(toolboxFlags, fmt.Sprintf("--env=%s", envFlags[i+1]))
+		}
+	}
+	return toolboxFlags
+}
+
+// InsertToolboxEnvFlags inserts --env= flags into a command slice at the
+// correct position for flatpak-spawn: after "flatpak-spawn" and "--host"
+// but before the terminal command. Returns the original command if no
+// flatpak-spawn is found or toolboxFlags is empty.
+func InsertToolboxEnvFlags(command []string, toolboxFlags []string) []string {
+	if len(toolboxFlags) == 0 {
+		return command
+	}
+
+	// Find the insertion point: right after "--host" in the flatpak-spawn prefix
+	insertIdx := -1
+	for i, arg := range command {
+		if arg == "--host" {
+			insertIdx = i + 1
+			break
+		}
+	}
+
+	if insertIdx < 0 || insertIdx > len(command) {
+		return command
+	}
+
+	result := make([]string, 0, len(command)+len(toolboxFlags))
+	result = append(result, command[:insertIdx]...)
+	result = append(result, toolboxFlags...)
+	result = append(result, command[insertIdx:]...)
+	return result
+}
+
 func (l *ClusterLauncher) validate() error {
 	errs := []error{}
 

--- a/pkg/launcher/launcher_test.go
+++ b/pkg/launcher/launcher_test.go
@@ -117,6 +117,105 @@ func TestBuildLoginCommand_ToolboxWrappingWithTmux(t *testing.T) {
 	assert.Equal(t, expected, cmd, "toolbox wrapping should work with tmux terminal commands")
 }
 
+func TestIsToolbox(t *testing.T) {
+	tests := []struct {
+		name     string
+		toolbox  bool
+		expected bool
+	}{
+		{"toolbox mode on", true, true},
+		{"toolbox mode off", false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := ClusterLauncher{
+				terminal:            []string{"gnome-terminal", "--"},
+				clusterLoginCommand: []string{"ocm-container", "-C", "%%CLUSTER_ID%%"},
+				runInToolbox:        tt.toolbox,
+			}
+			assert.Equal(t, tt.expected, l.IsToolbox())
+		})
+	}
+}
+
+func TestToolboxEnvFlags_AddsEnvFlags(t *testing.T) {
+	l := ClusterLauncher{
+		terminal:            []string{"gnome-terminal", "--"},
+		clusterLoginCommand: []string{"ocm-container", "-C", "%%CLUSTER_ID%%"},
+		runInToolbox:        true,
+	}
+	envFlags := []string{"-e", "KEY1=val1", "-e", "KEY2=val2"}
+	result := l.ToolboxEnvFlags(envFlags)
+	expected := []string{"--env=KEY1=val1", "--env=KEY2=val2"}
+	assert.Equal(t, expected, result)
+}
+
+func TestToolboxEnvFlags_NoFlagsWhenNotToolbox(t *testing.T) {
+	l := ClusterLauncher{
+		terminal:            []string{"gnome-terminal", "--"},
+		clusterLoginCommand: []string{"ocm-container", "-C", "%%CLUSTER_ID%%"},
+		runInToolbox:        false,
+	}
+	envFlags := []string{"-e", "KEY1=val1", "-e", "KEY2=val2"}
+	result := l.ToolboxEnvFlags(envFlags)
+	assert.Nil(t, result)
+}
+
+func TestToolboxEnvFlags_EmptyEnvFlags(t *testing.T) {
+	l := ClusterLauncher{
+		terminal:            []string{"gnome-terminal", "--"},
+		clusterLoginCommand: []string{"ocm-container", "-C", "%%CLUSTER_ID%%"},
+		runInToolbox:        true,
+	}
+	result := l.ToolboxEnvFlags([]string{})
+	assert.Nil(t, result)
+}
+
+func TestToolboxEnvFlags_NilEnvFlags(t *testing.T) {
+	l := ClusterLauncher{
+		terminal:            []string{"gnome-terminal", "--"},
+		clusterLoginCommand: []string{"ocm-container", "-C", "%%CLUSTER_ID%%"},
+		runInToolbox:        true,
+	}
+	result := l.ToolboxEnvFlags(nil)
+	assert.Nil(t, result)
+}
+
+func TestToolboxEnvFlags_OddLengthEnvFlags(t *testing.T) {
+	l := ClusterLauncher{
+		terminal:            []string{"gnome-terminal", "--"},
+		clusterLoginCommand: []string{"ocm-container", "-C", "%%CLUSTER_ID%%"},
+		runInToolbox:        true,
+	}
+	// Odd-length slice: trailing "-e" without a value should be ignored
+	envFlags := []string{"-e", "KEY1=val1", "-e"}
+	result := l.ToolboxEnvFlags(envFlags)
+	expected := []string{"--env=KEY1=val1"}
+	assert.Equal(t, expected, result)
+}
+
+func TestInsertToolboxEnvFlags_PositionAfterFlatpakSpawn(t *testing.T) {
+	command := []string{"flatpak-spawn", "--host", "gnome-terminal", "--", "ocm", "backplane", "login", "abc123"}
+	toolboxFlags := []string{"--env=KEY1=val1", "--env=KEY2=val2"}
+	result := InsertToolboxEnvFlags(command, toolboxFlags)
+	expected := []string{"flatpak-spawn", "--host", "--env=KEY1=val1", "--env=KEY2=val2", "gnome-terminal", "--", "ocm", "backplane", "login", "abc123"}
+	assert.Equal(t, expected, result)
+}
+
+func TestInsertToolboxEnvFlags_EmptyFlags(t *testing.T) {
+	command := []string{"flatpak-spawn", "--host", "gnome-terminal", "--", "ocm", "backplane", "login"}
+	result := InsertToolboxEnvFlags(command, []string{})
+	assert.Equal(t, command, result)
+}
+
+func TestInsertToolboxEnvFlags_NoFlatpakSpawn(t *testing.T) {
+	// No --host in command; should return command unchanged
+	command := []string{"gnome-terminal", "--", "ocm-container", "-C", "abc123"}
+	toolboxFlags := []string{"--env=KEY=val"}
+	result := InsertToolboxEnvFlags(command, toolboxFlags)
+	assert.Equal(t, command, result)
+}
+
 func TestClusterLauncherValidation(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -497,76 +497,106 @@ func buildPagerDutyEnvVars(incident *pagerduty.Incident, alerts []pagerduty.Inci
 	return envFlags
 }
 
-func login(vars map[string]string, launcher launcher.ClusterLauncher, incident *pagerduty.Incident, alerts []pagerduty.IncidentAlert, notes []pagerduty.IncidentNote) tea.Cmd {
+// commandContainsOCMContainer returns true if any element of the command
+// slice contains "ocm-container", indicating this is an ocm-container flow
+// where -e flags should be passed directly as container arguments.
+func commandContainsOCMContainer(command []string) bool {
+	for _, arg := range command {
+		if strings.Contains(arg, "ocm-container") {
+			return true
+		}
+	}
+	return false
+}
+
+// insertOCMContainerEnvFlags inserts -e env flags into a command at the
+// correct position for ocm-container: after the ocm-container command itself
+// but before its other arguments (like --cluster-id).
+func insertOCMContainerEnvFlags(command []string, envFlags []string) []string {
+	if len(envFlags) == 0 {
+		return command
+	}
+
+	// Find the ocm-container argument in the command slice
+	ocmIdx := -1
+	for i, arg := range command {
+		if strings.Contains(arg, "ocm-container") {
+			ocmIdx = i
+			break
+		}
+	}
+
+	log.Debug("tui.insertOCMContainerEnvFlags()", "ocmIdx", ocmIdx, "commandLen", len(command))
+
+	if ocmIdx < 0 {
+		// No ocm-container found; return command unchanged
+		return command
+	}
+
+	// Insert env flags right after the ocm-container argument
+	insertIdx := ocmIdx + 1
+	result := make([]string, 0, len(command)+len(envFlags))
+	result = append(result, command[:insertIdx]...)
+	result = append(result, envFlags...)
+	result = append(result, command[insertIdx:]...)
+
+	return result
+}
+
+// extractEnvVarPairs extracts "KEY=VALUE" strings from a slice of
+// ["-e", "KEY=VALUE", "-e", "KEY2=VALUE2", ...] pairs. It skips the "-e"
+// elements and returns only the environment variable assignments, suitable
+// for setting on exec.Cmd.Env.
+func extractEnvVarPairs(envFlags []string) []string {
+	var pairs []string
+	for i := 0; i < len(envFlags)-1; i += 2 {
+		if envFlags[i] == "-e" {
+			pairs = append(pairs, envFlags[i+1])
+		}
+	}
+	return pairs
+}
+
+func login(vars map[string]string, l launcher.ClusterLauncher, incident *pagerduty.Incident, alerts []pagerduty.IncidentAlert, notes []pagerduty.IncidentNote) tea.Cmd {
 	// The first element of Terminal is the command to be executed, followed by args, in order
 	// This handles if folks use, eg: flatpak run <some package> as a terminal.
-	command := launcher.BuildLoginCommand(vars)
+	command := l.BuildLoginCommand(vars)
 
 	// Build individual PAGERDUTY_* environment variables filtered to the selected cluster
 	clusterID := vars["%%CLUSTER_ID%%"]
 	envFlags := buildPagerDutyEnvVars(incident, alerts, notes, clusterID)
 
-	// Insert env flags into command
-	// We need to find the position after any terminal separator (like "--") but before ocm-container
-	// Typical command structure: ["gnome-terminal", "--", "ocm-container", "--cluster-id", "ABC123"]
-	// We want: ["gnome-terminal", "--", "ocm-container", "-e", "VAR=val", "--cluster-id", "ABC123"]
+	// Determine the correct env var passing mechanism based on the command flow:
+	// 1. ocm-container flow: use -e flags (they become podman -e flags)
+	// 2. Non-ocm-container in toolbox: use --env= flags on flatpak-spawn
+	// 3. Non-ocm-container, not in toolbox: set on exec.Cmd.Env
 
-	finalCommand := []string{}
-	separatorFound := false
-	insertPosition := -1
+	var finalCommand []string
+	var processEnvVars []string // Only used for the exec.Cmd.Env case
 
-	// Find the position right after "--" separator or at the start of the actual command
-	for i, arg := range command {
-		if arg == "--" {
-			separatorFound = true
-			insertPosition = i + 1
-			break
-		}
-	}
-
-	// If no separator found, look for the actual command (ocm-container, ocm, etc)
-	if !separatorFound {
-		for i, arg := range command {
-			// Skip the first element (terminal command) and find the first non-flag argument
-			if i > 0 && !strings.HasPrefix(arg, "-") {
-				insertPosition = i
-				break
-			}
-		}
-	}
-
-	// Build the final command
-	log.Debug("tui.login(): building final command", "insertPosition", insertPosition, "separatorFound", separatorFound, "commandLen", len(command))
-
-	if insertPosition > 0 && len(envFlags) > 0 {
-		// Insert env flags at the correct position
-		finalCommand = append(finalCommand, command[:insertPosition]...)
-		log.Debug("tui.login(): added prefix", "finalCommand", finalCommand)
-
-		// Check if the next argument is the actual command (like "ocm-container")
-		// If so, add it first, then the env flags
-		if insertPosition < len(command) && !strings.HasPrefix(command[insertPosition], "-") {
-			log.Debug("tui.login(): found command at insertPosition", "command", command[insertPosition])
-			finalCommand = append(finalCommand, command[insertPosition])
-			finalCommand = append(finalCommand, envFlags...)
-			log.Debug("tui.login(): added command and env flags", "finalCommand", finalCommand)
-			if insertPosition+1 < len(command) {
-				finalCommand = append(finalCommand, command[insertPosition+1:]...)
-				log.Debug("tui.login(): added remaining args", "finalCommand", finalCommand)
-			}
-		} else {
-			// Otherwise just insert the env flags here
-			log.Debug("tui.login(): inserting env flags directly")
-			finalCommand = append(finalCommand, envFlags...)
-			finalCommand = append(finalCommand, command[insertPosition:]...)
-		}
+	if commandContainsOCMContainer(command) {
+		// ocm-container flow: insert -e flags into the command for ocm-container
+		finalCommand = insertOCMContainerEnvFlags(command, envFlags)
+		log.Debug("tui.login(): ocm-container flow", "finalCommand", finalCommand)
+	} else if l.IsToolbox() {
+		// Non-ocm-container in toolbox: use --env= flags on flatpak-spawn
+		// so that the host process launched via flatpak-spawn inherits them
+		toolboxFlags := l.ToolboxEnvFlags(envFlags)
+		finalCommand = launcher.InsertToolboxEnvFlags(command, toolboxFlags)
+		log.Debug("tui.login(): toolbox non-ocm-container flow", "toolboxFlags", toolboxFlags, "finalCommand", finalCommand)
 	} else {
-		// No separator found or no env flags, use command as-is
-		log.Debug("tui.login(): using command as-is", "insertPosition", insertPosition, "envFlagsLen", len(envFlags))
+		// Non-ocm-container, not in toolbox: set env vars on the process directly
 		finalCommand = command
+		processEnvVars = extractEnvVarPairs(envFlags)
+		log.Debug("tui.login(): direct process env flow", "processEnvVars", processEnvVars, "finalCommand", finalCommand)
 	}
 
 	c := exec.Command(finalCommand[0], finalCommand[1:]...)
+
+	// For the non-ocm-container, non-toolbox case, set env vars on the process
+	if len(processEnvVars) > 0 {
+		c.Env = append(os.Environ(), processEnvVars...)
+	}
 
 	log.Debug("tui.login(): original command", "command", command)
 	log.Debug("tui.login(): env flags", "envFlags", envFlags)

--- a/pkg/tui/commands_test.go
+++ b/pkg/tui/commands_test.go
@@ -1134,6 +1134,142 @@ func TestGetUniqueClusters_MixedWithAndWithoutClusterID(t *testing.T) {
 	assert.Equal(t, []string{"cluster-abc-123", "cluster-def-456"}, result)
 }
 
+func TestCommandContainsOCMContainer_True(t *testing.T) {
+	tests := []struct {
+		name    string
+		command []string
+	}{
+		{
+			name:    "direct ocm-container command",
+			command: []string{"ocm-container", "--cluster-id", "abc123"},
+		},
+		{
+			name:    "gnome-terminal with ocm-container",
+			command: []string{"gnome-terminal", "--", "ocm-container", "-C", "abc123"},
+		},
+		{
+			name:    "flatpak-spawn with ocm-container",
+			command: []string{"flatpak-spawn", "--host", "gnome-terminal", "--", "ocm-container", "-C", "abc123"},
+		},
+		{
+			name:    "tmux with ocm-container",
+			command: []string{"tmux", "new-window", "-n", "cluster", "ocm-container", "-C", "abc123"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.True(t, commandContainsOCMContainer(tt.command), "expected true for command containing ocm-container")
+		})
+	}
+}
+
+func TestCommandContainsOCMContainer_False(t *testing.T) {
+	tests := []struct {
+		name    string
+		command []string
+	}{
+		{
+			name:    "ocm backplane login",
+			command: []string{"gnome-terminal", "--", "ocm", "backplane", "login", "abc123"},
+		},
+		{
+			name:    "direct ocm command",
+			command: []string{"ocm", "backplane", "login", "abc123"},
+		},
+		{
+			name:    "empty command",
+			command: []string{},
+		},
+		{
+			name:    "nil command",
+			command: nil,
+		},
+		{
+			name:    "flatpak-spawn without ocm-container",
+			command: []string{"flatpak-spawn", "--host", "gnome-terminal", "--", "ocm", "backplane", "login", "abc123"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.False(t, commandContainsOCMContainer(tt.command), "expected false for command without ocm-container")
+		})
+	}
+}
+
+func TestExtractEnvVarPairs(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "normal pairs",
+			input:    []string{"-e", "KEY1=val1", "-e", "KEY2=val2"},
+			expected: []string{"KEY1=val1", "KEY2=val2"},
+		},
+		{
+			name:     "single pair",
+			input:    []string{"-e", "SINGLE=value"},
+			expected: []string{"SINGLE=value"},
+		},
+		{
+			name:     "empty input",
+			input:    []string{},
+			expected: nil,
+		},
+		{
+			name:     "nil input",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "odd length skips trailing",
+			input:    []string{"-e", "KEY=val", "-e"},
+			expected: []string{"KEY=val"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractEnvVarPairs(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestInsertOCMContainerEnvFlags(t *testing.T) {
+	tests := []struct {
+		name     string
+		command  []string
+		envFlags []string
+		expected []string
+	}{
+		{
+			name:     "gnome-terminal with separator and ocm-container",
+			command:  []string{"gnome-terminal", "--", "ocm-container", "--cluster-id", "abc123"},
+			envFlags: []string{"-e", "KEY=val"},
+			expected: []string{"gnome-terminal", "--", "ocm-container", "-e", "KEY=val", "--cluster-id", "abc123"},
+		},
+		{
+			name:     "tmux with ocm-container no separator",
+			command:  []string{"tmux", "new-window", "ocm-container", "-C", "abc123"},
+			envFlags: []string{"-e", "KEY=val"},
+			expected: []string{"tmux", "new-window", "ocm-container", "-e", "KEY=val", "-C", "abc123"},
+		},
+		{
+			name:     "empty env flags returns command as-is",
+			command:  []string{"gnome-terminal", "--", "ocm-container", "--cluster-id", "abc123"},
+			envFlags: []string{},
+			expected: []string{"gnome-terminal", "--", "ocm-container", "--cluster-id", "abc123"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := insertOCMContainerEnvFlags(tt.command, tt.envFlags)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestSanitizeEnvValue(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary

Implements three-way flow detection for passing PAGERDUTY_* environment variables through different execution contexts:

1. **ocm-container flow** (detected by `ocm-container` in command): Uses `-e VAR=val` flags only — these are ocm-container CLI arguments passed to podman
2. **Non-ocm-container in toolbox** (detected by `launcher.IsToolbox()`): Uses `--env=VAR=val` flags on `flatpak-spawn` only — env vars don't cross the flatpak-spawn boundary without explicit `--env=` flags
3. **Non-ocm-container, not in toolbox**: Uses `exec.Cmd.Env` — standard process environment inheritance

### Why not both?
Previously this PR added BOTH `--env=` and `-e` flags redundantly. The ocm-container doesn't need `--env=` (it reads its own `-e` CLI args). Plain terminals don't need `-e` (they inherit process env). Each flow now uses only the appropriate mechanism.

### New functions
- `commandContainsOCMContainer()` — detects ocm-container in command
- `insertOCMContainerEnvFlags()` — inserts `-e` flags after ocm-container arg
- `extractEnvVarPairs()` — extracts `KEY=VALUE` from `["-e", "KEY=VALUE", ...]` for `Cmd.Env`
- `ToolboxEnvFlags()` / `InsertToolboxEnvFlags()` — convert and insert `--env=` flags

## Test plan
- [x] `TestCommandContainsOCMContainer_True/False`
- [x] `TestToolboxEnvFlags` conversion
- [x] `TestInsertToolboxEnvFlags` positioning
- [x] All tests pass locally (`go test ./... -count=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)