### PR TITLE
Fix incident view formatting: bold ID, dark style, indentation, borders

### DIFF
--- a/docs/plans/055-fix-incident-view-formatting.md
+++ b/docs/plans/055-fix-incident-view-formatting.md
@@ -1,0 +1,45 @@
+# 055: Fix Incident View Formatting
+
+GitHub Issue: #200
+
+## Problem
+
+The incident detail view has several formatting problems that make it
+hard to read:
+
+1. Incident ID is not bold in the heading
+2. Glamour renderer has no style configured (root cause of most visual issues)
+3. Double border from both container and viewport styles
+4. Notes not indented with 2-space prefix
+5. Alert detail lines not indented with 2-space prefix
+6. No spacing between multiple alerts
+7. Bold acknowledged username not rendering (consequence of #2)
+8. URLs showing both text and raw link (consequence of #2)
+9. No space between ID line and title (already has newline, but confirmed)
+
+## Changes
+
+### pkg/tui/model.go
+- Add `glamour.WithStylePath("dark")` to `glamour.NewTermRenderer()` call
+- Remove `vp.Style = incidentViewerStyle` from `newIncidentViewer()`
+
+### pkg/tui/views.go
+- Bold the incident ID: `**{{ .ID }}**`
+- Indent notes with 2-space prefix on blockquote and attribution lines
+- Indent alert detail bullet points with 2-space prefix
+- Add blank line between alert iterations (already has `{{ end }}` with
+  newline, but ensure explicit spacing)
+- Remove `incidentViewerStyle` variable definition (border style)
+
+## Testing
+
+- Template output tests: verify bold ID markers, indented notes,
+  indented alert details, spacing between alerts
+- Glamour renderer test: verify `WithStylePath("dark")` produces
+  styled output (bold renders as ANSI sequences)
+- Viewport border test: verify `newIncidentViewer()` has no border style
+
+## Files Modified
+
+- `pkg/tui/model.go`
+- `pkg/tui/views.go`

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -121,6 +121,7 @@ func InitialModel(
 
 	// Create markdown renderer once - reusing it is much faster than creating new ones
 	renderer, err := glamour.NewTermRenderer(
+		glamour.WithStylePath("dark"),
 		glamour.WithWordWrap(100), // Default width, will be adjusted on window resize
 	)
 	if err != nil {
@@ -397,6 +398,5 @@ func newHelp() help.Model {
 
 func newIncidentViewer() viewport.Model {
 	vp := viewport.New(100, 100)
-	vp.Style = incidentViewerStyle
 	return vp
 }

--- a/pkg/tui/model_test.go
+++ b/pkg/tui/model_test.go
@@ -4,11 +4,13 @@ import (
 	"testing"
 	"time"
 
+	"charm.land/glamour/v2"
 	"github.com/PagerDuty/go-pagerduty"
 	"github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/clcollins/srepd/pkg/pd"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // createTestModel creates a minimal model for testing
@@ -1215,6 +1217,28 @@ func TestConfirmAction_PromptRenderedInStatusArea(t *testing.T) {
 		view := m.View()
 		assert.Contains(t, view, "Silence P1234567? [y/n]", "View should render the confirmation prompt")
 	})
+}
+
+func TestGlamourRendererProducesBoldOutput(t *testing.T) {
+	// Create renderer with dark style (same as production code)
+	renderer, err := glamour.NewTermRenderer(
+		glamour.WithStylePath("dark"),
+		glamour.WithWordWrap(100),
+	)
+	require.NoError(t, err, "glamour renderer should be created without error")
+	require.NotNil(t, renderer, "renderer should not be nil")
+
+	// Render markdown with bold text
+	output, err := renderer.Render("**bold text**")
+	require.NoError(t, err, "rendering should not error")
+
+	// With dark style, bold text should contain ANSI escape sequences
+	// (not just the raw ** markers). The exact ANSI codes vary, but
+	// the output should NOT contain the literal "**" markers.
+	assert.NotContains(t, output, "**bold text**",
+		"glamour with dark style should render bold as ANSI, not raw markdown")
+	assert.Contains(t, output, "bold text",
+		"rendered output should still contain the text content")
 }
 
 func TestWindowSizeMsgHandler_SmallWindow(t *testing.T) {

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -65,8 +65,10 @@ func (m model) windowSizeMsgHandler(msg tea.Msg) (tea.Model, tea.Cmd) {
 	horizontalScratchWidth := horizontalMargins + horizontalPadding + horizontalBorders
 	verticalScratchWidth := verticalMargins + verticalPadding + verticalBorders
 
-	incidentHorizontalScratchWidth := incidentViewerStyle.GetHorizontalMargins() + incidentViewerStyle.GetHorizontalPadding() + incidentViewerStyle.GetHorizontalBorderSize()
-	incidentVerticalScratchWidth := incidentViewerStyle.GetVerticalMargins() + incidentViewerStyle.GetVerticalPadding() + incidentViewerStyle.GetVerticalBorderSize()
+	// The incident viewer viewport has no border/padding/margin of its own;
+	// all visual framing comes from tableContainerStyle wrapping the viewport.
+	incidentHorizontalScratchWidth := 0
+	incidentVerticalScratchWidth := 0
 
 	tableHorizontalScratchWidth := tableHorizontalMargins + tableHorizontalPadding + tableHorizontalBorders + cellHorizontalPadding + cellHorizontalMargins + cellHorizontalBorders
 	tableVerticalScratchWidth := tableVerticalMargins + tableVerticalPadding + tableVerticalBorders + cellVerticalPadding + cellVerticalMargins + cellVerticalBorders

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -122,8 +122,6 @@ var (
 	// Action log container style - border like main table
 	actionLogContainerStyle = lipgloss.NewStyle().Border(lipgloss.RoundedBorder(), true)
 
-	incidentViewerStyle = lipgloss.NewStyle().Border(lipgloss.RoundedBorder(), true)
-
 	errorStyle = lipgloss.NewStyle().
 			Bold(true).
 			Width(64).
@@ -551,9 +549,9 @@ var funcMap = template.FuncMap{
 
 const incidentTemplate = `
 {{- if .Priority -}}
-# {{ .Priority }} {{ .ID }} - {{ .Status }}
+# {{ .Priority }} **{{ .ID }}** - {{ .Status }}
 {{- else -}}
-# {{ .ID }} - {{ .Status }}
+# **{{ .ID }}** - {{ .Status }}
 {{- end }}
 
 {{ ToLink .Title .HTMLURL }}
@@ -579,8 +577,8 @@ Acknowledged by: {{ range $i, $ack := .Acknowledged -}}
 _Loading notes..._
 {{ else if .Notes }}
 {{ range $note := .Notes }}
-> {{ $note.Content }}
-    -- {{ $note.User }} @ {{ $note.Created }}
+  > {{ $note.Content }}
+  -- {{ $note.User }} @ {{ $note.Created }}
 {{ end }}
 {{ else }}
 _none_
@@ -591,14 +589,16 @@ _none_
 {{ if .AlertsLoading }}
 _Loading alerts..._
 {{ else }}
-{{ range $alert := .Alerts }}
+{{ $alertLen := len .Alerts }}{{ range $i, $alert := .Alerts }}
 ### {{ if $alert.Name }}{{ $alert.Name }}{{ else }}{{ $alert.ID }}{{ end }} ({{ $alert.Status }}){{ if $alert.Severity }} [{{ $alert.Severity }}]{{ end }}{{ if $alert.AlertType }} ({{ $alert.AlertType }}){{ end }}
 
-* Cluster: {{ $alert.Cluster }}
-* SOP: {{ if $alert.Link }}{{ ToLink "SOP" $alert.Link }}{{ else }}_none_{{ end }}
-* Alert: {{ ToLink $alert.ID $alert.HTMLURL }}
-* Service: {{ $alert.Service }}
-* Created: {{ $alert.Created }}
+  * Cluster: {{ $alert.Cluster }}
+  * SOP: {{ if $alert.Link }}{{ ToLink "SOP" $alert.Link }}{{ else }}_none_{{ end }}
+  * Alert: {{ ToLink $alert.ID $alert.HTMLURL }}
+  * Service: {{ $alert.Service }}
+  * Created: {{ $alert.Created }}
+
+{{ if not (Last $i $alertLen) }}---{{ end }}
 
 {{ end }}
 {{ end }}

--- a/pkg/tui/views_test.go
+++ b/pkg/tui/views_test.go
@@ -615,6 +615,168 @@ func TestIncidentTemplate_AlertWithEmptyName(t *testing.T) {
 	assert.Contains(t, result, "_none_")
 }
 
+func TestIncidentTemplate_BoldIncidentID(t *testing.T) {
+	tests := []struct {
+		name     string
+		summary  incidentSummary
+		expected string
+	}{
+		{
+			name: "incident ID is bold without priority",
+			summary: incidentSummary{
+				ID:           "INC001",
+				Title:        "Test",
+				HTMLURL:      "https://example.com",
+				Service:      "Svc",
+				Urgency:      "high",
+				Created:      "2025-01-01",
+				Status:       "triggered",
+				Acknowledged: []string{"User"},
+			},
+			expected: "# **INC001** - triggered",
+		},
+		{
+			name: "incident ID is bold with priority",
+			summary: incidentSummary{
+				ID:           "INC002",
+				Title:        "Test",
+				HTMLURL:      "https://example.com",
+				Service:      "Svc",
+				Urgency:      "high",
+				Created:      "2025-01-01",
+				Status:       "triggered",
+				Priority:     "P1",
+				Acknowledged: []string{"User"},
+			},
+			expected: "# P1 **INC002** - triggered",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := renderTestTemplate(t, tt.summary)
+			assert.Contains(t, result, tt.expected)
+		})
+	}
+}
+
+func TestIncidentTemplate_NotesIndented(t *testing.T) {
+	summary := incidentSummary{
+		ID:           "INC001",
+		Title:        "Test",
+		HTMLURL:      "https://example.com",
+		Service:      "Svc",
+		Urgency:      "high",
+		Created:      "2025-01-01",
+		Status:       "triggered",
+		Acknowledged: []string{"User"},
+		Notes: []noteSummary{
+			{
+				ID:      "N1",
+				User:    "John Doe",
+				Content: "This is a note",
+				Created: "2025-01-02",
+			},
+		},
+	}
+
+	result := renderTestTemplate(t, summary)
+
+	// Notes should have 2-space indented blockquote and attribution
+	assert.Contains(t, result, "  > This is a note")
+	assert.Contains(t, result, "  -- John Doe @ 2025-01-02")
+}
+
+func TestIncidentTemplate_AlertDetailsIndented(t *testing.T) {
+	summary := incidentSummary{
+		ID:           "INC001",
+		Title:        "Test",
+		HTMLURL:      "https://example.com",
+		Service:      "Svc",
+		Urgency:      "high",
+		Created:      "2025-01-01",
+		Status:       "triggered",
+		Acknowledged: []string{"User"},
+		Alerts: []alertSummary{
+			{
+				ID:      "ALERT001",
+				Name:    "TestAlert",
+				Link:    "https://example.com/sop",
+				HTMLURL: "https://example.com/alert",
+				Service: "AlertSvc",
+				Created: "2025-01-01",
+				Status:  "triggered",
+				Cluster: "abc-123",
+			},
+		},
+	}
+
+	result := renderTestTemplate(t, summary)
+
+	// Alert detail bullet points should have 2-space indent
+	assert.Contains(t, result, "  * Cluster: abc-123")
+	assert.Contains(t, result, "  * Service: AlertSvc")
+	assert.Contains(t, result, "  * Created: 2025-01-01")
+}
+
+func TestIncidentTemplate_SpacingBetweenAlerts(t *testing.T) {
+	summary := incidentSummary{
+		ID:           "INC001",
+		Title:        "Test",
+		HTMLURL:      "https://example.com",
+		Service:      "Svc",
+		Urgency:      "high",
+		Created:      "2025-01-01",
+		Status:       "triggered",
+		Acknowledged: []string{"User"},
+		Alerts: []alertSummary{
+			{
+				ID:      "ALERT001",
+				Name:    "FirstAlert",
+				HTMLURL: "https://example.com/alert1",
+				Service: "Svc1",
+				Created: "2025-01-01",
+				Status:  "triggered",
+				Cluster: "abc-123",
+			},
+			{
+				ID:      "ALERT002",
+				Name:    "SecondAlert",
+				HTMLURL: "https://example.com/alert2",
+				Service: "Svc2",
+				Created: "2025-01-02",
+				Status:  "triggered",
+				Cluster: "def-456",
+			},
+		},
+	}
+
+	result := renderTestTemplate(t, summary)
+
+	// Both alerts should be present
+	assert.Contains(t, result, "### FirstAlert (triggered)")
+	assert.Contains(t, result, "### SecondAlert (triggered)")
+
+	// There should be a horizontal rule (---) between alerts for clear visual separation
+	assert.Contains(t, result, "---")
+	// The separator should appear between the two alerts, with the ---
+	// separating the first alert's details from the second alert's heading
+	assert.Contains(t, result, "  * Created: 2025-01-01\n\n---\n")
+	// The second alert heading should follow after the separator
+	assert.Contains(t, result, "---\n\n\n### SecondAlert")
+}
+
+func TestIncidentViewerNoBorder(t *testing.T) {
+	vp := newIncidentViewer()
+
+	// The viewport should not have a border style set
+	// GetBorderTop returns false when no border is configured
+	assert.False(t, vp.Style.GetBorderTop(), "viewport should not have a top border")
+	assert.False(t, vp.Style.GetBorderBottom(), "viewport should not have a bottom border")
+	assert.False(t, vp.Style.GetBorderLeft(), "viewport should not have a left border")
+	assert.False(t, vp.Style.GetBorderRight(), "viewport should not have a right border")
+}
+
 func TestSummarizeAlerts_NoDetailsField(t *testing.T) {
 	alerts := []pagerduty.IncidentAlert{
 		{


### PR DESCRIPTION
## Summary
Fixes all 9 formatting issues from Issue #200:
1. Bold incident ID
2. Space between ID and title
3. Notes indented 2 spaces
4. Alert details indented 2 spaces
5. Spacing between multiple alerts
6. Double border removed (kept container, removed viewport)
7. **Root cause: glamour dark style restored** — `WithStylePath("dark")` re-enables bold/italic/color
8. URLs render as styled links (fixed by #7)
9. Acknowledged username renders bold (fixed by #7)

Closes #200

## Test plan
- [x] 6 new tests for formatting verification
- [x] `go test ./... -count=1` passes
- [ ] Build and visually verify incident view renders with styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)