### PR TITLE
Clean up alert display in incident detail view

### DIFF
--- a/docs/plans/045-alert-view-cleanup.md
+++ b/docs/plans/045-alert-view-cleanup.md
@@ -1,0 +1,70 @@
+# Plan 045: Alert View Cleanup
+
+## Problem
+
+The incident detail view renders every field from the PagerDuty alert body
+unfiltered, creating 15-30 lines of noise per alert. The essential information
+(alert name, cluster, SOP link) is already extracted into named fields but gets
+buried under a raw `Details` dump. URLs appear as plain text instead of
+clickable markdown links that glamour can render as OSC 8 hyperlinks.
+
+## Analysis
+
+A review of 2,044 PagerDuty incidents identified 6 alert types with different
+data structures. The current template iterates over `$alert.Details` (the full
+`body["details"]` map), dumping every key-value pair. The useful fields --
+`alert_name`, `cluster_id`, and `link` -- are already extracted by
+`summarizeAlerts()` into dedicated struct fields (`Name`, `Cluster`, `Link`).
+
+The `ToLink` template function already exists and is used for the incident
+title. It produces `[text](url)` markdown that glamour renders as clickable
+terminal hyperlinks.
+
+## Changes
+
+### Template (`incidentTemplate` in `pkg/tui/views.go`)
+
+- Remove the entire `Details :` section and its `{{ range }}` over
+  `$alert.Details`
+- Replace the raw alert ID/status/URL block with a `###` heading using the
+  alert name (falling back to alert ID when name is empty)
+- Format SOP link using `ToLink` with `_none_` fallback for missing SOPs
+- Format PagerDuty alert URL using `ToLink`
+- Reorder fields: alert name heading first, then cluster, SOP, alert link,
+  service, created
+
+### Struct cleanup (`alertSummary` in `pkg/tui/views.go`)
+
+- Remove the `Details map[string]interface{}` field from `alertSummary` since
+  nothing else references it after the template change
+- Remove the Details extraction code from `summarizeAlerts()`
+
+### Tests (`pkg/tui/views_test.go`)
+
+- `TestIncidentTemplate_AlertRendersAsMarkdownLink` -- verifies SOP and alert
+  URLs render as `[text](url)` format
+- `TestIncidentTemplate_AlertRendersSOPNoneWhenMissing` -- verifies `_none_`
+  shown when SOP link is empty
+- `TestIncidentTemplate_NoDetailsSection` -- verifies no "Details" text in
+  output
+- `TestIncidentTemplate_AlertNameAsHeading` -- verifies `###` heading format
+- `TestIncidentTemplate_AlertWithEmptyName` -- verifies fallback to alert ID
+  when name is empty
+- `TestSummarizeAlerts_NoDetailsField` -- verifies extraction still works
+  without Details field
+
+## What is NOT changed
+
+- The `summarizeAlerts()` extraction of `Name`, `Cluster`, `Link` fields
+- The incident header section (title, service, urgency, etc.)
+- The notes section
+- The `ToLink` or other template functions
+- The `getDetailFieldFromAlert` helper function
+- Backward compatibility with alerts missing Name, Link, or Cluster
+
+## Testing
+
+- TDD approach: tests written first, verified to fail against old template,
+  then implementation made to pass
+- All existing tests continue to pass
+- `go vet` and `gofmt` clean

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -428,7 +428,6 @@ type alertSummary struct {
 	Created  string
 	Status   string
 	Incident string
-	Details  map[string]interface{}
 	Cluster  string
 }
 
@@ -443,13 +442,6 @@ func summarizeAlerts(a []pagerduty.IncidentAlert) []alertSummary {
 		cluster := getDetailFieldFromAlert("cluster_id", alt)
 		link := getDetailFieldFromAlert("link", alt)
 
-		var details map[string]interface{}
-		if alt.Body != nil {
-			if d, ok := alt.Body["details"].(map[string]interface{}); ok {
-				details = d
-			}
-		}
-
 		s = append(s, alertSummary{
 			ID:       alt.ID,
 			Name:     name,
@@ -460,7 +452,6 @@ func summarizeAlerts(a []pagerduty.IncidentAlert) []alertSummary {
 			Created:  alt.CreatedAt,
 			Status:   alt.Status,
 			Incident: alt.Incident.ID,
-			Details:  details,
 		})
 
 	}
@@ -578,22 +569,13 @@ _none_
 _Loading alerts..._
 {{ else }}
 {{ range $alert := .Alerts }}
-{{ $alert.ID }} - {{ $alert.Status }}
-{{ if $alert.Name }}
-_{{- $alert.Name }}_
-{{- end }}
-{{ $alert.HTMLURL }}
+### {{ if $alert.Name }}{{ $alert.Name }}{{ else }}{{ $alert.ID }}{{ end }} ({{ $alert.Status }})
 
 * Cluster: {{ $alert.Cluster }}
+* SOP: {{ if $alert.Link }}{{ ToLink "SOP" $alert.Link }}{{ else }}_none_{{ end }}
+* Alert: {{ ToLink $alert.ID $alert.HTMLURL }}
 * Service: {{ $alert.Service }}
 * Created: {{ $alert.Created }}
-* SOP: {{ $alert.Link }}
-
-Details :
-
-{{ range $key, $value := $alert.Details }}
-* {{ $key }}: {{ $value }}
-{{ end }}
 
 {{ end }}
 {{ end }}

--- a/pkg/tui/views_test.go
+++ b/pkg/tui/views_test.go
@@ -1,10 +1,13 @@
 package tui
 
 import (
+	"bytes"
+	"html/template"
 	"testing"
 
 	"github.com/PagerDuty/go-pagerduty"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAssigneeArea(t *testing.T) {
@@ -369,4 +372,206 @@ func TestAddNoteTemplate(t *testing.T) {
 			}
 		})
 	}
