### PR TITLE
Pre-fetch incident details on navigation (#198)

### DIFF
--- a/docs/plans/055-eager-prefetch.md
+++ b/docs/plans/055-eager-prefetch.md
@@ -1,0 +1,72 @@
+# 055: Eager Pre-fetch on Navigation
+
+**Issue**: #198
+**Branch**: `srepd/eager-prefetch`
+**Status**: In Progress
+
+## Problem
+
+When a user presses 'l' (login) or views an incident, srepd must wait for full
+incident data (details, alerts, notes) to load from PagerDuty. This creates a
+visible "waiting for incident info..." delay because data is only fetched
+on-demand when the action is triggered.
+
+## Solution
+
+Pre-fetch incident details in the background when the user navigates to a new
+row (j/k/Up/Down/g/G). If the cache already has full data for the highlighted
+incident, skip the fetch. Rate limiting (token bucket: 10 req/s, burst 20)
+handles rapid scrolling naturally; no explicit debounce needed.
+
+## Design
+
+### Change to syncSelectedIncidentToHighlightedRow
+
+Currently `syncSelectedIncidentToHighlightedRow()` is a void method that only
+mutates model state. It will be refactored to return a `tea.Cmd` that, when the
+highlighted incident is not fully cached, emits a `getIncidentMsg` to trigger
+background fetching of incident details, alerts, and notes.
+
+Signature change:
+```go
+// Before
+func (m *model) syncSelectedIncidentToHighlightedRow()
+// After
+func (m *model) syncSelectedIncidentToHighlightedRow() tea.Cmd
+```
+
+### Callers updated
+
+All callers in `msgHandlers.go` (`switchTableFocusMode` for Up/Down/Top/Bottom
+keys, `switchIncidentFocusMode` for Escape, and `updatedIncidentListMsg` in
+`tui.go`) will propagate the returned command.
+
+### Cache guard
+
+The pre-fetch only fires when the incident is NOT already fully cached
+(dataLoaded AND alertsLoaded AND notesLoaded all true). The existing
+`gotIncidentMsg`, `gotIncidentAlertsMsg`, and `gotIncidentNotesMsg` handlers
+already guard against overwriting the currently-viewed incident with stale
+background data.
+
+## Tests (TDD)
+
+1. **TestSyncSelectedIncident_TriggersPrefetch** - uncached incident returns a
+   non-nil tea.Cmd
+2. **TestSyncSelectedIncident_SkipsCached** - fully cached incident returns nil
+3. **TestSyncSelectedIncident_TriggersPrefetchPartialCache** - partially cached
+   (e.g. data loaded but alerts not) still triggers prefetch
+4. **TestSyncSelectedIncident_NilRowReturnsNil** - no highlighted row returns nil
+5. **TestSyncSelectedIncident_SameIncidentReturnsNil** - already-selected
+   incident returns nil (no re-fetch)
+
+## Files Modified
+
+- `pkg/tui/model.go` - signature change + pre-fetch logic
+- `pkg/tui/model_test.go` - new test cases
+- `pkg/tui/tui.go` - propagate cmd from sync in updatedIncidentListMsg
+- `pkg/tui/msgHandlers.go` - propagate cmd from sync in navigation handlers
+
+## Post-mortem / Lessons Learned
+
+(To be filled after merge)

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -264,7 +264,11 @@ func (m *model) clearSelectedIncident(reason interface{}) {
 // syncSelectedIncidentToHighlightedRow updates m.selectedIncident to match the currently
 // highlighted table row. Sets to nil if no row is highlighted. Uses cached data if available,
 // otherwise uses stub data from m.incidentList.
-func (m *model) syncSelectedIncidentToHighlightedRow() {
+//
+// Returns a tea.Cmd to pre-fetch incident details if the highlighted incident is not fully
+// cached (data + alerts + notes). Returns nil if no fetch is needed. The rate limiter
+// handles debouncing for rapid navigation.
+func (m *model) syncSelectedIncidentToHighlightedRow() tea.Cmd {
 	row := m.table.SelectedRow()
 	if row == nil {
 		// Clear selection regardless of viewing state
@@ -274,19 +278,24 @@ func (m *model) syncSelectedIncidentToHighlightedRow() {
 		m.incidentNotesLoaded = false
 		m.incidentAlertsLoaded = false
 		log.Debug("syncSelectedIncidentToHighlightedRow", "no row highlighted", "cleared selection")
-		return
+		return nil
 	}
 
 	incidentID := row[1] // Column [1] is the incident ID
 
 	// If already viewing this incident, don't change anything
 	if m.selectedIncident != nil && m.selectedIncident.ID == incidentID {
-		return
+		return nil
 	}
 
+	// Track whether the cache is fully loaded to decide on pre-fetch
+	fullyLoaded := false
+
 	// Find incident in list
+	found := false
 	for i := range m.incidentList {
 		if m.incidentList[i].ID == incidentID {
+			found = true
 			// Check if we have cached full data
 			if cached, exists := m.incidentCache[incidentID]; exists && cached.incident != nil {
 				// Check if cache is fresh relative to incident list data
@@ -312,6 +321,8 @@ func (m *model) syncSelectedIncidentToHighlightedRow() {
 						m.selectedIncidentAlerts = nil
 						m.incidentAlertsLoaded = false
 					}
+					// Stale cache is not fully loaded
+					fullyLoaded = false
 				} else {
 					// Cache is fresh - use it
 					log.Debug("syncSelectedIncidentToHighlightedRow", "using cached data", "incident", incidentID)
@@ -331,6 +342,7 @@ func (m *model) syncSelectedIncidentToHighlightedRow() {
 					} else {
 						m.selectedIncidentAlerts = nil
 					}
+					fullyLoaded = cached.dataLoaded && cached.notesLoaded && cached.alertsLoaded
 				}
 			} else {
 				// Use stub data from incidentList
@@ -343,19 +355,34 @@ func (m *model) syncSelectedIncidentToHighlightedRow() {
 				m.incidentAlertsLoaded = false
 				m.selectedIncidentNotes = nil
 				m.selectedIncidentAlerts = nil
+				fullyLoaded = false
 			}
-			return
+			break
 		}
 	}
 
-	// Incident not found in list
-	log.Debug("syncSelectedIncidentToHighlightedRow", "incident not found in list", incidentID)
-	if !m.viewingIncident {
-		m.selectedIncident = nil
-		m.incidentDataLoaded = false
-		m.incidentNotesLoaded = false
-		m.incidentAlertsLoaded = false
+	if !found {
+		// Incident not found in list
+		log.Debug("syncSelectedIncidentToHighlightedRow", "incident not found in list", incidentID)
+		if !m.viewingIncident {
+			m.selectedIncident = nil
+			m.incidentDataLoaded = false
+			m.incidentNotesLoaded = false
+			m.incidentAlertsLoaded = false
+		}
+		return nil
 	}
+
+	// Pre-fetch: if the incident is not fully cached, trigger a background fetch.
+	// The getIncidentMsg handler in Update will fetch details, alerts, and notes
+	// concurrently and populate the cache. The rate limiter handles rapid scrolling.
+	if !fullyLoaded {
+		id := incidentID
+		log.Debug("syncSelectedIncidentToHighlightedRow", "triggering pre-fetch", "incident", id)
+		return func() tea.Msg { return getIncidentMsg(id) }
+	}
+
+	return nil
 }
 
 func (m *model) setStatus(msg string) {

--- a/pkg/tui/model_test.go
+++ b/pkg/tui/model_test.go
@@ -1241,6 +1241,157 @@ func TestGlamourRendererProducesBoldOutput(t *testing.T) {
 		"rendered output should still contain the text content")
 }
 
+// --- Eager pre-fetch tests (Issue #198) ---
+
+// createTestModelWithTable sets up a model with a table containing the given
+// incidents and an incident list that matches. The table cursor starts at row 0.
+func createTestModelWithTable(incidents []pagerduty.Incident) model {
+	m := createTestModel()
+	m.incidentList = incidents
+
+	cols := []table.Column{
+		{Title: dot, Width: dotWidth},
+		{Title: "ID", Width: idWidth - dotWidth},
+		{Title: "Summary", Width: 30},
+		{Title: "Service", Width: 20},
+	}
+	var rows []table.Row
+	for _, inc := range incidents {
+		rows = append(rows, table.Row{dot, inc.ID, inc.Title, inc.Service.Summary})
+	}
+	m.table = table.New(
+		table.WithColumns(cols),
+		table.WithRows(rows),
+		table.WithFocused(true),
+	)
+	return m
+}
+
+func TestSyncSelectedIncident_TriggersPrefetch(t *testing.T) {
+	t.Run("uncached incident triggers pre-fetch command", func(t *testing.T) {
+		incidents := []pagerduty.Incident{
+			{
+				APIObject:          pagerduty.APIObject{ID: "Q111"},
+				Title:              "Test Incident",
+				Service:            pagerduty.APIObject{Summary: "test-svc"},
+				LastStatusChangeAt: "2024-01-01T00:00:00Z",
+			},
+		}
+		m := createTestModelWithTable(incidents)
+
+		cmd := m.syncSelectedIncidentToHighlightedRow()
+
+		assert.NotNil(t, m.selectedIncident, "selectedIncident should be set")
+		assert.Equal(t, "Q111", m.selectedIncident.ID, "selected incident should match highlighted row")
+		assert.NotNil(t, cmd, "should return a pre-fetch command for uncached incident")
+	})
+}
+
+func TestSyncSelectedIncident_SkipsCached(t *testing.T) {
+	t.Run("fully cached incident does not trigger pre-fetch", func(t *testing.T) {
+		incidents := []pagerduty.Incident{
+			{
+				APIObject:          pagerduty.APIObject{ID: "Q222"},
+				Title:              "Cached Incident",
+				Service:            pagerduty.APIObject{Summary: "cached-svc"},
+				LastStatusChangeAt: "2024-01-01T00:00:00Z",
+			},
+		}
+		m := createTestModelWithTable(incidents)
+
+		// Pre-populate cache with fully loaded data
+		incidentCopy := incidents[0]
+		m.incidentCache["Q222"] = &cachedIncidentData{
+			incident:     &incidentCopy,
+			dataLoaded:   true,
+			notesLoaded:  true,
+			alertsLoaded: true,
+			lastFetched:  time.Now(),
+		}
+
+		cmd := m.syncSelectedIncidentToHighlightedRow()
+
+		assert.NotNil(t, m.selectedIncident, "selectedIncident should be set from cache")
+		assert.Equal(t, "Q222", m.selectedIncident.ID)
+		assert.Nil(t, cmd, "should NOT return a command for fully cached incident")
+	})
+}
+
+func TestSyncSelectedIncident_TriggersPrefetchPartialCache(t *testing.T) {
+	t.Run("partially cached incident triggers pre-fetch", func(t *testing.T) {
+		incidents := []pagerduty.Incident{
+			{
+				APIObject:          pagerduty.APIObject{ID: "Q333"},
+				Title:              "Partial Incident",
+				Service:            pagerduty.APIObject{Summary: "partial-svc"},
+				LastStatusChangeAt: "2024-01-01T00:00:00Z",
+			},
+		}
+		m := createTestModelWithTable(incidents)
+
+		// Pre-populate cache with only data loaded (alerts and notes missing)
+		incidentCopy := incidents[0]
+		m.incidentCache["Q333"] = &cachedIncidentData{
+			incident:     &incidentCopy,
+			dataLoaded:   true,
+			notesLoaded:  false,
+			alertsLoaded: false,
+			lastFetched:  time.Now(),
+		}
+
+		cmd := m.syncSelectedIncidentToHighlightedRow()
+
+		assert.NotNil(t, m.selectedIncident, "selectedIncident should be set from cache")
+		assert.Equal(t, "Q333", m.selectedIncident.ID)
+		assert.NotNil(t, cmd, "should return a pre-fetch command for partially cached incident")
+	})
+}
+
+func TestSyncSelectedIncident_NilRowReturnsNil(t *testing.T) {
+	t.Run("no highlighted row returns nil command", func(t *testing.T) {
+		// Empty table - no rows to highlight
+		m := createTestModel()
+		m.table = table.New(
+			table.WithColumns([]table.Column{
+				{Title: dot, Width: dotWidth},
+				{Title: "ID", Width: idWidth - dotWidth},
+				{Title: "Summary", Width: 30},
+				{Title: "Service", Width: 20},
+			}),
+			table.WithFocused(true),
+		)
+
+		cmd := m.syncSelectedIncidentToHighlightedRow()
+
+		assert.Nil(t, m.selectedIncident, "selectedIncident should be nil with no rows")
+		assert.Nil(t, cmd, "should return nil command when no row is highlighted")
+	})
+}
+
+func TestSyncSelectedIncident_SameIncidentReturnsNil(t *testing.T) {
+	t.Run("already-selected incident returns nil command", func(t *testing.T) {
+		incidents := []pagerduty.Incident{
+			{
+				APIObject:          pagerduty.APIObject{ID: "Q444"},
+				Title:              "Same Incident",
+				Service:            pagerduty.APIObject{Summary: "same-svc"},
+				LastStatusChangeAt: "2024-01-01T00:00:00Z",
+			},
+		}
+		m := createTestModelWithTable(incidents)
+
+		// Pre-set selectedIncident to the same incident
+		incidentCopy := incidents[0]
+		m.selectedIncident = &incidentCopy
+
+		cmd := m.syncSelectedIncidentToHighlightedRow()
+
+		assert.NotNil(t, m.selectedIncident, "selectedIncident should remain set")
+		assert.Equal(t, "Q444", m.selectedIncident.ID)
+		assert.Nil(t, cmd, "should return nil command when incident is already selected")
+	})
+}
+
 func TestWindowSizeMsgHandler_SmallWindow(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -327,19 +327,27 @@ func switchTableFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case key.Matches(msg, defaultKeyMap.Up):
 			m.table.MoveUp(1)
-			m.syncSelectedIncidentToHighlightedRow()
+			if cmd := m.syncSelectedIncidentToHighlightedRow(); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
 
 		case key.Matches(msg, defaultKeyMap.Down):
 			m.table.MoveDown(1)
-			m.syncSelectedIncidentToHighlightedRow()
+			if cmd := m.syncSelectedIncidentToHighlightedRow(); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
 
 		case key.Matches(msg, defaultKeyMap.Top):
 			m.table.GotoTop()
-			m.syncSelectedIncidentToHighlightedRow()
+			if cmd := m.syncSelectedIncidentToHighlightedRow(); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
 
 		case key.Matches(msg, defaultKeyMap.Bottom):
 			m.table.GotoBottom()
-			m.syncSelectedIncidentToHighlightedRow()
+			if cmd := m.syncSelectedIncidentToHighlightedRow(); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
 
 		case key.Matches(msg, defaultKeyMap.Team):
 			m.teamMode = !m.teamMode
@@ -581,10 +589,10 @@ func switchIncidentFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 		// This un-sets the selected incident and returns to the table view
 		case key.Matches(msg, defaultKeyMap.Back):
 			m.clearSelectedIncident(msg.String() + " (back)")
-			m.table.Focus()                          // Ensure table regains focus immediately
-			m.syncSelectedIncidentToHighlightedRow() // Re-establish selection to current cursor position
+			m.table.Focus()                                        // Ensure table regains focus immediately
+			prefetchCmd := m.syncSelectedIncidentToHighlightedRow() // Re-establish selection to current cursor position
 			// Return immediately - no need to process anything else or update viewport
-			return m, nil
+			return m, prefetchCmd
 
 		case key.Matches(msg, defaultKeyMap.Refresh):
 			return m, func() tea.Msg { return getIncidentMsg(m.selectedIncident.ID) }

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -589,7 +589,7 @@ func switchIncidentFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 		// This un-sets the selected incident and returns to the table view
 		case key.Matches(msg, defaultKeyMap.Back):
 			m.clearSelectedIncident(msg.String() + " (back)")
-			m.table.Focus()                                        // Ensure table regains focus immediately
+			m.table.Focus()                                         // Ensure table regains focus immediately
 			prefetchCmd := m.syncSelectedIncidentToHighlightedRow() // Re-establish selection to current cursor position
 			// Return immediately - no need to process anything else or update viewport
 			return m, prefetchCmd

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -498,7 +498,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// Re-sync selectedIncident to match highlighted row
 		// This handles cases where the incident list changed but cursor position stayed same
-		m.syncSelectedIncidentToHighlightedRow()
+		if cmd := m.syncSelectedIncidentToHighlightedRow(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 
 	case parseTemplateForNoteMsg:
 		if m.selectedIncident == nil {


### PR DESCRIPTION
## Summary

- Refactors `syncSelectedIncidentToHighlightedRow()` to return a `tea.Cmd` that triggers background pre-fetching of incident details, alerts, and notes when navigating to a new row
- Pre-fetch fires only when the highlighted incident is not fully cached (data + alerts + notes); fully cached incidents skip the fetch entirely
- All navigation keys (j/k/Up/Down/g/G), Escape from incident view, and incident list refresh propagate the returned command
- Rate limiter (10 req/s, burst 20) naturally handles rapid scrolling -- no explicit debounce needed

Closes #198

## Test plan

- [x] `TestSyncSelectedIncident_TriggersPrefetch` -- uncached incident returns non-nil command
- [x] `TestSyncSelectedIncident_SkipsCached` -- fully cached incident returns nil
- [x] `TestSyncSelectedIncident_TriggersPrefetchPartialCache` -- partially cached triggers fetch
- [x] `TestSyncSelectedIncident_NilRowReturnsNil` -- empty table returns nil
- [x] `TestSyncSelectedIncident_SameIncidentReturnsNil` -- already-selected returns nil
- [x] Full test suite passes: `go test ./... -count=1` (8 packages, 0 failures)
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)