### PR TITLE
Add native iTerm2 and Terminal.app support via AppleScript profile

### DIFF
--- a/docs/plans/050-iterm2-support.md
+++ b/docs/plans/050-iterm2-support.md
@@ -1,0 +1,88 @@
+# Plan 050: iTerm2 and Terminal.app Native Support
+
+## Status: Implemented
+
+## Summary
+
+Adds native AppleScript-based terminal support for macOS terminals
+(iTerm2 and Terminal.app), eliminating the need for wrapper shell scripts
+documented in the README.
+
+Previously, iTerm2 users needed to create a shell script that invoked
+`osascript` to launch commands in iTerm2 windows. With this change, users
+can simply set `terminal: iterm2` in their config and srepd constructs
+the osascript command automatically.
+
+## Approach
+
+Since macOS terminals like iTerm2 and Terminal.app don't have simple
+`-e` or `--` CLI flags for launching commands, they require AppleScript
+via `osascript`. A new `AppleScriptProfile` type implements the
+`TerminalProfile` interface and constructs the appropriate osascript
+command internally.
+
+When the user sets `terminal: iterm2`, srepd builds:
+```
+osascript -e 'tell application "iTerm2" to create window with default profile command "ocm-container -C abc123"'
+```
+
+When the user sets `terminal: terminal`, srepd builds:
+```
+osascript -e 'tell application "Terminal" to do script "ocm-container -C abc123"'
+```
+
+## Files Changed
+
+- `pkg/launcher/profiles.go` -- Added `AppleScriptProfile` struct with
+  `Name()` and `BuildCommand()` methods; added `appleScriptTerminals`
+  map for case-insensitive terminal name to macOS app name mapping;
+  updated `profileForExecName()` to check AppleScript terminals first;
+  updated `validateTerminalExists()` to check for `osascript` when an
+  AppleScript terminal is configured.
+
+- `pkg/launcher/profiles_test.go` -- Added 13 tests covering detection,
+  name, build command, error handling, quoting, and validation for both
+  iTerm2 and Terminal.app.
+
+## Design Decisions
+
+- **AppleScriptProfile vs separate iTerm2Profile**: A single
+  `AppleScriptProfile` handles both iTerm2 and Terminal.app with a
+  switch on terminal name for the different AppleScript syntax. This
+  is extensible to other AppleScript-controlled terminals without
+  creating new profile types.
+
+- **Case-insensitive matching**: Users may type "iterm2", "iTerm2", or
+  "Terminal" -- all are normalized via `strings.ToLower()` for matching
+  and the correct macOS application name is stored in `appName`.
+
+- **osascript validation**: Since AppleScript terminals don't have their
+  own binary in PATH, `validateTerminalExists()` checks for `osascript`
+  instead. On Linux, this produces a warning (not an error) since the
+  user may be developing config for a macOS machine.
+
+- **No change to NewClusterLauncher flow**: The existing launcher flow
+  works correctly because `BuildLoginCommand` delegates to the profile's
+  `BuildCommand`, which returns the full osascript command. The terminal
+  name in `l.terminal[0]` is only used for logging.
+
+- **Backward compatibility**: The `alreadyHasSeparator` function returns
+  false for `AppleScriptProfile` (unmatched by the switch), so the
+  profile's `BuildCommand` is always used. Existing configurations are
+  unaffected.
+
+## Test Plan
+
+- `TestDetectProfile_ITerm2` -- "iterm2" resolves to AppleScriptProfile
+- `TestDetectProfile_ITerm2_MixedCase` -- "iTerm2" resolves correctly
+- `TestDetectProfile_TerminalApp` -- "terminal" resolves to AppleScriptProfile
+- `TestDetectProfile_TerminalApp_UpperCase` -- "Terminal" resolves correctly
+- `TestAppleScriptProfile_Name_ITerm2` -- Name() returns "applescript (iterm2)"
+- `TestAppleScriptProfile_Name_Terminal` -- Name() returns "applescript (terminal)"
+- `TestAppleScriptProfile_BuildCommand_ITerm2` -- produces osascript with iTerm2 create window syntax
+- `TestAppleScriptProfile_BuildCommand_TerminalApp` -- produces osascript with Terminal do script syntax
+- `TestAppleScriptProfile_BuildCommand_EmptyTerminalArgs` -- returns error
+- `TestAppleScriptProfile_BuildCommand_EmptyLoginCmd` -- returns error
+- `TestAppleScriptProfile_BuildCommand_ITerm2_QuotesInCommand` -- handles multi-word commands
+- `TestAppleScriptProfile_ValidateTerminal_ITerm2` -- checks for osascript, not iterm2
+- `TestAppleScriptProfile_ValidateTerminal_Terminal` -- checks for osascript, not terminal

