### PR TITLE
Fix broken test referencing removed Details field

### DIFF
--- a/docs/plans/049-fix-broken-details-test.md
+++ b/docs/plans/049-fix-broken-details-test.md
@@ -1,0 +1,27 @@
+# 049: Fix broken test referencing removed Details field
+
+## Status: Complete
+
+## Problem
+
+PR #186 removed the `Details` field from the `alertSummary` struct in
+`pkg/tui/views.go`. PR #184 merged after #186 and re-introduced a test
+(`TestSummarizeAlerts_AlertWithNilBody`) that asserts on `result[0].Details`,
+which no longer exists. This causes a compilation failure on main.
+
+## Fix
+
+Remove the line:
+
+```go
+assert.Nil(t, result[0].Details, "details should be nil when body is nil")
+```
+
+from `pkg/tui/views_test.go` (line 410). The assertion is meaningless because
+the field was removed from the struct. No other test references the removed
+struct field.
+
+## Verification
+
+- `go test ./pkg/tui/... -v -count=1` passes
+- `go vet ./...` passes

--- a/pkg/tui/views_test.go
+++ b/pkg/tui/views_test.go
@@ -407,7 +407,6 @@ func TestSummarizeAlerts_AlertWithNilBody(t *testing.T) {
 	assert.Equal(t, "", result[0].Name, "name should be empty when body is nil")
 	assert.Equal(t, "", result[0].Link, "link should be empty when body is nil")
 	assert.Equal(t, "", result[0].Cluster, "cluster should be empty when body is nil")
-	assert.Nil(t, result[0].Details, "details should be nil when body is nil")
 	assert.Equal(t, "Test Service", result[0].Service, "service summary should be preserved")
 }
 


### PR DESCRIPTION
## Summary

**URGENT: main branch is broken -- tests fail to compile.**

- PR #186 removed the `Details` field from the `alertSummary` struct
- PR #184 merged after #186 and re-introduced a test (`TestSummarizeAlerts_AlertWithNilBody`) that asserts on `result[0].Details`
- This causes a compilation failure on main: the field no longer exists on the struct
- Fix: remove the single broken assertion line (line 410 in `views_test.go`)

## Test plan

- [x] `go test ./pkg/tui/... -v -count=1` passes
- [x] `go vet ./...` passes
- [x] No other references to the removed `Details` struct field in test files

Created with assistance from Claude <claude@anthropic.com>

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>