+}
+
+// renderTestTemplate is a helper that executes the incidentTemplate with funcMap
+// against the given incidentSummary and returns the rendered string.
+func renderTestTemplate(t *testing.T, summary incidentSummary) string {
+	t.Helper()
+	tmpl, err := template.New("incident").Funcs(funcMap).Parse(incidentTemplate)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, summary)
+	require.NoError(t, err)
+
+	return buf.String()
+}
+
+func TestIncidentTemplate_AlertRendersAsMarkdownLink(t *testing.T) {
+	summary := incidentSummary{
+		ID:           "INC001",
+		Title:        "Test Incident",
+		HTMLURL:      "https://example.pagerduty.com/incidents/INC001",
+		Service:      "Test Service",
+		Urgency:      "high",
+		Created:      "2025-01-01T00:00:00Z",
+		Status:       "triggered",
+		Acknowledged: []string{"SRE User"},
+		Alerts: []alertSummary{
+			{
+				ID:      "ALERT001",
+				Name:    "ClusterOperatorDown",
+				Link:    "https://example.com/sop/cluster-operator-down",
+				HTMLURL: "https://example.pagerduty.com/alerts/ALERT001",
+				Service: "Alert Service",
+				Created: "2025-01-01T00:00:00Z",
+				Status:  "triggered",
+				Cluster: "abc-123-def",
+			},
+		},
+	}
+
+	result := renderTestTemplate(t, summary)
+
+	// SOP should render as a markdown link using ToLink
+	assert.Contains(t, result, "[SOP](https://example.com/sop/cluster-operator-down)")
+
+	// Alert PD URL should render as a markdown link using ToLink
+	assert.Contains(t, result, "[ALERT001](https://example.pagerduty.com/alerts/ALERT001)")
+}
+
+func TestIncidentTemplate_AlertRendersSOPNoneWhenMissing(t *testing.T) {
+	summary := incidentSummary{
+		ID:           "INC002",
+		Title:        "Test Incident No SOP",
+		HTMLURL:      "https://example.pagerduty.com/incidents/INC002",
+		Service:      "Test Service",
+		Urgency:      "high",
+		Created:      "2025-01-01T00:00:00Z",
+		Status:       "triggered",
+		Acknowledged: []string{"SRE User"},
+		Alerts: []alertSummary{
+			{
+				ID:      "ALERT002",
+				Name:    "SomeAlert",
+				Link:    "",
+				HTMLURL: "https://example.pagerduty.com/alerts/ALERT002",
+				Service: "Alert Service",
+				Created: "2025-01-01T00:00:00Z",
+				Status:  "triggered",
+				Cluster: "xyz-789",
+			},
+		},
+	}
+
+	result := renderTestTemplate(t, summary)
+
+	// When Link is empty, SOP should show _none_
+	assert.Contains(t, result, "_none_")
+	// Should NOT contain an empty SOP link
+	assert.NotContains(t, result, "[SOP]()")
+}
+
+func TestIncidentTemplate_NoDetailsSection(t *testing.T) {
+	summary := incidentSummary{
+		ID:           "INC003",
+		Title:        "Test Incident",
+		HTMLURL:      "https://example.pagerduty.com/incidents/INC003",
+		Service:      "Test Service",
+		Urgency:      "high",
+		Created:      "2025-01-01T00:00:00Z",
+		Status:       "triggered",
+		Acknowledged: []string{"SRE User"},
+		Alerts: []alertSummary{
+			{
+				ID:      "ALERT003",
+				Name:    "TestAlert",
+				Link:    "https://example.com/sop",
+				HTMLURL: "https://example.pagerduty.com/alerts/ALERT003",
+				Service: "Alert Service",
+				Created: "2025-01-01T00:00:00Z",
+				Status:  "triggered",
+				Cluster: "cluster-id",
+			},
+		},
+	}
+
+	result := renderTestTemplate(t, summary)
+
+	// The rendered output should NOT contain a "Details" section
+	assert.NotContains(t, result, "Details")
+}
+
+func TestIncidentTemplate_AlertNameAsHeading(t *testing.T) {
+	summary := incidentSummary{
+		ID:           "INC004",
+		Title:        "Test Incident",
+		HTMLURL:      "https://example.pagerduty.com/incidents/INC004",
+		Service:      "Test Service",
+		Urgency:      "high",
+		Created:      "2025-01-01T00:00:00Z",
+		Status:       "triggered",
+		Acknowledged: []string{"SRE User"},
+		Alerts: []alertSummary{
+			{
+				ID:      "ALERT004",
+				Name:    "KubePersistentVolumeFillingUp",
+				Link:    "https://example.com/sop",
+				HTMLURL: "https://example.pagerduty.com/alerts/ALERT004",
+				Service: "Alert Service",
+				Created: "2025-01-01T00:00:00Z",
+				Status:  "triggered",
+				Cluster: "cluster-id",
+			},
+		},
+	}
+
+	result := renderTestTemplate(t, summary)
+
+	// Alert name should appear as a ### heading
+	assert.Contains(t, result, "### KubePersistentVolumeFillingUp (triggered)")
+}
+
+func TestIncidentTemplate_AlertWithEmptyName(t *testing.T) {
+	summary := incidentSummary{
+		ID:           "INC005",
+		Title:        "Test Incident",
+		HTMLURL:      "https://example.pagerduty.com/incidents/INC005",
+		Service:      "Test Service",
+		Urgency:      "high",
+		Created:      "2025-01-01T00:00:00Z",
+		Status:       "triggered",
+		Acknowledged: []string{"SRE User"},
+		Alerts: []alertSummary{
+			{
+				ID:      "ALERT005",
+				Name:    "",
+				Link:    "",
+				HTMLURL: "https://example.pagerduty.com/alerts/ALERT005",
+				Service: "Alert Service",
+				Created: "2025-01-01T00:00:00Z",
+				Status:  "triggered",
+				Cluster: "",
+			},
+		},
+	}
+
+	result := renderTestTemplate(t, summary)
+
+	// Should still render gracefully with empty fields
+	// The heading should fall back to the alert ID when Name is empty
+	assert.Contains(t, result, "### ALERT005 (triggered)")
+	// Should contain _none_ for SOP
+	assert.Contains(t, result, "_none_")
+}
+
+func TestSummarizeAlerts_NoDetailsField(t *testing.T) {
+	alerts := []pagerduty.IncidentAlert{
+		{
+			APIObject: pagerduty.APIObject{
+				ID:      "ALERT001",
+				HTMLURL: "https://example.pagerduty.com/alerts/ALERT001",
+			},
+			Service: pagerduty.APIObject{Summary: "Test Service"},
+			Status:  "triggered",
+			Body: map[string]interface{}{
+				"details": map[string]interface{}{
+					"cluster_id": "abc-123",
+					"alert_name": "TestAlert",
+					"link":       "https://example.com/sop",
+					"extra_key":  "extra_value",
+				},
+			},
+			Incident: pagerduty.APIReference{ID: "INC001"},
+		},
+	}
+
+	result := summarizeAlerts(alerts)
+
+	assert.Len(t, result, 1)
+	assert.Equal(t, "ALERT001", result[0].ID)
+	assert.Equal(t, "TestAlert", result[0].Name)
+	assert.Equal(t, "abc-123", result[0].Cluster)
+	assert.Equal(t, "https://example.com/sop", result[0].Link)
 }


### PR DESCRIPTION
## Summary

- Remove the noisy `Details :` dump from the incident template that rendered 15-30 lines of raw key-value pairs per alert -- the essential fields (alert name, cluster, SOP link) are already extracted into named struct fields
- Format SOP and alert URLs as clickable markdown links using the existing `ToLink` template function (glamour renders these as OSC 8 hyperlinks in modern terminals)
- Use `###` heading with alert name (or alert ID fallback) instead of raw ID line, and show `_none_` for missing SOP links
- Remove the unused `Details` field from `alertSummary` struct

## Test plan

- [x] Write tests first (TDD red phase) -- 4 of 6 new tests fail against old template
- [x] Implement template and struct changes -- all 6 new tests pass (TDD green phase)
- [x] Full test suite passes (`go test ./... -count=1`)
- [x] `go vet` clean
- [x] `gofmt` clean
- [ ] Manual verification: view an incident with alerts and confirm reduced noise, clickable links

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>