--- a/pkg/launcher/profiles.go
+++ b/pkg/launcher/profiles.go
@@ -96,6 +96,48 @@ func (p *DirectProfile) BuildCommand(terminalArgs []string, loginCmd []string) (
 	return cmd, nil
 }
 
+// AppleScriptProfile is used by macOS terminals that must be launched
+// via osascript (iTerm2, Terminal.app). Instead of executing the
+// terminal binary directly, it constructs an osascript command with
+// the appropriate AppleScript to open a window and run the login
+// command inside it.
+type AppleScriptProfile struct {
+	terminalName string // lowercase identifier (e.g., "iterm2", "terminal")
+	appName      string // macOS application name (e.g., "iTerm2", "Terminal")
+}
+
+func (p *AppleScriptProfile) Name() string {
+	return fmt.Sprintf("applescript (%s)", p.terminalName)
+}
+
+func (p *AppleScriptProfile) BuildCommand(terminalArgs []string, loginCmd []string) ([]string, error) {
+	if len(terminalArgs) == 0 {
+		return nil, fmt.Errorf("terminal args must not be empty")
+	}
+	if len(loginCmd) == 0 {
+		return nil, fmt.Errorf("login command must not be empty")
+	}
+
+	fullLoginCmd := strings.Join(loginCmd, " ")
+
+	var script string
+	switch p.terminalName {
+	case "iterm2":
+		script = fmt.Sprintf(
+			`tell application "%s" to create window with default profile command "%s"`,
+			p.appName, fullLoginCmd,
+		)
+	default:
+		// Terminal.app and any other AppleScript-based terminal.
+		script = fmt.Sprintf(
+			`tell application "%s" to do script "%s"`,
+			p.appName, fullLoginCmd,
+		)
+	}
+
+	return []string{"osascript", "-e", script}, nil
+}
+
 // GenericProfile is the fallback that preserves the original launcher
 // behavior: terminal args and login command are simply concatenated.
 type GenericProfile struct{}
@@ -140,6 +182,14 @@ var directTerminals = map[string]bool{
 	"kitty":   true,
 	"foot":    true,
 	"contour": true,
+}
+
+// appleScriptTerminals maps terminal names (lowercase) to their macOS
+// application names. These terminals are launched via osascript instead
+// of being executed directly.
+var appleScriptTerminals = map[string]string{
+	"iterm2":   "iTerm2",
+	"terminal": "Terminal",
 }
 
 // flatpakAppTerminals maps Flatpak application IDs to executable names
