### PR TITLE
Add srepd journal identifier and log level priority mapping

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -286,14 +286,39 @@ func setupFileLogging(filePath string) {
 	log.SetOutput(logWriter)
 }
 
+// syslogIdentifier is the identifier used for systemd journal entries,
+// enabling log retrieval via "journalctl -t srepd".
+const syslogIdentifier = "srepd"
+
 // journalWriter implements io.Writer for systemd journal
 type journalWriter struct{}
 
 func (jw journalWriter) Write(p []byte) (n int, err error) {
 	message := strings.TrimSpace(string(p))
-	err = journal.Send(message, journal.PriInfo, nil)
+	priority := journalPriority(message)
+	vars := map[string]string{
+		"SYSLOG_IDENTIFIER": syslogIdentifier,
+	}
+	err = journal.Send(message, priority, vars)
 	if err != nil {
 		return 0, err
 	}
 	return len(p), nil
+}
+
+// journalPriority maps log message content to the appropriate systemd
+// journal priority level. It inspects the message for common log level
+// prefixes emitted by the charmbracelet/log package.
+func journalPriority(message string) journal.Priority {
+	upper := strings.ToUpper(message)
+	switch {
+	case strings.Contains(upper, "ERROR"), strings.Contains(upper, "ERRO"):
+		return journal.PriErr
+	case strings.Contains(upper, "WARN"):
+		return journal.PriWarning
+	case strings.Contains(upper, "DEBUG"):
+		return journal.PriDebug
+	default:
+		return journal.PriInfo
+	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"testing"
 
+	"github.com/coreos/go-systemd/journal"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -86,6 +87,86 @@ func TestDetermineLogDestination(t *testing.T) {
 			dest, path := determineLogDestination(tt.goos, tt.logToJournal, tt.journalEnabled)
 			assert.Equal(t, tt.expectedDest, dest, "Log destination mismatch")
 			assert.Equal(t, tt.expectedPath, path, "Log path mismatch")
+		})
+	}
+}
+
+func TestSyslogIdentifier(t *testing.T) {
+	assert.Equal(t, "srepd", syslogIdentifier, "SYSLOG_IDENTIFIER must be 'srepd' for journalctl -t srepd")
+}
+
+func TestJournalPriorityMapping(t *testing.T) {
+	tests := []struct {
+		name     string
+		message  string
+		expected journal.Priority
+	}{
+		{
+			name:     "ERROR maps to PriErr",
+			message:  "ERROR something went wrong",
+			expected: journal.PriErr,
+		},
+		{
+			name:     "ERRO maps to PriErr",
+			message:  "ERRO short form error",
+			expected: journal.PriErr,
+		},
+		{
+			name:     "lowercase error maps to PriErr",
+			message:  "an error occurred in the system",
+			expected: journal.PriErr,
+		},
+		{
+			name:     "WARN maps to PriWarning",
+			message:  "WARN something might be wrong",
+			expected: journal.PriWarning,
+		},
+		{
+			name:     "WARNING maps to PriWarning",
+			message:  "WARNING elevated concern",
+			expected: journal.PriWarning,
+		},
+		{
+			name:     "lowercase warn maps to PriWarning",
+			message:  "a warning was issued",
+			expected: journal.PriWarning,
+		},
+		{
+			name:     "DEBUG maps to PriDebug",
+			message:  "DEBUG verbose output here",
+			expected: journal.PriDebug,
+		},
+		{
+			name:     "lowercase debug maps to PriDebug",
+			message:  "debug information available",
+			expected: journal.PriDebug,
+		},
+		{
+			name:     "INFO maps to PriInfo",
+			message:  "INFO normal operation",
+			expected: journal.PriInfo,
+		},
+		{
+			name:     "plain message defaults to PriInfo",
+			message:  "just a regular log line",
+			expected: journal.PriInfo,
+		},
+		{
+			name:     "empty message defaults to PriInfo",
+			message:  "",
+			expected: journal.PriInfo,
+		},
+		{
+			name:     "error takes precedence over warn when both present",
+			message:  "ERROR warning about something",
+			expected: journal.PriErr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			priority := journalPriority(tt.message)
+			assert.Equal(t, tt.expected, priority, "Priority mismatch for message: %s", tt.message)
 		})
 	}
 }

--- a/docs/plans/054-journal-identifier.md
+++ b/docs/plans/054-journal-identifier.md
@@ -1,0 +1,21 @@
+# Add srepd journal identifier and priority mapping
+
+## Context
+
+The journalWriter sends all log messages without a SYSLOG_IDENTIFIER,
+making srepd logs impossible to filter with `journalctl -t srepd`.
+Also uses hard-coded PriInfo for all messages regardless of level.
+
+## Plan
+
+1. Pass `SYSLOG_IDENTIFIER=srepd` in journal.Send() vars map
+2. Map log levels to journal priorities (ERROR→PriErr, WARN→PriWarning, DEBUG→PriDebug)
+
+## Files Modified
+
+- `cmd/root.go` — journalWriter with identifier and priority mapping
+
+## Verification
+
+- `journalctl -t srepd` shows only srepd logs
+- Error messages show as priority err in journal


### PR DESCRIPTION
## Summary
- Set `SYSLOG_IDENTIFIER=srepd` in journal.Send() so logs can be filtered: `journalctl -t srepd`
- Map log levels to journal priorities: ERROR→PriErr, WARN→PriWarning, DEBUG→PriDebug (was hard-coded PriInfo for everything)

Partial fix for #7

## Test plan
- [x] Tests pass locally
- [ ] `journalctl -t srepd` shows only srepd logs
- [ ] Error messages show correct priority in journal

🤖 Generated with [Claude Code](https://claude.com/claude-code)