### PR TITLE
Require local test verification before commits in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,16 +57,21 @@ Pass extra test flags via `TESTOPTS`, e.g.:
 - Type assertions must use the comma-ok pattern
 - Tests before code (TDD)
 - Each PR must pass all CI checks
+- **All tests must pass locally before committing.** Run
+  `make test-all` (or at minimum `go test ./... -count=1`)
+  and verify zero failures before creating a commit or PR.
+  Do not push code that fails tests.
 
 ## PR Workflow
 
 1. Create feature branch: `srepd/<description>`
 2. Write failing tests
 3. Implement minimum code to pass tests
-4. Run `make test-all` locally
-5. Push and create PR against `main`
-6. CI runs all checks via `make` targets
-7. Review, approve, merge
+4. Run `make test-all` locally — **all tests must pass**
+5. If any test fails, fix it before proceeding
+6. Push and create PR against `main`
+7. CI runs all checks via `make` targets
+8. Review, approve, merge
 
 ## Key Files
 

--- a/docs/plans/051-agents-md-test-requirement.md
+++ b/docs/plans/051-agents-md-test-requirement.md
@@ -1,0 +1,29 @@
+# 051: Require Local Test Verification in AGENTS.md
+
+## Status: In Progress
+
+## Problem
+
+AGENTS.md did not explicitly require that all tests pass locally before
+committing or pushing code. Developers (human or AI) could create commits
+and PRs with failing tests, wasting CI resources and review cycles.
+
+## Solution
+
+Add explicit requirements to AGENTS.md:
+
+1. **Key Invariants** -- new bullet requiring `make test-all` (or at minimum
+   `go test ./... -count=1`) to pass with zero failures before any commit or PR.
+
+2. **PR Workflow** -- update step 4 to emphasize that all tests **must** pass,
+   add a new step 5 requiring fixes before proceeding, and renumber subsequent
+   steps accordingly.
+
+## Changes
+
+- `AGENTS.md` -- Key Invariants section and PR Workflow section updated.
+
+## Verification
+
+- `go test ./... -count=1` passes with zero failures.
+- AGENTS.md content reviewed for correctness and clarity.


### PR DESCRIPTION
## Summary

- Add explicit requirement to Key Invariants that all tests must pass locally
  (`make test-all` or `go test ./... -count=1`) before creating commits or PRs.
- Update PR Workflow step 4 to emphasize test passage requirement and add a new
  step 5 requiring test failures to be fixed before proceeding.
- Renumber remaining PR Workflow steps accordingly.

## Test plan

- [x] Verified `go test ./... -count=1` passes with zero failures
- [ ] Review AGENTS.md changes for clarity and accuracy

Created with assistance from Claude <claude@anthropic.com>

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>