@@ -205,6 +255,13 @@ func resolveFlatpakTerminal(parts []string) string {
 
 // profileForExecName returns the correct profile for a given executable name.
 func profileForExecName(execName string) TerminalProfile {
+	// Check AppleScript terminals first (case-insensitive match).
+	if appName, ok := appleScriptTerminals[strings.ToLower(execName)]; ok {
+		return &AppleScriptProfile{
+			terminalName: strings.ToLower(execName),
+			appName:      appName,
+		}
+	}
 	if separatorTerminals[execName] {
 		return &SeparatorProfile{terminalName: execName}
 	}
@@ -264,6 +321,7 @@ func detectRedundantFlatpakPrefix(terminalCmd string) (string, bool) {
 // available on the system. It returns a non-empty warning message if the
 // terminal cannot be found, or an empty string if everything looks fine.
 // For Flatpak app IDs, it checks for the "flatpak" binary instead.
+// For AppleScript terminals (iterm2, terminal), it checks for "osascript".
 func validateTerminalExists(terminal string) string {
 	if terminal == "" {
 		return "terminal command is empty"
@@ -271,6 +329,15 @@ func validateTerminalExists(terminal string) string {
 
 	parts := strings.Fields(terminal)
 	name := parts[0]
+
+	// For AppleScript terminals, check that "osascript" is available.
+	if _, ok := appleScriptTerminals[strings.ToLower(name)]; ok {
+		_, err := exec.LookPath("osascript")
+		if err != nil {
+			return fmt.Sprintf("osascript command not found in PATH; cluster login via %s may fail (requires macOS)", name)
+		}
+		return ""
+	}
 
 	// For Flatpak app IDs, check that "flatpak" is available.
 	if isFlatpakAppID(name) {

--- a/pkg/launcher/profiles_test.go
+++ b/pkg/launcher/profiles_test.go
@@ -411,3 +411,119 @@ func TestValidateTerminal_EmptyString(t *testing.T) {
 	warning := validateTerminalExists("")
 	assert.NotEmpty(t, warning, "expected a warning for an empty terminal string")
 }
+
+// --- AppleScript terminal support (iTerm2, Terminal.app) ---
+
+func TestDetectProfile_ITerm2(t *testing.T) {
+	profile := DetectTerminalProfile("iterm2")
+	assert.IsType(t, &AppleScriptProfile{}, profile)
+	assert.Contains(t, profile.Name(), "iterm2")
+}
+
+func TestDetectProfile_ITerm2_MixedCase(t *testing.T) {
+	profile := DetectTerminalProfile("iTerm2")
+	assert.IsType(t, &AppleScriptProfile{}, profile)
+	assert.Contains(t, profile.Name(), "iterm2")
+}
+
+func TestDetectProfile_TerminalApp(t *testing.T) {
+	profile := DetectTerminalProfile("terminal")
+	assert.IsType(t, &AppleScriptProfile{}, profile)
+	assert.Contains(t, profile.Name(), "terminal")
+}
+
+func TestDetectProfile_TerminalApp_UpperCase(t *testing.T) {
+	profile := DetectTerminalProfile("Terminal")
+	assert.IsType(t, &AppleScriptProfile{}, profile)
+	assert.Contains(t, profile.Name(), "terminal")
+}
+
+func TestAppleScriptProfile_Name_ITerm2(t *testing.T) {
+	p := &AppleScriptProfile{terminalName: "iterm2", appName: "iTerm2"}
+	assert.Equal(t, "applescript (iterm2)", p.Name())
+}
+
+func TestAppleScriptProfile_Name_Terminal(t *testing.T) {
+	p := &AppleScriptProfile{terminalName: "terminal", appName: "Terminal"}
+	assert.Equal(t, "applescript (terminal)", p.Name())
+}
+
+func TestAppleScriptProfile_BuildCommand_ITerm2(t *testing.T) {
+	p := &AppleScriptProfile{terminalName: "iterm2", appName: "iTerm2"}
+	// terminalArgs is just ["iterm2"] since the user sets terminal: iterm2
+	termArgs := []string{"iterm2"}
+	loginCmd := []string{"ocm-container", "-C", "abc123"}
+
+	cmd, err := p.BuildCommand(termArgs, loginCmd)
+	require.NoError(t, err)
+
+	// The profile should produce an osascript command that tells iTerm2
+	// to create a window with the login command.
+	assert.Equal(t, "osascript", cmd[0])
+	assert.Equal(t, "-e", cmd[1])
+
+	// The AppleScript should reference iTerm2 and contain the login command.
+	script := cmd[2]
+	assert.Contains(t, script, "iTerm2")
+	assert.Contains(t, script, "ocm-container -C abc123")
+}
+
+func TestAppleScriptProfile_BuildCommand_TerminalApp(t *testing.T) {
+	p := &AppleScriptProfile{terminalName: "terminal", appName: "Terminal"}
+	termArgs := []string{"terminal"}
+	loginCmd := []string{"ocm-container", "-C", "abc123"}
+
+	cmd, err := p.BuildCommand(termArgs, loginCmd)
+	require.NoError(t, err)
+
+	// Should produce osascript command for Terminal.app.
+	assert.Equal(t, "osascript", cmd[0])
+	assert.Equal(t, "-e", cmd[1])
+
+	script := cmd[2]
+	assert.Contains(t, script, "Terminal")
+	assert.Contains(t, script, "ocm-container -C abc123")
+}
+
+func TestAppleScriptProfile_BuildCommand_EmptyTerminalArgs(t *testing.T) {
+	p := &AppleScriptProfile{terminalName: "iterm2", appName: "iTerm2"}
+	_, err := p.BuildCommand([]string{}, []string{"cmd"})
+	assert.Error(t, err)
+}
+
+func TestAppleScriptProfile_BuildCommand_EmptyLoginCmd(t *testing.T) {
+	p := &AppleScriptProfile{terminalName: "iterm2", appName: "iTerm2"}
+	_, err := p.BuildCommand([]string{"iterm2"}, []string{})
+	assert.Error(t, err)
+}
+
+func TestAppleScriptProfile_BuildCommand_ITerm2_QuotesInCommand(t *testing.T) {
+	p := &AppleScriptProfile{terminalName: "iterm2", appName: "iTerm2"}
+	termArgs := []string{"iterm2"}
+	loginCmd := []string{"bash", "-c", "echo hello world"}
+
+	cmd, err := p.BuildCommand(termArgs, loginCmd)
+	require.NoError(t, err)
+
+	assert.Equal(t, "osascript", cmd[0])
+	script := cmd[2]
+	assert.Contains(t, script, "bash -c echo hello world")
+}
+
+func TestAppleScriptProfile_ValidateTerminal_ITerm2(t *testing.T) {
+	// "iterm2" is a virtual terminal name; validation should check for
+	// "osascript" rather than "iterm2" itself.
+	warning := validateTerminalExists("iterm2")
+	// On macOS, osascript exists. On Linux CI, it will not, so just
+	// verify it returns something sensible.
+	if warning != "" {
+		assert.Contains(t, warning, "osascript")
+	}
+}
+
+func TestAppleScriptProfile_ValidateTerminal_Terminal(t *testing.T) {
+	warning := validateTerminalExists("terminal")
+	if warning != "" {
+		assert.Contains(t, warning, "osascript")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `AppleScriptProfile` implementing `TerminalProfile` for macOS terminals (iTerm2, Terminal.app) that require `osascript` to launch commands
- Users can now set `terminal: iterm2` or `terminal: terminal` in their config, eliminating the need for wrapper shell scripts
- Detection is case-insensitive (`iterm2`, `iTerm2`, `terminal`, `Terminal` all work)
- Validation checks for `osascript` availability rather than the terminal binary itself

## How it works

When `terminal: iterm2` is configured, srepd constructs:
```
osascript -e 'tell application "iTerm2" to create window with default profile command "ocm-container -C abc123"'
```

When `terminal: terminal` is configured (macOS Terminal.app):
```
osascript -e 'tell application "Terminal" to do script "ocm-container -C abc123"'
```

## Test plan

- [x] 13 new tests covering detection, naming, command building, error handling, quoting, and validation
- [x] All existing tests continue to pass
- [x] `make test` passes (all 7 packages)
- [x] `make fmt-check` passes
- [x] `make vet` passes

## Based on

This PR is based on `srepd/flatpak-ghostty-validation` (PR #188), which provides the profile system, Ghostty support, and flatpak detection.

Created with assistance from Claude <claude@anthropic.com>

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>