### PR TITLE
Add scrollable debug log viewer pane (ctrl+d)

### DIFF
--- a/docs/plans/055-log-viewer-pane.md
+++ b/docs/plans/055-log-viewer-pane.md
@@ -1,0 +1,75 @@
+# 055: Scrollable Log Viewer Pane
+
+**Issue**: #203
+**Branch**: srepd/log-viewer-pane-v2
+**Status**: In Progress
+
+## Problem
+
+No way to view the debug log from within srepd. Users must open a separate terminal to tail the log file.
+
+## Solution
+
+Add a scrollable log viewer pane using the same viewport pattern as the existing `incidentViewer`. The log viewer is opened with `ctrl+d`, reads `~/.config/srepd/debug.log`, shows the latest entries (scrolls to bottom), and is dismissed with Escape.
+
+## Implementation Plan
+
+### Model Changes (model.go)
+
+- Add `viewingLog bool` field
+- Add `logViewer viewport.Model` field
+- Add `logFilePath string` field (set from platform config dir)
+- Add `newLogViewer()` constructor matching `newIncidentViewer()` pattern
+- Set `logFilePath` in `InitialModel()`
+
+### Key Binding (keymap.go)
+
+- Add `ViewLog` key binding for `ctrl+d`
+- Add to help display in appropriate column
+
+### Message Types (commands.go)
+
+- Add `logFileContentMsg string` message type
+- Add `readLogFile(path string) tea.Cmd` command function
+
+### Key Handler (msgHandlers.go)
+
+- In `keyMsgHandler`: before focus mode switch, check `m.viewingLog` and route to `switchLogFocusMode`
+- In `switchTableFocusMode`: handle `ctrl+d` to trigger `readLogFile`
+- Add `switchLogFocusMode()`: up/down/pgup/pgdn scroll via viewport, Escape dismisses
+
+### Update Handler (tui.go)
+
+- Handle `logFileContentMsg`: set viewport content, GotoBottom(), set `viewingLog = true`
+
+### View Rendering (views.go)
+
+- In `View()`: when `viewingLog`, render `logViewer` viewport (same as `viewingIncident` layout)
+
+### Window Resize (msgHandlers.go)
+
+- In `windowSizeMsgHandler`: set `logViewer` width/height (same calculation as `incidentViewer`)
+
+### Edge Cases
+
+- File does not exist: show "No log file found at <path>" in viewport
+- Large file: load entire file (viewport handles scrolling)
+- Show latest entries first: `GotoBottom()` after `SetContent`
+
+## Test Plan
+
+1. `TestViewLogKey_OpensLogViewer` - ctrl+d key sets viewingLog=true via readLogFile command
+2. `TestViewLogKey_EscapeCloses` - Escape in log view returns viewingLog=false
+3. `TestLogFileContentMsg_SetsViewport` - logFileContentMsg loads content into viewport
+4. `TestLogFileContentMsg_FileNotFound` - missing file shows error message in viewport
+5. `TestLogViewer_WindowResize` - logViewer dimensions set on WindowSizeMsg
+6. `TestViewLogKey_InKeymap` - ctrl+d binding exists in keymap
+
+## Files Modified
+
+- `pkg/tui/model.go` - viewingLog, logViewer, logFilePath fields
+- `pkg/tui/keymap.go` - ViewLog key binding
+- `pkg/tui/commands.go` - logFileContentMsg, readLogFile
+- `pkg/tui/msgHandlers.go` - log focus mode handler, key binding, window resize
+- `pkg/tui/views.go` - render log viewer in View()
+- `pkg/tui/tui.go` - handle logFileContentMsg

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -203,6 +203,21 @@ type TickMsg struct {
 
 type PollIncidentsMsg struct{}
 
+// logFileContentMsg is a message containing the contents of the debug log file.
+type logFileContentMsg string
+
+// readLogFile returns a command that reads the log file at the given path.
+// If the file does not exist, it returns a logFileContentMsg with an error message.
+func readLogFile(path string) tea.Cmd {
+	return func() tea.Msg {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return logFileContentMsg(fmt.Sprintf("No log file found at %s", path))
+		}
+		return logFileContentMsg(string(data))
+	}
+}
+
 type renderIncidentMsg string
 
 type renderedIncidentMsg struct {

--- a/pkg/tui/keymap.go
+++ b/pkg/tui/keymap.go
@@ -18,7 +18,7 @@ func (k keymap) FullHelp() [][]key.Binding {
 		// Column 2: Primary incident actions
 		{k.Ack, k.Note, k.Login, k.Open, k.SOP, k.UnAck, k.Silence},
 		// Column 3: Settings & toggles, Quit at bottom
-		{k.Team, k.Refresh, k.AutoRefresh, k.AutoAck, k.Urgency, k.ToggleActionLog, k.Quit},
+		{k.Team, k.Refresh, k.AutoRefresh, k.AutoAck, k.Urgency, k.ToggleActionLog, k.ViewLog, k.Quit},
 	}
 }
 
@@ -45,6 +45,7 @@ type keymap struct {
 	Login           key.Binding
 	Open            key.Binding
 	SOP             key.Binding
+	ViewLog         key.Binding
 }
 
 type inputKeymap struct {
@@ -168,6 +169,10 @@ var defaultKeyMap = keymap{
 	SOP: key.NewBinding(
 		key.WithKeys("s"),
 		key.WithHelp("s", "open SOP"),
+	),
+	ViewLog: key.NewBinding(
+		key.WithKeys("ctrl+d"),
+		key.WithHelp("ctrl+d", "view debug log"),
 	),
 }
 

--- a/pkg/tui/keymap_test.go
+++ b/pkg/tui/keymap_test.go
@@ -43,6 +43,12 @@ func TestKeymapCompleteness(t *testing.T) {
 			keymapSourceName: "defaultKeyMap", // Uses defaultKeyMap for key.Matches
 		},
 		{
+			name:             "switchLogFocusMode uses defaultKeyMap",
+			functionName:     "switchLogFocusMode",
+			keymap:           defaultKeyMap,
+			keymapSourceName: "defaultKeyMap",
+		},
+		{
 			name:             "switchErrorFocusMode uses errorViewKeyMap",
 			functionName:     "switchErrorFocusMode",
 			keymap:           errorViewKeyMap,

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"os"
 	"time"
 
 	"charm.land/glamour/v2"
@@ -65,6 +66,9 @@ type model struct {
 	// This is a hack since viewport.Model doesn't have a Focused() method
 	viewingIncident  bool
 	incidentViewer   viewport.Model
+	viewingLog       bool
+	logViewer        viewport.Model
+	logFilePath      string
 	help             help.Model
 	spinner          spinner.Model
 	apiInProgress    bool
@@ -140,6 +144,8 @@ func InitialModel(
 		actionLog:        []actionLogEntry{},
 		input:            newTextInput(),
 		incidentViewer:   newIncidentViewer(),
+		logViewer:        newLogViewer(),
+		logFilePath:      defaultLogFilePath(),
 		spinner:          s,
 		markdownRenderer: renderer,
 		apiInProgress:    false,
@@ -399,4 +405,19 @@ func newIncidentViewer() viewport.Model {
 	vp := viewport.New(100, 100)
 	vp.Style = incidentViewerStyle
 	return vp
+}
+
+func newLogViewer() viewport.Model {
+	vp := viewport.New(100, 100)
+	vp.Style = incidentViewerStyle
+	return vp
+}
+
+// defaultLogFilePath returns the default path for the srepd debug log file.
+func defaultLogFilePath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return home + "/.config/srepd/debug.log"
 }

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -139,6 +139,10 @@ func (m model) windowSizeMsgHandler(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.incidentViewer.Height = 10 // Minimum height
 	}
 
+	// Log viewer uses the same dimensions as the incident viewer
+	m.logViewer.Width = m.incidentViewer.Width
+	m.logViewer.Height = m.incidentViewer.Height
+
 	m.help.Width = windowSize.Width - horizontalScratchWidth
 
 	return m, nil
@@ -190,6 +194,9 @@ func (m model) keyMsgHandler(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch {
 	case m.err != nil:
 		return switchErrorFocusMode(m, msg)
+
+	case m.viewingLog:
+		return switchLogFocusMode(m, msg)
 
 	case m.viewingIncident:
 		return switchIncidentFocusMode(m, msg)
@@ -484,6 +491,9 @@ func switchTableFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 			c := []string{defaultBrowserOpenCommand}
 			return m, openBrowserCmd(c, link)
 
+		case key.Matches(msg, defaultKeyMap.ViewLog):
+			return m, readLogFile(m.logFilePath)
+
 		}
 	}
 	return m, tea.Batch(cmds...)
@@ -609,6 +619,34 @@ func switchIncidentFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 	// This prevents the viewport from consuming ESC and other navigation keys
 	if !handledKey {
 		m.incidentViewer, cmd = m.incidentViewer.Update(msg)
+		cmds = append(cmds, cmd)
+	}
+
+	return m, tea.Batch(cmds...)
+}
+
+func switchLogFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	var cmds []tea.Cmd
+
+	handledKey := false
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch {
+		case key.Matches(msg, defaultKeyMap.Back):
+			m.viewingLog = false
+			m.table.Focus()
+			return m, nil
+
+		case key.Matches(msg, defaultKeyMap.Help):
+			m.toggleHelp()
+			handledKey = true
+		}
+	}
+
+	if !handledKey {
+		m.logViewer, cmd = m.logViewer.Update(msg)
 		cmds = append(cmds, cmd)
 	}
 

--- a/pkg/tui/msgHandlers_test.go
+++ b/pkg/tui/msgHandlers_test.go
@@ -347,6 +347,109 @@ func TestClusterSelect_ClearedOnViewTransition(t *testing.T) {
 		"Cluster select options should be cleared on view transition")
 }
 
+// viewLogKeyMsg returns a tea.KeyMsg that matches the ViewLog key binding (ctrl+d).
+func viewLogKeyMsg() tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyCtrlD}
+}
+
+func TestViewLogKey_OpensLogViewer(t *testing.T) {
+	// Scenario: Pressing ctrl+d in table mode should trigger a readLogFile command
+	// which, when its message arrives, sets viewingLog=true.
+
+	m := createTestModel()
+	m.table = newTableWithStyles()
+	m.table.Focus()
+	m.logFilePath = "/tmp/test-srepd-debug.log"
+
+	// Press ctrl+d
+	result, cmd := m.Update(viewLogKeyMsg())
+	updatedModel := result.(model)
+
+	// The model should NOT yet be viewingLog (that happens on logFileContentMsg)
+	// But a command should be returned (readLogFile)
+	assert.NotNil(t, cmd, "ctrl+d should return a command to read the log file")
+	assert.False(t, updatedModel.viewingLog, "viewingLog should not be set until content arrives")
+}
+
+func TestViewLogKey_EscapeCloses(t *testing.T) {
+	// Scenario: When viewingLog is true, pressing Escape should dismiss the log viewer.
+
+	m := createTestModel()
+	m.viewingLog = true
+	m.logViewer = newLogViewer()
+
+	escMsg := tea.KeyMsg{Type: tea.KeyEscape}
+	result, cmd := m.Update(escMsg)
+	updatedModel := result.(model)
+
+	assert.False(t, updatedModel.viewingLog, "Escape should dismiss the log viewer")
+	assert.Nil(t, cmd, "No command should be returned after dismissing log viewer")
+}
+
+func TestLogFileContentMsg_SetsViewport(t *testing.T) {
+	// Scenario: When logFileContentMsg arrives, it should set viewport content
+	// and set viewingLog=true.
+
+	m := createTestModel()
+	m.logViewer = newLogViewer()
+
+	content := "2025-01-01 DEBUG test log entry\n2025-01-02 INFO another entry"
+	msg := logFileContentMsg(content)
+
+	result, cmd := m.Update(msg)
+	updatedModel := result.(model)
+
+	assert.True(t, updatedModel.viewingLog, "viewingLog should be true after content arrives")
+	assert.Nil(t, cmd, "No further command should be returned")
+}
+
+func TestLogFileContentMsg_FileNotFound(t *testing.T) {
+	// Scenario: When logFileContentMsg arrives with a "file not found" message,
+	// it should still display in the viewport.
+
+	m := createTestModel()
+	m.logViewer = newLogViewer()
+
+	content := "No log file found at /tmp/nonexistent.log"
+	msg := logFileContentMsg(content)
+
+	result, _ := m.Update(msg)
+	updatedModel := result.(model)
+
+	assert.True(t, updatedModel.viewingLog, "viewingLog should be true even for error messages")
+}
+
+func TestLogViewer_WindowResize(t *testing.T) {
+	// Scenario: WindowSizeMsg should set logViewer dimensions.
+
+	m := model{
+		table:          newTableWithStyles(),
+		actionLogTable: newActionLogTable(),
+		incidentViewer: newIncidentViewer(),
+		logViewer:      newLogViewer(),
+		help:           newHelp(),
+		incidentCache:  make(map[string]*cachedIncidentData),
+	}
+
+	msg := tea.WindowSizeMsg{Width: 120, Height: 50}
+	result, _ := m.windowSizeMsgHandler(msg)
+	updatedModel := result.(model)
+
+	// logViewer should have the same dimensions as incidentViewer
+	assert.Equal(t, updatedModel.incidentViewer.Width, updatedModel.logViewer.Width,
+		"logViewer width should match incidentViewer width")
+	assert.Equal(t, updatedModel.incidentViewer.Height, updatedModel.logViewer.Height,
+		"logViewer height should match incidentViewer height")
+}
+
+func TestViewLogKey_InKeymap(t *testing.T) {
+	// Scenario: ctrl+d should be registered in the keymap as ViewLog.
+
+	// Check that the binding exists and matches ctrl+d
+	keys := defaultKeyMap.ViewLog.Keys()
+	assert.Contains(t, keys, "ctrl+d", "ViewLog binding should include ctrl+d")
+}
+
 func TestTableMode_UnAckKeyWithNoSelectedIncident(t *testing.T) {
 	// Scenario: The table has rows with incidents highlighted, but
 	// selectedIncident is nil. Pressing UnAck key should sync the highlighted

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -690,6 +690,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		log.Debug("Update", "waitForSelectedIncidentThenDoMsg", "performing action", "action", msg.action, "incident", m.selectedIncident.ID)
 		return m, msg.action
 
+	case logFileContentMsg:
+		m.logViewer.SetContent(string(msg))
+		m.logViewer.GotoBottom()
+		m.viewingLog = true
+		return m, nil
+
 	case renderIncidentMsg:
 		if m.selectedIncident == nil {
 			m.setStatus("failed render incidents - no incidents provided")

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -156,6 +156,9 @@ func (m model) View() string {
 
 		return errorStyle.Render(s.String())
 
+	case m.viewingLog:
+		s.WriteString(tableContainerStyle.Render(m.logViewer.View()))
+
 	case m.viewingIncident:
 		s.WriteString(tableContainerStyle.Render(m.incidentViewer.View()))
 


### PR DESCRIPTION
## Summary
Scrollable viewport showing debug log contents, same pattern as incident viewer:
- ctrl+d opens log viewer (reads ~/.config/srepd/debug.log)
- Escape to dismiss
- Up/down/page scroll through log entries
- GotoBottom on open (shows latest entries)
- Graceful handling when log file missing
- 6 TDD tests

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)