### PR TITLE
Add dev mode with test data fixtures (--dev flag)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,6 +33,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/log"
 	"github.com/clcollins/srepd/pkg/launcher"
+	"github.com/clcollins/srepd/pkg/pd"
 	"github.com/clcollins/srepd/pkg/tui"
 	"github.com/coreos/go-systemd/journal"
 	"github.com/spf13/cobra"
@@ -62,6 +63,12 @@ but rather a simple tool to make on-call tasks easier.`,
 			return log.WarnLevel
 		}())
 
+		// Skip config validation in dev mode
+		if viper.GetBool("dev") {
+			log.Info("Dev mode enabled: skipping config validation")
+			return
+		}
+
 		err := validateConfig()
 		if err != nil {
 			log.Fatal(err)
@@ -69,6 +76,11 @@ but rather a simple tool to make on-call tasks easier.`,
 
 	},
 	Run: func(cmd *cobra.Command, args []string) {
+
+		if viper.GetBool("dev") {
+			runDevMode()
+			return
+		}
 
 		launcher, err := launcher.NewClusterLauncher(viper.GetString("terminal"), viper.GetString("cluster_login_command"), viper.GetString("toolbox_mode"))
 		if err != nil {
@@ -135,6 +147,11 @@ func bindArgsToViper(cmd *cobra.Command) {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	err = viper.BindPFlag("dev", cmd.Flags().Lookup("dev"))
+	if err != nil {
+		log.Fatal(err)
+	}
 }
 
 type cliFlag struct {
@@ -157,6 +174,7 @@ func (f cliFlag) BoolValue() bool {
 func init() {
 	var flags = []cliFlag{
 		{"bool", "debug", "d", "false", "enable debug logging"},
+		{"bool", "dev", "D", "false", "enable dev mode with fixture data (no PagerDuty connection required)"},
 		// TODO - For some reason the parsed cluster-login-command flag does not work (the "%%" is stripped out)
 		// Commenting out the config options for now, as the config file is the preferred method
 		// {"string", "token", "T", "", "PagerDuty API token"},
@@ -179,6 +197,60 @@ func init() {
 		case "stringSlice":
 			rootCmd.Flags().StringSliceP(f.name, f.shorthand, []string{f.StringValue()}, f.usage)
 		}
+	}
+}
+
+// defaultFixturesDir is the path to fixture data relative to the binary's working directory.
+// It can be overridden by the SREPD_FIXTURES_DIR environment variable.
+const defaultFixturesDir = "testdata/fixtures"
+
+// runDevMode starts the TUI in development mode using fixture data instead of live PagerDuty.
+func runDevMode() {
+	fixturesDir := viper.GetString("fixtures_dir")
+	if fixturesDir == "" {
+		fixturesDir = defaultFixturesDir
+	}
+
+	log.Info("Dev mode: loading fixtures", "dir", fixturesDir)
+
+	config, err := pd.NewDevConfig(fixturesDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to load dev fixtures: %v\n", err)
+		log.Fatal(err)
+	}
+
+	// Create a dev launcher that logs instead of executing
+	devLauncher, err := launcher.NewClusterLauncherWithToolbox(
+		"echo dev-mode",
+		"echo %%CLUSTER_ID%%",
+		"false",
+		func() bool { return false },
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create dev launcher: %v\n", err)
+		log.Fatal(err)
+	}
+
+	m, _ := tui.InitialModelWithConfig(
+		config,
+		viper.GetStringSlice("editor"),
+		devLauncher,
+		viper.GetBool("debug"),
+	)
+
+	p := tea.NewProgram(m, tea.WithAltScreen())
+
+	go func() {
+		for {
+			time.Sleep(tickInterval * time.Second)
+			p.Send(tui.TickMsg{})
+		}
+	}()
+
+	_, err = p.Run()
+	if err != nil {
+		fmt.Println(err)
+		log.Fatal(err)
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -152,6 +152,10 @@ func bindArgsToViper(cmd *cobra.Command) {
 	if err != nil {
 		log.Fatal(err)
 	}
+	err = viper.BindPFlag("fixtures_dir", cmd.Flags().Lookup("fixtures-dir"))
+	if err != nil {
+		log.Fatal(err)
+	}
 }
 
 type cliFlag struct {
@@ -175,6 +179,7 @@ func init() {
 	var flags = []cliFlag{
 		{"bool", "debug", "d", "false", "enable debug logging"},
 		{"bool", "dev", "D", "false", "enable dev mode with fixture data (no PagerDuty connection required)"},
+		{"string", "fixtures-dir", "F", "testdata/fixtures", "path to fixture data directory for dev mode"},
 		// TODO - For some reason the parsed cluster-login-command flag does not work (the "%%" is stripped out)
 		// Commenting out the config options for now, as the config file is the preferred method
 		// {"string", "token", "T", "", "PagerDuty API token"},
@@ -216,6 +221,8 @@ func runDevMode() {
 	config, err := pd.NewDevConfig(fixturesDir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to load dev fixtures: %v\n", err)
+		fmt.Fprintf(os.Stderr, "\nRun srepd --dev from the repository root, or set SREPD_FIXTURES_DIR:\n")
+		fmt.Fprintf(os.Stderr, "  SREPD_FIXTURES_DIR=/path/to/testdata/fixtures srepd --dev\n\n")
 		log.Fatal(err)
 	}
 

--- a/docs/plans/055-dev-mode.md
+++ b/docs/plans/055-dev-mode.md
@@ -1,0 +1,66 @@
+# Plan 055: Dev Mode with DevPagerDutyClient
+
+**Issue**: #201
+**Branch**: srepd/dev-mode-v2
+**Status**: In Progress
+
+## Problem
+
+srepd requires a live PagerDuty connection for development and UI iteration.
+Developers need a way to run the TUI with realistic fixture data without
+a PagerDuty API token.
+
+## Solution
+
+Add a `--dev` / `-D` CLI flag (and `SREPD_DEV=true` env var) that:
+
+1. Skips token validation and PagerDuty API initialization
+2. Loads JSON fixture data from `testdata/fixtures/`
+3. Uses a `DevPagerDutyClient` with in-memory mutable state
+4. Logs instead of launching terminals for cluster login
+
+### Components
+
+| File | Action |
+|------|--------|
+| `pkg/pd/dev.go` | New: DevPagerDutyClient with 12 interface methods |
+| `pkg/pd/dev_test.go` | New: 7+ TDD tests |
+| `testdata/fixtures/incidents.json` | New: 12 incident scenarios |
+| `testdata/fixtures/alerts.json` | New: alert data keyed by incident ID |
+| `testdata/fixtures/notes.json` | New: notes keyed by incident ID |
+| `testdata/fixtures/config.json` | New: user, teams, escalation policies |
+| `cmd/root.go` | Modify: --dev flag, init bypass |
+| `cmd/config.go` | Modify: skip validation in dev mode |
+
+### Fixture Scenarios (12 incidents covering 6 alert types)
+
+1. osd_hive single alert
+2. osd_hive multi-alert (3 alerts same cluster)
+3. appsre alert
+4. rhobs_hcp alert
+5. rhobs_infra alert (no cluster_id)
+6. deadmanssnitch alert
+7. cee_escalation (zero alerts)
+8. 25+ alerts for large payload testing
+9. Multi-cluster incident (3 different cluster_ids)
+10. Already acknowledged incident
+11. Title mutations with bracket prefixes
+12. Incident with 3 notes from different users
+
+### Write Operations (In-Memory State Changes)
+
+- Acknowledge: status -> "acknowledged", add to Acknowledgements
+- Silence: update EscalationPolicy
+- Re-escalate: update Assignments
+- Add note: append to in-memory notes map
+
+## Test Plan
+
+- [ ] TestDevClient_ListIncidents - returns fixture incidents
+- [ ] TestDevClient_GetIncident - returns specific incident
+- [ ] TestDevClient_AcknowledgeUpdatesState - ManageIncidents modifies status
+- [ ] TestDevClient_AddNoteAppendsToList - CreateNote adds to map
+- [ ] TestDevClient_ListIncidentsAfterAck - state persists across calls
+- [ ] TestDevClient_SilenceUpdatesPolicy - policy changes in memory
+- [ ] TestLoadFixtures - JSON files load correctly
+- [ ] All existing tests continue to pass

--- a/pkg/pd/dev.go
+++ b/pkg/pd/dev.go
@@ -1,0 +1,639 @@
+package pd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/PagerDuty/go-pagerduty"
+	"github.com/charmbracelet/log"
+	"github.com/clcollins/srepd/pkg/rand"
+)
+
+// FixtureConfig holds the dev mode configuration data loaded from config.json
+type FixtureConfig struct {
+	User               fixtureUser                        `json:"user"`
+	Teams              []fixtureTeam                      `json:"teams"`
+	TeamMembers        []fixtureUser                      `json:"team_members"`
+	EscalationPolicies map[string]fixtureEscalationPolicy `json:"escalation_policies"`
+}
+
+type fixtureUser struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Email   string `json:"email"`
+	Type    string `json:"type"`
+	Self    string `json:"self"`
+	HTMLURL string `json:"html_url"`
+}
+
+type fixtureTeam struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Type    string `json:"type"`
+	Self    string `json:"self"`
+	HTMLURL string `json:"html_url"`
+}
+
+type fixtureEscalationPolicy struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+// fixtureIncident is a simplified incident for JSON unmarshaling.
+// Fields match the PagerDuty API JSON structure.
+type fixtureIncident struct {
+	ID                 string              `json:"id"`
+	Type               string              `json:"type"`
+	Self               string              `json:"self"`
+	HTMLURL            string              `json:"html_url"`
+	IncidentNumber     uint                `json:"incident_number"`
+	Title              string              `json:"title"`
+	Status             string              `json:"status"`
+	Urgency            string              `json:"urgency"`
+	CreatedAt          string              `json:"created_at"`
+	LastStatusChangeAt string              `json:"last_status_change_at"`
+	Service            fixtureServiceRef   `json:"service"`
+	EscalationPolicy   fixtureAPIRef       `json:"escalation_policy"`
+	Assignments        []fixtureAssignment `json:"assignments"`
+	Acknowledgements   []fixtureAck        `json:"acknowledgements"`
+}
+
+type fixtureServiceRef struct {
+	ID      string `json:"id"`
+	Type    string `json:"type"`
+	Summary string `json:"summary"`
+	Self    string `json:"self"`
+	HTMLURL string `json:"html_url"`
+}
+
+type fixtureAPIRef struct {
+	ID      string `json:"id"`
+	Type    string `json:"type"`
+	Summary string `json:"summary"`
+}
+
+type fixtureAssignment struct {
+	At       string        `json:"at"`
+	Assignee fixtureAPIRef `json:"assignee"`
+}
+
+type fixtureAck struct {
+	At           string        `json:"at"`
+	Acknowledger fixtureAPIRef `json:"acknowledger"`
+}
+
+// fixtureAlert is a simplified alert for JSON unmarshaling
+type fixtureAlert struct {
+	ID        string                 `json:"id"`
+	Type      string                 `json:"type"`
+	Status    string                 `json:"status"`
+	CreatedAt string                 `json:"created_at"`
+	Service   fixtureServiceRef      `json:"service"`
+	Body      map[string]interface{} `json:"body"`
+}
+
+// fixtureNote is a simplified note for JSON unmarshaling
+type fixtureNote struct {
+	ID        string        `json:"id"`
+	Content   string        `json:"content"`
+	CreatedAt string        `json:"created_at"`
+	User      fixtureAPIRef `json:"user"`
+}
+
+// Fixtures holds all loaded fixture data
+type Fixtures struct {
+	Incidents []fixtureIncident
+	Alerts    map[string][]fixtureAlert
+	Notes     map[string][]fixtureNote
+	Config    FixtureConfig
+}
+
+// LoadFixtures reads JSON fixture files from the given directory
+func LoadFixtures(dir string) (*Fixtures, error) {
+	var fixtures Fixtures
+
+	// Load incidents
+	incidentsData, err := os.ReadFile(filepath.Join(dir, "incidents.json"))
+	if err != nil {
+		return nil, fmt.Errorf("LoadFixtures: failed to read incidents.json: %w", err)
+	}
+	if err := json.Unmarshal(incidentsData, &fixtures.Incidents); err != nil {
+		return nil, fmt.Errorf("LoadFixtures: failed to parse incidents.json: %w", err)
+	}
+
+	// Load alerts
+	alertsData, err := os.ReadFile(filepath.Join(dir, "alerts.json"))
+	if err != nil {
+		return nil, fmt.Errorf("LoadFixtures: failed to read alerts.json: %w", err)
+	}
+	if err := json.Unmarshal(alertsData, &fixtures.Alerts); err != nil {
+		return nil, fmt.Errorf("LoadFixtures: failed to parse alerts.json: %w", err)
+	}
+
+	// Load notes
+	notesData, err := os.ReadFile(filepath.Join(dir, "notes.json"))
+	if err != nil {
+		return nil, fmt.Errorf("LoadFixtures: failed to read notes.json: %w", err)
+	}
+	if err := json.Unmarshal(notesData, &fixtures.Notes); err != nil {
+		return nil, fmt.Errorf("LoadFixtures: failed to parse notes.json: %w", err)
+	}
+
+	// Load config
+	configData, err := os.ReadFile(filepath.Join(dir, "config.json"))
+	if err != nil {
+		return nil, fmt.Errorf("LoadFixtures: failed to read config.json: %w", err)
+	}
+	if err := json.Unmarshal(configData, &fixtures.Config); err != nil {
+		return nil, fmt.Errorf("LoadFixtures: failed to parse config.json: %w", err)
+	}
+
+	log.Debug("LoadFixtures", "incidents", len(fixtures.Incidents), "alert_keys", len(fixtures.Alerts), "note_keys", len(fixtures.Notes))
+	return &fixtures, nil
+}
+
+// DevPagerDutyClient implements PagerDutyClientInterface with in-memory mutable state
+// for development and testing without a live PagerDuty connection.
+type DevPagerDutyClient struct {
+	mu        sync.RWMutex
+	incidents map[string]*pagerduty.Incident
+	alerts    map[string][]pagerduty.IncidentAlert
+	notes     map[string][]pagerduty.IncidentNote
+
+	currentUser        *pagerduty.User
+	teams              map[string]*pagerduty.Team
+	teamMembers        []pagerduty.Member
+	escalationPolicies map[string]*pagerduty.EscalationPolicy
+	users              map[string]*pagerduty.User
+}
+
+// NewDevPagerDutyClient creates a new DevPagerDutyClient from loaded fixtures
+func NewDevPagerDutyClient(fixtures *Fixtures) (*DevPagerDutyClient, error) {
+	client := &DevPagerDutyClient{
+		incidents:          make(map[string]*pagerduty.Incident),
+		alerts:             make(map[string][]pagerduty.IncidentAlert),
+		notes:              make(map[string][]pagerduty.IncidentNote),
+		teams:              make(map[string]*pagerduty.Team),
+		escalationPolicies: make(map[string]*pagerduty.EscalationPolicy),
+		users:              make(map[string]*pagerduty.User),
+	}
+
+	// Convert fixture user to PagerDuty user
+	client.currentUser = &pagerduty.User{
+		APIObject: pagerduty.APIObject{
+			ID:      fixtures.Config.User.ID,
+			Type:    fixtures.Config.User.Type,
+			Self:    fixtures.Config.User.Self,
+			HTMLURL: fixtures.Config.User.HTMLURL,
+		},
+		Name:  fixtures.Config.User.Name,
+		Email: fixtures.Config.User.Email,
+	}
+	client.users[fixtures.Config.User.ID] = client.currentUser
+
+	// Convert fixture team members to PagerDuty users and members
+	for _, fm := range fixtures.Config.TeamMembers {
+		user := &pagerduty.User{
+			APIObject: pagerduty.APIObject{
+				ID:   fm.ID,
+				Type: fm.Type,
+			},
+			Name:  fm.Name,
+			Email: fm.Email,
+		}
+		client.users[fm.ID] = user
+		client.teamMembers = append(client.teamMembers, pagerduty.Member{
+			User: pagerduty.APIObject{
+				ID:   fm.ID,
+				Type: fm.Type,
+			},
+		})
+	}
+
+	// Convert fixture teams
+	for _, ft := range fixtures.Config.Teams {
+		client.teams[ft.ID] = &pagerduty.Team{
+			APIObject: pagerduty.APIObject{
+				ID:      ft.ID,
+				Type:    ft.Type,
+				Self:    ft.Self,
+				HTMLURL: ft.HTMLURL,
+			},
+			Name: ft.Name,
+		}
+	}
+
+	// Convert fixture escalation policies
+	for key, fp := range fixtures.Config.EscalationPolicies {
+		client.escalationPolicies[fp.ID] = &pagerduty.EscalationPolicy{
+			APIObject: pagerduty.APIObject{
+				ID:   fp.ID,
+				Type: fp.Type,
+			},
+			Name: fp.Name,
+		}
+		// Also store by config key name for lookup
+		client.escalationPolicies[key] = client.escalationPolicies[fp.ID]
+	}
+
+	// Convert fixture incidents to PagerDuty incidents
+	for _, fi := range fixtures.Incidents {
+		incident := convertFixtureIncident(fi)
+		client.incidents[fi.ID] = incident
+	}
+
+	// Convert fixture alerts
+	for incidentID, fixtureAlerts := range fixtures.Alerts {
+		var pdAlerts []pagerduty.IncidentAlert
+		for _, fa := range fixtureAlerts {
+			pdAlerts = append(pdAlerts, convertFixtureAlert(fa))
+		}
+		client.alerts[incidentID] = pdAlerts
+	}
+
+	// Convert fixture notes
+	for incidentID, fixtureNotes := range fixtures.Notes {
+		var pdNotes []pagerduty.IncidentNote
+		for _, fn := range fixtureNotes {
+			pdNotes = append(pdNotes, convertFixtureNote(fn))
+		}
+		client.notes[incidentID] = pdNotes
+	}
+
+	return client, nil
+}
+
+// convertFixtureIncident converts a fixture incident to a PagerDuty incident
+func convertFixtureIncident(fi fixtureIncident) *pagerduty.Incident {
+	incident := &pagerduty.Incident{
+		APIObject: pagerduty.APIObject{
+			ID:      fi.ID,
+			Type:    fi.Type,
+			Self:    fi.Self,
+			HTMLURL: fi.HTMLURL,
+		},
+		IncidentNumber:     fi.IncidentNumber,
+		Title:              fi.Title,
+		Status:             fi.Status,
+		Urgency:            fi.Urgency,
+		CreatedAt:          fi.CreatedAt,
+		LastStatusChangeAt: fi.LastStatusChangeAt,
+		Service: pagerduty.APIObject{
+			ID:      fi.Service.ID,
+			Type:    fi.Service.Type,
+			Summary: fi.Service.Summary,
+			Self:    fi.Service.Self,
+			HTMLURL: fi.Service.HTMLURL,
+		},
+		EscalationPolicy: pagerduty.APIObject{
+			ID:      fi.EscalationPolicy.ID,
+			Type:    fi.EscalationPolicy.Type,
+			Summary: fi.EscalationPolicy.Summary,
+		},
+	}
+
+	for _, fa := range fi.Assignments {
+		incident.Assignments = append(incident.Assignments, pagerduty.Assignment{
+			At: fa.At,
+			Assignee: pagerduty.APIObject{
+				ID:      fa.Assignee.ID,
+				Type:    fa.Assignee.Type,
+				Summary: fa.Assignee.Summary,
+			},
+		})
+	}
+
+	for _, fack := range fi.Acknowledgements {
+		incident.Acknowledgements = append(incident.Acknowledgements, pagerduty.Acknowledgement{
+			At: fack.At,
+			Acknowledger: pagerduty.APIObject{
+				ID:      fack.Acknowledger.ID,
+				Type:    fack.Acknowledger.Type,
+				Summary: fack.Acknowledger.Summary,
+			},
+		})
+	}
+
+	return incident
+}
+
+// convertFixtureAlert converts a fixture alert to a PagerDuty IncidentAlert
+func convertFixtureAlert(fa fixtureAlert) pagerduty.IncidentAlert {
+	return pagerduty.IncidentAlert{
+		APIObject: pagerduty.APIObject{
+			ID:   fa.ID,
+			Type: fa.Type,
+		},
+		Status:    fa.Status,
+		CreatedAt: fa.CreatedAt,
+		Service: pagerduty.APIObject{
+			ID:      fa.Service.ID,
+			Type:    fa.Service.Type,
+			Summary: fa.Service.Summary,
+		},
+		Body: fa.Body,
+	}
+}
+
+// convertFixtureNote converts a fixture note to a PagerDuty IncidentNote
+func convertFixtureNote(fn fixtureNote) pagerduty.IncidentNote {
+	return pagerduty.IncidentNote{
+		ID:        fn.ID,
+		Content:   fn.Content,
+		CreatedAt: fn.CreatedAt,
+		User: pagerduty.APIObject{
+			ID:      fn.User.ID,
+			Type:    fn.User.Type,
+			Summary: fn.User.Summary,
+		},
+	}
+}
+
+// --- PagerDutyClientInterface implementation ---
+
+func (d *DevPagerDutyClient) CreateIncidentNoteWithContext(_ context.Context, id string, note pagerduty.IncidentNote) (*pagerduty.IncidentNote, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	log.Debug("DevPagerDutyClient.CreateIncidentNoteWithContext", "incident_id", id, "content_len", len(note.Content))
+
+	newNote := pagerduty.IncidentNote{
+		ID:        rand.ID("N"),
+		Content:   note.Content,
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		User:      note.User,
+	}
+
+	d.notes[id] = append(d.notes[id], newNote)
+	return &newNote, nil
+}
+
+func (d *DevPagerDutyClient) GetCurrentUserWithContext(_ context.Context, _ pagerduty.GetCurrentUserOptions) (*pagerduty.User, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	return d.currentUser, nil
+}
+
+func (d *DevPagerDutyClient) GetEscalationPolicyWithContext(_ context.Context, id string, _ *pagerduty.GetEscalationPolicyOptions) (*pagerduty.EscalationPolicy, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	policy, ok := d.escalationPolicies[id]
+	if !ok {
+		return nil, fmt.Errorf("DevPagerDutyClient: escalation policy %q not found", id)
+	}
+	return policy, nil
+}
+
+func (d *DevPagerDutyClient) GetIncidentWithContext(_ context.Context, id string) (*pagerduty.Incident, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	incident, ok := d.incidents[id]
+	if !ok {
+		return nil, fmt.Errorf("DevPagerDutyClient: incident %q not found", id)
+	}
+
+	// Return a copy to prevent external mutation
+	copy := *incident
+	return &copy, nil
+}
+
+func (d *DevPagerDutyClient) GetTeamWithContext(_ context.Context, id string) (*pagerduty.Team, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	team, ok := d.teams[id]
+	if !ok {
+		// Fallback: return a team with the ID as name (matches mock behavior)
+		return &pagerduty.Team{
+			APIObject: pagerduty.APIObject{ID: id},
+			Name:      id,
+		}, nil
+	}
+	return team, nil
+}
+
+func (d *DevPagerDutyClient) ListMembersWithContext(_ context.Context, _ string, _ pagerduty.ListTeamMembersOptions) (*pagerduty.ListTeamMembersResponse, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	return &pagerduty.ListTeamMembersResponse{
+		Members: d.teamMembers,
+	}, nil
+}
+
+func (d *DevPagerDutyClient) GetUserWithContext(_ context.Context, id string, _ pagerduty.GetUserOptions) (*pagerduty.User, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	user, ok := d.users[id]
+	if !ok {
+		return nil, fmt.Errorf("DevPagerDutyClient: user %q not found", id)
+	}
+	return user, nil
+}
+
+func (d *DevPagerDutyClient) ListIncidentAlertsWithContext(_ context.Context, id string, _ pagerduty.ListIncidentAlertsOptions) (*pagerduty.ListAlertsResponse, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	alerts := d.alerts[id]
+	if alerts == nil {
+		alerts = []pagerduty.IncidentAlert{}
+	}
+
+	return &pagerduty.ListAlertsResponse{
+		Alerts: alerts,
+	}, nil
+}
+
+func (d *DevPagerDutyClient) ListIncidentsWithContext(_ context.Context, opts pagerduty.ListIncidentsOptions) (*pagerduty.ListIncidentsResponse, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	var incidents []pagerduty.Incident
+
+	for _, incident := range d.incidents {
+		// Filter by status if specified
+		if len(opts.Statuses) > 0 {
+			matched := false
+			for _, status := range opts.Statuses {
+				if incident.Status == status {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				continue
+			}
+		}
+
+		// Return a copy to prevent external mutation
+		copy := *incident
+		incidents = append(incidents, copy)
+	}
+
+	return &pagerduty.ListIncidentsResponse{
+		Incidents: incidents,
+	}, nil
+}
+
+func (d *DevPagerDutyClient) ListIncidentNotesWithContext(_ context.Context, id string) ([]pagerduty.IncidentNote, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	notes := d.notes[id]
+	if notes == nil {
+		notes = []pagerduty.IncidentNote{}
+	}
+
+	return notes, nil
+}
+
+func (d *DevPagerDutyClient) ListOnCallsWithContext(_ context.Context, _ pagerduty.ListOnCallOptions) (*pagerduty.ListOnCallsResponse, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	// Return on-call entries for the fixture user covering the current time
+	now := time.Now().UTC()
+	return &pagerduty.ListOnCallsResponse{
+		OnCalls: []pagerduty.OnCall{
+			{
+				User: pagerduty.User{
+					APIObject: pagerduty.APIObject{
+						ID:      d.currentUser.ID,
+						Type:    "user_reference",
+						Summary: d.currentUser.Name,
+					},
+					Name:  d.currentUser.Name,
+					Email: d.currentUser.Email,
+				},
+				Start:           now.Add(-1 * time.Hour).Format(time.RFC3339),
+				End:             now.Add(12 * time.Hour).Format(time.RFC3339),
+				EscalationLevel: 1,
+			},
+		},
+	}, nil
+}
+
+func (d *DevPagerDutyClient) ManageIncidentsWithContext(_ context.Context, _ string, opts []pagerduty.ManageIncidentsOptions) (*pagerduty.ListIncidentsResponse, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	var managed []pagerduty.Incident
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	for _, opt := range opts {
+		incident, ok := d.incidents[opt.ID]
+		if !ok {
+			return nil, fmt.Errorf("DevPagerDutyClient: incident %q not found", opt.ID)
+		}
+
+		// Handle status change (acknowledge)
+		if opt.Status != "" {
+			log.Debug("DevPagerDutyClient.ManageIncidents", "action", "status_change", "id", opt.ID, "new_status", opt.Status)
+			incident.Status = opt.Status
+			incident.LastStatusChangeAt = now
+
+			// Add acknowledgement if acknowledging
+			if opt.Status == "acknowledged" && len(opt.Assignments) > 0 {
+				incident.Acknowledgements = append(incident.Acknowledgements, pagerduty.Acknowledgement{
+					At: now,
+					Acknowledger: pagerduty.APIObject{
+						ID:   opt.Assignments[0].Assignee.ID,
+						Type: opt.Assignments[0].Assignee.Type,
+					},
+				})
+			}
+		}
+
+		// Handle escalation policy change (silence)
+		if opt.EscalationPolicy != nil {
+			log.Debug("DevPagerDutyClient.ManageIncidents", "action", "policy_change", "id", opt.ID, "new_policy", opt.EscalationPolicy.ID)
+			incident.EscalationPolicy = pagerduty.APIObject{
+				ID:   opt.EscalationPolicy.ID,
+				Type: opt.EscalationPolicy.Type,
+			}
+			incident.LastStatusChangeAt = now
+		}
+
+		// Handle assignment change (reassign/re-escalate)
+		if len(opt.Assignments) > 0 && opt.Status == "" && opt.EscalationPolicy == nil {
+			log.Debug("DevPagerDutyClient.ManageIncidents", "action", "reassign", "id", opt.ID)
+			var assignments []pagerduty.Assignment
+			for _, a := range opt.Assignments {
+				assignments = append(assignments, pagerduty.Assignment{
+					At:       now,
+					Assignee: a.Assignee,
+				})
+			}
+			incident.Assignments = assignments
+			incident.LastStatusChangeAt = now
+		}
+
+		// Handle escalation level change (un-acknowledge)
+		if opt.EscalationLevel > 0 && opt.Status == "" && opt.EscalationPolicy == nil && len(opt.Assignments) == 0 {
+			log.Debug("DevPagerDutyClient.ManageIncidents", "action", "escalation_level", "id", opt.ID, "level", opt.EscalationLevel)
+			incident.LastStatusChangeAt = now
+		}
+
+		copy := *incident
+		managed = append(managed, copy)
+	}
+
+	return &pagerduty.ListIncidentsResponse{
+		Incidents: managed,
+	}, nil
+}
+
+// NewDevConfig creates a pd.Config using the DevPagerDutyClient, bypassing live PD API calls.
+// This is used when --dev mode is active.
+func NewDevConfig(fixturesDir string) (*Config, error) {
+	fixtures, err := LoadFixtures(fixturesDir)
+	if err != nil {
+		return nil, fmt.Errorf("NewDevConfig: %w", err)
+	}
+
+	client, err := NewDevPagerDutyClient(fixtures)
+	if err != nil {
+		return nil, fmt.Errorf("NewDevConfig: %w", err)
+	}
+
+	config := &Config{
+		Client:             client,
+		CurrentUser:        client.currentUser,
+		EscalationPolicies: make(map[string]*pagerduty.EscalationPolicy),
+	}
+
+	// Set up teams
+	for _, team := range client.teams {
+		config.Teams = append(config.Teams, team)
+	}
+
+	// Set up team member IDs
+	for _, member := range client.teamMembers {
+		config.TeamsMemberIDs = append(config.TeamsMemberIDs, member.User.ID)
+	}
+
+	// Set up escalation policies using config keys
+	for key, fp := range fixtures.Config.EscalationPolicies {
+		config.EscalationPolicies[key] = &pagerduty.EscalationPolicy{
+			APIObject: pagerduty.APIObject{
+				ID:   fp.ID,
+				Type: fp.Type,
+			},
+			Name: fp.Name,
+		}
+	}
+
+	log.Info("DevPagerDutyClient initialized", "incidents", len(client.incidents), "user", client.currentUser.Email)
+	return config, nil
+}

--- a/pkg/pd/dev_test.go
+++ b/pkg/pd/dev_test.go
@@ -1,0 +1,385 @@
+package pd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/PagerDuty/go-pagerduty"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testFixturesDir = "../../testdata/fixtures"
+
+func TestLoadFixtures(t *testing.T) {
+	t.Run("loads all fixture files successfully", func(t *testing.T) {
+		fixtures, err := LoadFixtures(testFixturesDir)
+		require.NoError(t, err)
+
+		assert.NotNil(t, fixtures.Incidents)
+		assert.NotNil(t, fixtures.Alerts)
+		assert.NotNil(t, fixtures.Notes)
+		assert.NotNil(t, fixtures.Config)
+
+		// Verify incident count matches fixture data (12 scenarios)
+		assert.Equal(t, 12, len(fixtures.Incidents))
+
+		// Verify config has user, teams, team members, and escalation policies
+		assert.NotEmpty(t, fixtures.Config.User.ID)
+		assert.NotEmpty(t, fixtures.Config.Teams)
+		assert.NotEmpty(t, fixtures.Config.TeamMembers)
+		assert.NotEmpty(t, fixtures.Config.EscalationPolicies)
+	})
+
+	t.Run("returns error for nonexistent directory", func(t *testing.T) {
+		_, err := LoadFixtures("/nonexistent/path")
+		assert.Error(t, err)
+	})
+}
+
+func TestDevClient_ListIncidents(t *testing.T) {
+	client := newTestDevClient(t)
+	ctx := context.Background()
+
+	t.Run("returns all fixture incidents", func(t *testing.T) {
+		resp, err := client.ListIncidentsWithContext(ctx, pagerduty.ListIncidentsOptions{})
+		require.NoError(t, err)
+
+		assert.Equal(t, 12, len(resp.Incidents))
+		assert.False(t, resp.More)
+	})
+
+	t.Run("filters by triggered status", func(t *testing.T) {
+		resp, err := client.ListIncidentsWithContext(ctx, pagerduty.ListIncidentsOptions{
+			Statuses: []string{"triggered"},
+		})
+		require.NoError(t, err)
+
+		for _, inc := range resp.Incidents {
+			assert.Equal(t, "triggered", inc.Status)
+		}
+	})
+
+	t.Run("filters by acknowledged status", func(t *testing.T) {
+		resp, err := client.ListIncidentsWithContext(ctx, pagerduty.ListIncidentsOptions{
+			Statuses: []string{"acknowledged"},
+		})
+		require.NoError(t, err)
+
+		for _, inc := range resp.Incidents {
+			assert.Equal(t, "acknowledged", inc.Status)
+		}
+		// Fixture PDEV_INC_010 is pre-acknowledged
+		assert.GreaterOrEqual(t, len(resp.Incidents), 1)
+	})
+
+	t.Run("returns both triggered and acknowledged by default", func(t *testing.T) {
+		resp, err := client.ListIncidentsWithContext(ctx, pagerduty.ListIncidentsOptions{
+			Statuses: []string{"triggered", "acknowledged"},
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, 12, len(resp.Incidents))
+	})
+}
+
+func TestDevClient_GetIncident(t *testing.T) {
+	client := newTestDevClient(t)
+	ctx := context.Background()
+
+	t.Run("returns specific incident by ID", func(t *testing.T) {
+		incident, err := client.GetIncidentWithContext(ctx, "PDEV_INC_001")
+		require.NoError(t, err)
+
+		assert.Equal(t, "PDEV_INC_001", incident.ID)
+		assert.Equal(t, "ClusterOperatorDown CRITICAL (1)", incident.Title)
+		assert.Equal(t, "triggered", incident.Status)
+	})
+
+	t.Run("returns error for nonexistent incident", func(t *testing.T) {
+		_, err := client.GetIncidentWithContext(ctx, "NONEXISTENT")
+		assert.Error(t, err)
+	})
+}
+
+func TestDevClient_AcknowledgeUpdatesState(t *testing.T) {
+	client := newTestDevClient(t)
+	ctx := context.Background()
+
+	t.Run("acknowledge changes status and adds acknowledgement", func(t *testing.T) {
+		// Verify initial state is triggered
+		incident, err := client.GetIncidentWithContext(ctx, "PDEV_INC_001")
+		require.NoError(t, err)
+		assert.Equal(t, "triggered", incident.Status)
+		assert.Empty(t, incident.Acknowledgements)
+
+		// Acknowledge the incident
+		resp, err := client.ManageIncidentsWithContext(ctx, "dev@example.com", []pagerduty.ManageIncidentsOptions{
+			{
+				ID:     "PDEV_INC_001",
+				Status: "acknowledged",
+				Assignments: []pagerduty.Assignee{
+					{
+						Assignee: pagerduty.APIObject{
+							ID:   "PDEV_USER_001",
+							Type: "user_reference",
+						},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, resp.Incidents)
+
+		// Verify state changed
+		updated, err := client.GetIncidentWithContext(ctx, "PDEV_INC_001")
+		require.NoError(t, err)
+		assert.Equal(t, "acknowledged", updated.Status)
+		assert.NotEmpty(t, updated.Acknowledgements)
+		assert.Equal(t, "PDEV_USER_001", updated.Acknowledgements[0].Acknowledger.ID)
+	})
+}
+
+func TestDevClient_AddNoteAppendsToList(t *testing.T) {
+	client := newTestDevClient(t)
+	ctx := context.Background()
+
+	t.Run("adds note to incident", func(t *testing.T) {
+		// Check initial notes for an incident with no notes
+		notes, err := client.ListIncidentNotesWithContext(ctx, "PDEV_INC_001")
+		require.NoError(t, err)
+		initialCount := len(notes)
+
+		// Add a note
+		note, err := client.CreateIncidentNoteWithContext(ctx, "PDEV_INC_001", pagerduty.IncidentNote{
+			Content: "Test note from dev client",
+			User: pagerduty.APIObject{
+				ID:   "PDEV_USER_001",
+				Type: "user_reference",
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "Test note from dev client", note.Content)
+		assert.NotEmpty(t, note.ID)
+
+		// Verify note was appended
+		updatedNotes, err := client.ListIncidentNotesWithContext(ctx, "PDEV_INC_001")
+		require.NoError(t, err)
+		assert.Equal(t, initialCount+1, len(updatedNotes))
+	})
+}
+
+func TestDevClient_ListIncidentsAfterAck(t *testing.T) {
+	client := newTestDevClient(t)
+	ctx := context.Background()
+
+	t.Run("acknowledged incident persists in list", func(t *testing.T) {
+		// Acknowledge incident
+		_, err := client.ManageIncidentsWithContext(ctx, "dev@example.com", []pagerduty.ManageIncidentsOptions{
+			{
+				ID:     "PDEV_INC_003",
+				Status: "acknowledged",
+				Assignments: []pagerduty.Assignee{
+					{
+						Assignee: pagerduty.APIObject{
+							ID:   "PDEV_USER_001",
+							Type: "user_reference",
+						},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		// List incidents with both statuses
+		resp, err := client.ListIncidentsWithContext(ctx, pagerduty.ListIncidentsOptions{
+			Statuses: []string{"triggered", "acknowledged"},
+		})
+		require.NoError(t, err)
+
+		// Find our acknowledged incident
+		found := false
+		for _, inc := range resp.Incidents {
+			if inc.ID == "PDEV_INC_003" {
+				found = true
+				assert.Equal(t, "acknowledged", inc.Status)
+			}
+		}
+		assert.True(t, found, "acknowledged incident should still appear in list")
+	})
+}
+
+func TestDevClient_SilenceUpdatesPolicy(t *testing.T) {
+	client := newTestDevClient(t)
+	ctx := context.Background()
+
+	t.Run("re-escalate changes escalation policy", func(t *testing.T) {
+		// Verify initial policy
+		incident, err := client.GetIncidentWithContext(ctx, "PDEV_INC_005")
+		require.NoError(t, err)
+		initialPolicyID := incident.EscalationPolicy.ID
+
+		// Re-escalate to silent policy
+		_, err = client.ManageIncidentsWithContext(ctx, "dev@example.com", []pagerduty.ManageIncidentsOptions{
+			{
+				ID:               "PDEV_INC_005",
+				EscalationPolicy: &pagerduty.APIReference{ID: "PDEV_POLICY_SILENT", Type: "escalation_policy"},
+				EscalationLevel:  1,
+			},
+		})
+		require.NoError(t, err)
+
+		// Verify policy changed
+		updated, err := client.GetIncidentWithContext(ctx, "PDEV_INC_005")
+		require.NoError(t, err)
+		assert.NotEqual(t, initialPolicyID, updated.EscalationPolicy.ID)
+		assert.Equal(t, "PDEV_POLICY_SILENT", updated.EscalationPolicy.ID)
+	})
+}
+
+func TestDevClient_ListIncidentAlerts(t *testing.T) {
+	client := newTestDevClient(t)
+	ctx := context.Background()
+
+	t.Run("returns alerts for incident with single alert", func(t *testing.T) {
+		resp, err := client.ListIncidentAlertsWithContext(ctx, "PDEV_INC_001", pagerduty.ListIncidentAlertsOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(resp.Alerts))
+		assert.Equal(t, "PDEV_ALERT_001", resp.Alerts[0].ID)
+	})
+
+	t.Run("returns alerts for incident with multiple alerts", func(t *testing.T) {
+		resp, err := client.ListIncidentAlertsWithContext(ctx, "PDEV_INC_002", pagerduty.ListIncidentAlertsOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, 3, len(resp.Alerts))
+	})
+
+	t.Run("returns empty alerts for CEE escalation", func(t *testing.T) {
+		resp, err := client.ListIncidentAlertsWithContext(ctx, "PDEV_INC_007", pagerduty.ListIncidentAlertsOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(resp.Alerts))
+	})
+
+	t.Run("returns 25 alerts for large payload incident", func(t *testing.T) {
+		resp, err := client.ListIncidentAlertsWithContext(ctx, "PDEV_INC_008", pagerduty.ListIncidentAlertsOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, 25, len(resp.Alerts))
+	})
+}
+
+func TestDevClient_ListIncidentNotes(t *testing.T) {
+	client := newTestDevClient(t)
+	ctx := context.Background()
+
+	t.Run("returns notes for incident with notes", func(t *testing.T) {
+		notes, err := client.ListIncidentNotesWithContext(ctx, "PDEV_INC_012")
+		require.NoError(t, err)
+		assert.Equal(t, 3, len(notes))
+	})
+
+	t.Run("returns empty notes for incident without notes", func(t *testing.T) {
+		notes, err := client.ListIncidentNotesWithContext(ctx, "PDEV_INC_001")
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(notes))
+	})
+}
+
+func TestDevClient_GetCurrentUser(t *testing.T) {
+	client := newTestDevClient(t)
+	ctx := context.Background()
+
+	t.Run("returns fixture user", func(t *testing.T) {
+		user, err := client.GetCurrentUserWithContext(ctx, pagerduty.GetCurrentUserOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, "PDEV_USER_001", user.ID)
+		assert.Equal(t, "dev@example.com", user.Email)
+		assert.Equal(t, "Dev User", user.Name)
+	})
+}
+
+func TestDevClient_GetTeam(t *testing.T) {
+	client := newTestDevClient(t)
+	ctx := context.Background()
+
+	t.Run("returns fixture team", func(t *testing.T) {
+		team, err := client.GetTeamWithContext(ctx, "PDEV_TEAM_001")
+		require.NoError(t, err)
+		assert.Equal(t, "PDEV_TEAM_001", team.ID)
+		assert.Equal(t, "SREP On-Call", team.Name)
+	})
+}
+
+func TestDevClient_GetEscalationPolicy(t *testing.T) {
+	client := newTestDevClient(t)
+	ctx := context.Background()
+
+	t.Run("returns fixture escalation policy", func(t *testing.T) {
+		policy, err := client.GetEscalationPolicyWithContext(ctx, "PDEV_POLICY_DEFAULT", &pagerduty.GetEscalationPolicyOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, "PDEV_POLICY_DEFAULT", policy.ID)
+		assert.Equal(t, "SREP Default Escalation", policy.Name)
+	})
+
+	t.Run("returns error for unknown policy", func(t *testing.T) {
+		_, err := client.GetEscalationPolicyWithContext(ctx, "NONEXISTENT", &pagerduty.GetEscalationPolicyOptions{})
+		assert.Error(t, err)
+	})
+}
+
+func TestDevClient_ListMembers(t *testing.T) {
+	client := newTestDevClient(t)
+	ctx := context.Background()
+
+	t.Run("returns team members", func(t *testing.T) {
+		resp, err := client.ListMembersWithContext(ctx, "PDEV_TEAM_001", pagerduty.ListTeamMembersOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, 3, len(resp.Members))
+	})
+}
+
+func TestDevClient_GetUser(t *testing.T) {
+	client := newTestDevClient(t)
+	ctx := context.Background()
+
+	t.Run("returns user by ID", func(t *testing.T) {
+		user, err := client.GetUserWithContext(ctx, "PDEV_USER_002", pagerduty.GetUserOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, "PDEV_USER_002", user.ID)
+		assert.Equal(t, "Alice Engineer", user.Name)
+	})
+
+	t.Run("returns error for unknown user", func(t *testing.T) {
+		_, err := client.GetUserWithContext(ctx, "NONEXISTENT", pagerduty.GetUserOptions{})
+		assert.Error(t, err)
+	})
+}
+
+func TestDevClient_ListOnCalls(t *testing.T) {
+	client := newTestDevClient(t)
+	ctx := context.Background()
+
+	t.Run("returns on-call entries", func(t *testing.T) {
+		resp, err := client.ListOnCallsWithContext(ctx, pagerduty.ListOnCallOptions{})
+		require.NoError(t, err)
+		assert.NotNil(t, resp)
+		// Dev client returns a current on-call entry for the fixture user
+		assert.GreaterOrEqual(t, len(resp.OnCalls), 1)
+	})
+}
+
+func TestDevClient_ImplementsInterface(t *testing.T) {
+	// Compile-time check that DevPagerDutyClient implements PagerDutyClientInterface
+	var _ PagerDutyClientInterface = (*DevPagerDutyClient)(nil)
+}
+
+// newTestDevClient creates a DevPagerDutyClient loaded with test fixtures
+func newTestDevClient(t *testing.T) *DevPagerDutyClient {
+	t.Helper()
+	fixtures, err := LoadFixtures(testFixturesDir)
+	require.NoError(t, err)
+
+	client, err := NewDevPagerDutyClient(fixtures)
+	require.NoError(t, err)
+
+	return client
+}

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"os"
 	"time"
 
@@ -173,6 +174,62 @@ func InitialModel(
 
 	return m, func() tea.Msg {
 		return errMsg{err}
+	}
+}
+
+// InitialModelWithConfig creates the initial TUI model using a pre-built pd.Config.
+// This is used by dev mode to bypass live PagerDuty API initialization.
+func InitialModelWithConfig(
+	config *pd.Config,
+	editor []string,
+	launcher launcher.ClusterLauncher,
+	debug bool,
+) (tea.Model, tea.Cmd) {
+
+	s := spinner.New()
+	s.Spinner = spinner.MiniDot
+	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
+
+	// Create markdown renderer once
+	renderer, err := glamour.NewTermRenderer(
+		glamour.WithWordWrap(100),
+	)
+	if err != nil {
+		log.Error("tui.InitialModelWithConfig()", "msg", "failed to create markdown renderer", "error", err)
+		renderer = nil
+	}
+
+	m := model{
+
+		editor:           editor,
+		launcher:         launcher,
+		debug:            debug,
+		help:             newHelp(),
+		table:            newTableWithStyles(),
+		actionLogTable:   newActionLogTable(),
+		actionLog:        []actionLogEntry{},
+		input:            newTextInput(),
+		incidentViewer:   newIncidentViewer(),
+		spinner:          s,
+		markdownRenderer: renderer,
+		apiInProgress:    false,
+		status:           "",
+		incidentCache:    make(map[string]*cachedIncidentData),
+		scheduledJobs:    append([]*scheduledJob{}, initialScheduledJobs...),
+		autoRefresh:      true,
+		showLowUrgency:   true,
+	}
+
+	m.config = config
+
+	if config == nil {
+		m.err = fmt.Errorf("InitialModelWithConfig: config is nil")
+	}
+
+	log.Debug("InitialModelWithConfig", "config", m.config)
+
+	return m, func() tea.Msg {
+		return errMsg{m.err}
 	}
 }
 

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -466,7 +466,7 @@ func newIncidentViewer() viewport.Model {
 
 func newLogViewer() viewport.Model {
 	vp := viewport.New(100, 100)
-	vp.Style = incidentViewerStyle
+	// Viewport uses container border from View(), no style needed here
 	return vp
 }
 

--- a/testdata/fixtures/alerts.json
+++ b/testdata/fixtures/alerts.json
@@ -1,0 +1,291 @@
+{
+  "PDEV_INC_001": [
+    {
+      "id": "PDEV_ALERT_001",
+      "type": "alert",
+      "status": "triggered",
+      "created_at": "2026-05-28T14:30:00Z",
+      "service": {
+        "id": "PDEV_SVC_001",
+        "type": "service_reference",
+        "summary": "osd-testcluster.p1.openshiftapps.com-hive-cluster"
+      },
+      "body": {
+        "type": "alert_body",
+        "details": {
+          "alert_name": "ClusterOperatorDown",
+          "cluster_id": "e7c5363a-b69b-47bf-98ff-edf99fc3ea25",
+          "firing": "Labels:\n - alertname = ClusterOperatorDown\n - container = kube-rbac-proxy\n - endpoint = metrics\n - namespace = openshift-ingress-operator\n - pod = ingress-operator-5b7c8d9f6-abc12\n - prometheus = openshift-monitoring/k8s\n - severity = critical\nAnnotations:\n - description = The ingress cluster operator has not been available for 10 minutes.\n - summary = Cluster operator ingress is not available\nSource: https://console.redhat.com/monitoring",
+          "link": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/ClusterOperatorDown.md",
+          "num_firing": "1",
+          "num_resolved": "0",
+          "ocm_link": "https://console.redhat.com/openshift/details/e7c5363a-b69b-47bf-98ff-edf99fc3ea25",
+          "resolved": ""
+        }
+      }
+    }
+  ],
+  "PDEV_INC_002": [
+    {
+      "id": "PDEV_ALERT_002A",
+      "type": "alert",
+      "status": "triggered",
+      "created_at": "2026-05-28T13:45:00Z",
+      "service": {
+        "id": "PDEV_SVC_002",
+        "type": "service_reference",
+        "summary": "osd-multicluster.abc1.p1.openshiftapps.com-hive-cluster"
+      },
+      "body": {
+        "type": "alert_body",
+        "details": {
+          "alert_name": "etcdDatabaseQuotaLowSpace",
+          "cluster_id": "b2d4e6f8-1234-5678-9abc-def012345678",
+          "firing": "Labels:\n - alertname = etcdDatabaseQuotaLowSpace\n - namespace = openshift-etcd\n - pod = etcd-master-0\n - severity = critical\nAnnotations:\n - description = etcd database running out of space\n - summary = etcd running low on disk space\nSource: https://console.redhat.com/monitoring",
+          "link": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/etcdDatabaseQuotaLowSpace.md",
+          "num_firing": "3",
+          "num_resolved": "0",
+          "ocm_link": "https://console.redhat.com/openshift/details/b2d4e6f8-1234-5678-9abc-def012345678",
+          "resolved": ""
+        }
+      }
+    },
+    {
+      "id": "PDEV_ALERT_002B",
+      "type": "alert",
+      "status": "triggered",
+      "created_at": "2026-05-28T13:46:00Z",
+      "service": {
+        "id": "PDEV_SVC_002",
+        "type": "service_reference",
+        "summary": "osd-multicluster.abc1.p1.openshiftapps.com-hive-cluster"
+      },
+      "body": {
+        "type": "alert_body",
+        "details": {
+          "alert_name": "etcdMembersDown",
+          "cluster_id": "b2d4e6f8-1234-5678-9abc-def012345678",
+          "firing": "Labels:\n - alertname = etcdMembersDown\n - namespace = openshift-etcd\n - severity = critical\nAnnotations:\n - description = etcd cluster members are down\n - summary = etcd member is down\nSource: https://console.redhat.com/monitoring",
+          "link": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/etcdMembersDown.md",
+          "num_firing": "1",
+          "num_resolved": "0",
+          "ocm_link": "https://console.redhat.com/openshift/details/b2d4e6f8-1234-5678-9abc-def012345678",
+          "resolved": ""
+        }
+      }
+    },
+    {
+      "id": "PDEV_ALERT_002C",
+      "type": "alert",
+      "status": "triggered",
+      "created_at": "2026-05-28T13:47:00Z",
+      "service": {
+        "id": "PDEV_SVC_002",
+        "type": "service_reference",
+        "summary": "osd-multicluster.abc1.p1.openshiftapps.com-hive-cluster"
+      },
+      "body": {
+        "type": "alert_body",
+        "details": {
+          "alert_name": "etcdHighCommitDurations",
+          "cluster_id": "b2d4e6f8-1234-5678-9abc-def012345678",
+          "firing": "Labels:\n - alertname = etcdHighCommitDurations\n - namespace = openshift-etcd\n - severity = warning\nAnnotations:\n - description = etcd commit durations are too high\n - summary = etcd high commit durations\nSource: https://console.redhat.com/monitoring",
+          "link": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/etcdHighCommitDurations.md",
+          "num_firing": "1",
+          "num_resolved": "0",
+          "ocm_link": "https://console.redhat.com/openshift/details/b2d4e6f8-1234-5678-9abc-def012345678",
+          "resolved": ""
+        }
+      }
+    }
+  ],
+  "PDEV_INC_003": [
+    {
+      "id": "PDEV_ALERT_003",
+      "type": "alert",
+      "status": "triggered",
+      "created_at": "2026-05-28T12:15:00Z",
+      "service": {
+        "id": "PDEV_SVC_003",
+        "type": "service_reference",
+        "summary": "app-sre-alertmanager"
+      },
+      "body": {
+        "type": "alert_body",
+        "details": {
+          "cluster_id": "2qjmjvgq7808oqt2hrg190r76h7v4etu",
+          "firing": "Labels:\n - alertname = ClusterProvisioningDelay - production\n - cluster = hivep04ew2\n - cluster_deployment = edf-mas\n - condition = ProvisionFailed\n - endpoint = metrics\n - environment = production\n - image_set = openshift-v4.21.16\n - job = hive-controllers\n - namespace = hive\n - platform = gcp\n - prometheus = openshift-customer-monitoring/app-sre\n - reason = UnknownError\n - severity = high\n - team = srep\nAnnotations:\n - message = cluster edf-mas has been in ProvisionFailed condition for over 4 hours. SOP: https://github.com/openshift/ops-sop/blob/master/v4/alerts/ClusterProvisioningDelay.md\n - runbook = https://github.com/openshift/ops-sop/blob/master/v4/alerts/ClusterProvisioningDelay.md\nSource: https://prometheus.app-sre.devshift.net",
+          "num_firing": "1",
+          "num_resolved": "0",
+          "resolved": ""
+        }
+      }
+    }
+  ],
+  "PDEV_INC_004": [
+    {
+      "id": "PDEV_ALERT_004",
+      "type": "alert",
+      "status": "triggered",
+      "created_at": "2026-05-28T11:00:00Z",
+      "service": {
+        "id": "PDEV_SVC_004",
+        "type": "service_reference",
+        "summary": "rhobs-hcp-prod-critical-us-east-1"
+      },
+      "body": {
+        "type": "alert_body",
+        "details": {
+          "alert_name": "ClusterOperatorDown",
+          "cluster_id": "a4ba96fe-ac69-4573-a78b-17d38eeaab99",
+          "dashboard": "https://grafana.app-sre.devshift.net/d/cf6ntunq7rb40c/rhobs-next-central-rosa-hcp-dashboard?orgId=1&var-cluster_id=a4ba96fe-ac69-4573-a78b-17d38eeaab99",
+          "firing": "\n\n  - alertname: ClusterOperatorDown\n    cluster_id: a4ba96fe-ac69-4573-a78b-17d38eeaab99\n    namespace: ocm-production-a4ba96fe-ac69-4573\n    description: The ingress operator is unavailable for HCP a4ba96fe-ac69-4573-a78b-17d38eeaab99\n\n",
+          "link": "https://github.com/openshift/ops-sop/blob/master/hypershift/alerts/ClusterOperatorDown.md",
+          "num_firing": "1",
+          "num_resolved": "0",
+          "ocm_link": "https://console.redhat.com/openshift/details/a4ba96fe-ac69-4573-a78b-17d38eeaab99",
+          "resolved": "\n\n"
+        }
+      }
+    }
+  ],
+  "PDEV_INC_005": [
+    {
+      "id": "PDEV_ALERT_005",
+      "type": "alert",
+      "status": "triggered",
+      "created_at": "2026-05-28T10:30:00Z",
+      "service": {
+        "id": "PDEV_SVC_005",
+        "type": "service_reference",
+        "summary": "rhobs-infra-prod-us-east-1"
+      },
+      "body": {
+        "type": "alert_body",
+        "details": {
+          "alert_name": "RMOAPIRequestErrorRate",
+          "firing": "\n\n  - alertname: RMOAPIRequestErrorRate\n    cluster_id: \n    namespace: openshift-route-monitor-operator\n    description: Route-monitor-operator on MC hs-mc-n1q4m3hb0 (us-east-1) has >50% API request error rate for 30 minutes.\n\n",
+          "link": "https://github.com/openshift/ops-sop/blob/master/hypershift/alerts/rhobs-synthetics/RMOAPIRequestErrorRate.md",
+          "num_firing": "1",
+          "num_resolved": "0",
+          "resolved": "\n\n"
+        }
+      }
+    }
+  ],
+  "PDEV_INC_006": [
+    {
+      "id": "PDEV_ALERT_006",
+      "type": "alert",
+      "status": "triggered",
+      "created_at": "2026-05-28T09:00:00Z",
+      "service": {
+        "id": "PDEV_SVC_006",
+        "type": "service_reference",
+        "summary": "prod-deadmanssnitch"
+      },
+      "body": {
+        "type": "alert_body",
+        "details": {
+          "cluster_id": "06f058a0-35fa-42c5-83a1-f39184fee819",
+          "last healthy check-in": "2026-05-28T08:50:00.000Z",
+          "name": "testcluster.5uqt.p1.openshiftapps.com",
+          "notes": "cluster_id: 06f058a0-35fa-42c5-83a1-f39184fee819\nrunbook: https://github.com/openshift/ops-sop/blob/master/v4/alerts/cluster_has_gone_missing.md\n",
+          "tags": ["hive-production"],
+          "token": "e686efc420"
+        }
+      }
+    }
+  ],
+  "PDEV_INC_007": [],
+  "PDEV_INC_008": [
+    {
+      "id": "PDEV_ALERT_008_01",
+      "type": "alert",
+      "status": "triggered",
+      "created_at": "2026-05-28T07:00:00Z",
+      "service": {"id": "PDEV_SVC_008", "type": "service_reference", "summary": "osd-largecluster.xyz9.p1.openshiftapps.com-hive-cluster"},
+      "body": {"type": "alert_body", "details": {"alert_name": "MachineHealthCheckUnterminatedShortCircuitSRE", "cluster_id": "c1d2e3f4-5678-9abc-def0-123456789001", "firing": "Labels:\n - alertname = MachineHealthCheckUnterminatedShortCircuitSRE\n - name = worker-us-east-1a\n - namespace = openshift-machine-api\n - severity = critical\nAnnotations:\n - description = MHC worker-us-east-1a short-circuited\nSource: https://console.redhat.com/monitoring", "link": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/MachineHealthCheckUnterminatedShortCircuitSRE.md", "num_firing": "1", "num_resolved": "0", "ocm_link": "https://console.redhat.com/openshift/details/c1d2e3f4-5678-9abc-def0-123456789001"}}
+    },
+    {"id": "PDEV_ALERT_008_02", "type": "alert", "status": "triggered", "created_at": "2026-05-28T07:00:01Z", "service": {"id": "PDEV_SVC_008", "type": "service_reference", "summary": "osd-largecluster.xyz9.p1.openshiftapps.com-hive-cluster"}, "body": {"type": "alert_body", "details": {"alert_name": "MachineHealthCheckUnterminatedShortCircuitSRE", "cluster_id": "c1d2e3f4-5678-9abc-def0-123456789001", "firing": "Labels:\n - alertname = MachineHealthCheckUnterminatedShortCircuitSRE\n - name = worker-us-east-1b\n - namespace = openshift-machine-api\nAnnotations:\n - description = MHC worker-us-east-1b short-circuited\nSource: https://console.redhat.com/monitoring", "link": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/MachineHealthCheckUnterminatedShortCircuitSRE.md", "num_firing": "1", "num_resolved": "0", "ocm_link": "https://console.redhat.com/openshift/details/c1d2e3f4-5678-9abc-def0-123456789001"}}},
+    {"id": "PDEV_ALERT_008_03", "type": "alert", "status": "triggered", "created_at": "2026-05-28T07:00:02Z", "service": {"id": "PDEV_SVC_008", "type": "service_reference", "summary": "osd-largecluster.xyz9.p1.openshiftapps.com-hive-cluster"}, "body": {"type": "alert_body", "details": {"alert_name": "MachineHealthCheckUnterminatedShortCircuitSRE", "cluster_id": "c1d2e3f4-5678-9abc-def0-123456789001", "firing": "Labels:\n - alertname = MachineHealthCheckUnterminatedShortCircuitSRE\n - name = worker-us-east-1c\nAnnotations:\n - description = MHC worker-us-east-1c short-circuited\nSource: https://console.redhat.com/monitoring", "link": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/MachineHealthCheckUnterminatedShortCircuitSRE.md", "num_firing": "1", "num_resolved": "0", "ocm_link": "https://console.redhat.com/openshift/details/c1d2e3f4-5678-9abc-def0-123456789001"}}},
+    {"id": "PDEV_ALERT_008_04", "type": "alert", "status": "triggered", "created_at": "2026-05-28T07:00:03Z", "service": {"id": "PDEV_SVC_008", "type": "service_reference", "summary": "osd-largecluster.xyz9.p1.openshiftapps.com-hive-cluster"}, "body": {"type": "alert_body", "details": {"alert_name": "MachineHealthCheckUnterminatedShortCircuitSRE", "cluster_id": "c1d2e3f4-5678-9abc-def0-123456789001", "firing": "Labels:\n - alertname = MachineHealthCheckUnterminatedShortCircuitSRE\n - name = worker-us-east-1d\nAnnotations:\n - description = MHC worker-us-east-1d short-circuited", "link": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/MachineHealthCheckUnterminatedShortCircuitSRE.md", "num_firing": "1", "num_resolved": "0", "ocm_link": "https://console.redhat.com/openshift/details/c1d2e3f4-5678-9abc-def0-123456789001"}}},
+    {"id": "PDEV_ALERT_008_05", "type": "alert", "status": "triggered", "created_at": "2026-05-28T07:00:04Z", "service": {"id": "PDEV_SVC_008", "type": "service_reference", "summary": "osd-largecluster.xyz9.p1.openshiftapps.com-hive-cluster"}, "body": {"type": "alert_body", "details": {"alert_name": "MachineHealthCheckUnterminatedShortCircuitSRE", "cluster_id": "c1d2e3f4-5678-9abc-def0-123456789001", "firing": "Labels:\n - alertname = MachineHealthCheckUnterminatedShortCircuitSRE\n - name = worker-us-east-1e", "link": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/MachineHealthCheckUnterminatedShortCircuitSRE.md", "num_firing": "1", "num_resolved": "0", "ocm_link": "https://console.redhat.com/openshift/details/c1d2e3f4-5678-9abc-def0-123456789001"}}},
+    {"id": "PDEV_ALERT_008_06", "type": "alert", "status": "triggered", "created_at": "2026-05-28T07:00:05Z", "service": {"id": "PDEV_SVC_008", "type": "service_reference", "summary": "osd-largecluster.xyz9.p1.openshiftapps.com-hive-cluster"}, "body": {"type": "alert_body", "details": {"alert_name": "MachineHealthCheckUnterminatedShortCircuitSRE", "cluster_id": "c1d2e3f4-5678-9abc-def0-123456789001", "firing": "Labels:\n - alertname = MachineHealthCheckUnterminatedShortCircuitSRE\n - name = worker-us-east-1f", "link": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/MachineHealthCheckUnterminatedShortCircuitSRE.md", "num_firing": "1", "num_resolved": "0", "ocm_link": "https://console.redhat.com/openshift/details/c1d2e3f4-5678-9abc-def0-123456789001"}}},
+    {"id": "PDEV_ALERT_008_07", "type": "alert", "status": "triggered", "created_at": "2026-05-28T07:00:06Z", "service": {"id": "PDEV_SVC_008", "type": "service_reference", "summary": "osd-largecluster.xyz9.p1.openshiftapps.com-hive-cluster"}, "body": {"type": "alert_body", "details": {"alert_name": "MachineHealthCheckUnterminatedShortCircuitSRE", "cluster_id": "c1d2e3f4-5678-9abc-def0-123456789001", "firing": "Labels:\n - alertname = MachineHealthCheckUnterminatedShortCircuitSRE\n - name = worker-us-west-2a", "link": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/MachineHealthCheckUnterminatedShortCircuitSRE.md", "num_firing": "1", "num_resolved": "0", "ocm_link": "https://console.redhat.com/openshift/details/c1d2e3f4-5678-9abc-def0-123456789001"}}},
+    {"id": "PDEV_ALERT_008_08", "type": "alert", "status": "triggered", "created_at": "2026-05-28T07:00:07Z", "service": {"id": "PDEV_SVC_008", "type": "service_reference", "summary": "osd-largecluster.xyz9.p1.openshiftapps.com-hive-cluster"}, "body": {"type": "alert_body", "details": {"alert_name": "MachineHealthCheckUnterminatedShortCircuitSRE", "cluster_id": "c1d2e3f4-5678-9abc-def0-123456789001", "firing": "Labels:\n - alertname = MachineHealthCheckUnterminatedShortCircuitSRE\n - name = worker-us-west-2b", "link": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/MachineHealthCheckUnterminatedShortCircuitSRE.md", "num_firing": "1", "num_resolved": "0", "ocm_link": "https://console.redhat.com/openshift/details/c1d2e3f4-5678-9abc-def0-123456789001"}}},
+    {"id": "PDEV_ALERT_008_09", "type": "alert", "status": "triggered", "created_at": "2026-05-28T07:00:08Z", "service": {"id": "PDEV_SVC_008", "type": "service_reference", "summary": "osd-largecluster.xyz9.p1.openshiftapps.com-hive-cluster"}, "body": {"type": "alert_body", "details": {"alert_name": "MachineHealthCheckUnterminatedShortCircuitSRE", "cluster_id": "c1d2e3f4-5678-9abc-def0-123456789001", "firing": "Labels:\n - alertname = MachineHealthCheckUnterminatedShortCircuitSRE\n - name = worker-us-west-2c", "link": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/MachineHealthCheckUnterminatedShortCircuitSRE.md", "num_firing": "1", "num_resolved": "0", "ocm_link": "https://console.redhat.com/openshift/details/c1d2e3f4-5678-9abc-def0-123456789001"}}},
+    {"id": "PDEV_ALERT_008_10", "type": "alert", "status": "triggered", "created_at": "2026-05-28T07:00:09Z", "service": {"id": "PDEV_SVC_008", "type": "service_reference", "summary": "osd-largecluster.xyz9.p1.openshiftapps.com-hive-cluster"}, "body": {"type": "alert_body", "details": {"alert_name": "MachineHealthCheckUnterminatedShortCircuitSRE", "cluster_id": "c1d2e3f4-5678-9abc-def0-123456789001", "firing": "Labels:\n - alertname = MachineHealthCheckUnterminatedShortCircuitSRE\n - name = worker-eu-west-1a", "link": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/MachineHealthCheckUnterminatedShortCircuitSRE.md", "num_firing": "1", "num_resolved": "0", "ocm_link": "https://console.redhat.com/openshift/details/c1d2e3f4-5678-9abc-def0-123456789001"}}},
+    {"id": "PDEV_ALERT_008_11", "type": "alert", "status": "triggered", "created_at": "2026-05-28T07:00:10Z", "service": {"id": "PDEV_SVC_008", "type": "service_reference", "summary": "osd-largecluster.xyz9.p1.openshiftapps.com-hive-cluster"}, "body": {"type": "alert_body", "details": {"alert_name": "MachineHealthCheckUnterminatedShortCircuitSRE", "cluster_id": "c1d2e3f4-5678-9abc-def0-123456789001", "firing": "Labels:\n - alertname = MachineHealthCheckUnterminatedShortCircuitSRE\n - name = worker-eu-west-1b", "link": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/MachineHealthCheckUnterminatedShortCircuitSRE.md", "num_firing": "1", "num_resolved": "0", "ocm_link": "https://console.redhat.com/openshift/details/c1d2e3f4-5678-9abc-def0-123456789001"}}},
+    {"id": "PDEV_ALERT_008_12", "type": "alert", "status": "triggered", "created_at": "2026-05-28T07:00:11Z", "service": {"id": "PDEV_SVC_008", "type": "service_reference", "summary": "osd-largecluster.xyz9.p1.openshiftapps.com-hive-cluster"}, "body": {"type": "alert_body", "details": {"alert_name": "MachineHealthCheckUnterminatedShortCircuitSRE", "cluster_id": "c1d2e3f4-5678-9abc-def0-123456789001", "firing": "Labels:\n - alertname = MachineHealthCheckUnterminatedShortCircuitSRE\n - name = worker-eu-west-1c", "link": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/MachineHealthCheckUnterminatedShortCircuitSRE.md", "num_firing": "1", "num_resolved": "0", "ocm_link": "https://console.redhat.com/openshift/details/c1d2e3f4-5678-9abc-def0-123456789001"}}},
+    {"id": "PDEV_ALERT_008_13", "type": "alert", "status": "triggered", "created_at": "2026-05-28T07:00:12Z", "service": {"id": "PDEV_SVC_008", "type": "service_reference", "summary": "osd-largecluster.xyz9.p1.openshiftapps.com-hive-cluster"}, "body": {"type": "alert_body", "details": {"alert_name": "MachineHealthCheckUnterminatedShortCircuitSRE", "cluster_id": "c1d2e3f4-5678-9abc-def0-123456789001", "firing": "Labels:\n - alertname = MachineHealthCheckUnterminatedShortCircuitSRE\n - name = worker-ap-southeast-1a", "link": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/MachineHealthCheckUnterminatedShortCircuitSRE.md", "num_firing": "1", "num_resolved": "0", "ocm_link": "https://console.redhat.com/openshift/details/c1d2e3f4-5678-9abc-def0-123456789001"}}},
+    {"id": "PDEV_ALERT_008_14", "type": "alert", "status": "triggered", "created_at": "2026-05-28T07:00:13Z", "service": {"id": "PDEV_SVC_008", "type": "service_reference", "summary": "osd-largecluster.xyz9.p1.openshiftapps.com-hive-cluster"}, "body": {"type": "alert_body", "details": {"alert_name": "MachineHealthCheckUnterminatedShortCircuitSRE", "cluster_id": "c1d2e3f4-5678-9abc-def0-123456789001", "firing": "Labels:\n - alertname = MachineHealthCheckUnterminatedShortCircuitSRE\n - name = worker-ap-southeast-1b", "link": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/MachineHealthCheckUnterminatedShortCircuitSRE.md", "num_firing": "1", "num_resolved": "0", "ocm_link": "https://console.redhat.com/openshift/details/c1d2e3f4-5678-9abc-def0-123456789001"}}},
+    {"id": "PDEV_ALERT_008_15", "type": "alert", "status": "triggered", "created_at": "2026-05-28T07:00:14Z", "service": {"id": "PDEV_SVC_008", "type": "service_reference", "summary": "osd-largecluster.xyz9.p1.openshiftapps.com-hive-cluster"}, "body": {"type": "alert_body", "details": {"alert_name": "MachineHealthCheckUnterminatedShortCircuitSRE", "cluster_id": "c1d2e3f4-5678-9abc-def0-123456789001", "firing": "Labels:\n - alertname = MachineHealthCheckUnterminatedShortCircuitSRE\n - name = worker-ap-southeast-2a", "link": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/MachineHealthCheckUnterminatedShortCircuitSRE.md", "num_firing": "1", "num_resolved": "0", "ocm_link": "https://console.redhat.com/openshift/details/c1d2e3f4-5678-9abc-def0-123456789001"}}},
+    {"id": "PDEV_ALERT_008_16", "type": "alert", "status": "triggered", "created_at": "2026-05-28T07:00:15Z", "service": {"id": "PDEV_SVC_008", "type": "service_reference", "summary": "osd-largecluster.xyz9.p1.openshiftapps.com-hive-cluster"}, "body": {"type": "alert_body", "details": {"alert_name": "MachineHealthCheckUnterminatedShortCircuitSRE", "cluster_id": "c1d2e3f4-5678-9abc-def0-123456789001", "firing": "Labels:\n - alertname = MachineHealthCheckUnterminatedShortCircuitSRE\n - name = worker-ap-southeast-2b", "link": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/MachineHealthCheckUnterminatedShortCircuitSRE.md", "num_firing": "1", "num_resolved": "0", "ocm_link": "https://console.redhat.com/openshift/details/c1d2e3f4-5678-9abc-def0-123456789001"}}},
+    {"id": "PDEV_ALERT_008_17", "type": "alert", "status": "triggered", "created_at": "2026-05-28T07:00:16Z", "service": {"id": "PDEV_SVC_008", "type": "service_reference", "summary": "osd-largecluster.xyz9.p1.openshiftapps.com-hive-cluster"}, "body": {"type": "alert_body", "details": {"alert_name": "MachineHealthCheckUnterminatedShortCircuitSRE", "cluster_id": "c1d2e3f4-5678-9abc-def0-123456789001", "firing": "Labels:\n - alertname = MachineHealthCheckUnterminatedShortCircuitSRE\n - name = worker-ca-central-1a", "link": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/MachineHealthCheckUnterminatedShortCircuitSRE.md", "num_firing": "1", "num_resolved": "0", "ocm_link": "https://console.redhat.com/openshift/details/c1d2e3f4-5678-9abc-def0-123456789001"}}},
+    {"id": "PDEV_ALERT_008_18", "type": "alert", "status": "triggered", "created_at": "2026-05-28T07:00:17Z", "service": {"id": "PDEV_SVC_008", "type": "service_reference", "summary": "osd-largecluster.xyz9.p1.openshiftapps.com-hive-cluster"}, "body": {"type": "alert_body", "details": {"alert_name": "MachineHealthCheckUnterminatedShortCircuitSRE", "cluster_id": "c1d2e3f4-5678-9abc-def0-123456789001", "firing": "Labels:\n - alertname = MachineHealthCheckUnterminatedShortCircuitSRE\n - name = worker-ca-central-1b", "link": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/MachineHealthCheckUnterminatedShortCircuitSRE.md", "num_firing": "1", "num_resolved": "0", "ocm_link": "https://console.redhat.com/openshift/details/c1d2e3f4-5678-9abc-def0-123456789001"}}},
+    {"id": "PDEV_ALERT_008_19", "type": "alert", "status": "triggered", "created_at": "2026-05-28T07:00:18Z", "service": {"id": "PDEV_SVC_008", "type": "service_reference", "summary": "osd-largecluster.xyz9.p1.openshiftapps.com-hive-cluster"}, "body": {"type": "alert_body", "details": {"alert_name": "MachineHealthCheckUnterminatedShortCircuitSRE", "cluster_id": "c1d2e3f4-5678-9abc-def0-123456789001", "firing": "Labels:\n - alertname = MachineHealthCheckUnterminatedShortCircuitSRE\n - name = worker-sa-east-1a", "link": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/MachineHealthCheckUnterminatedShortCircuitSRE.md", "num_firing": "1", "num_resolved": "0", "ocm_link": "https://console.redhat.com/openshift/details/c1d2e3f4-5678-9abc-def0-123456789001"}}},
+    {"id": "PDEV_ALERT_008_20", "type": "alert", "status": "triggered", "created_at": "2026-05-28T07:00:19Z", "service": {"id": "PDEV_SVC_008", "type": "service_reference", "summary": "osd-largecluster.xyz9.p1.openshiftapps.com-hive-cluster"}, "body": {"type": "alert_body", "details": {"alert_name": "MachineHealthCheckUnterminatedShortCircuitSRE", "cluster_id": "c1d2e3f4-5678-9abc-def0-123456789001", "firing": "Labels:\n - alertname = MachineHealthCheckUnterminatedShortCircuitSRE\n - name = worker-sa-east-1b", "link": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/MachineHealthCheckUnterminatedShortCircuitSRE.md", "num_firing": "1", "num_resolved": "0", "ocm_link": "https://console.redhat.com/openshift/details/c1d2e3f4-5678-9abc-def0-123456789001"}}},
+    {"id": "PDEV_ALERT_008_21", "type": "alert", "status": "triggered", "created_at": "2026-05-28T07:00:20Z", "service": {"id": "PDEV_SVC_008", "type": "service_reference", "summary": "osd-largecluster.xyz9.p1.openshiftapps.com-hive-cluster"}, "body": {"type": "alert_body", "details": {"alert_name": "MachineHealthCheckUnterminatedShortCircuitSRE", "cluster_id": "c1d2e3f4-5678-9abc-def0-123456789001", "firing": "Labels:\n - alertname = MachineHealthCheckUnterminatedShortCircuitSRE\n - name = worker-me-south-1a", "link": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/MachineHealthCheckUnterminatedShortCircuitSRE.md", "num_firing": "1", "num_resolved": "0", "ocm_link": "https://console.redhat.com/openshift/details/c1d2e3f4-5678-9abc-def0-123456789001"}}},
+    {"id": "PDEV_ALERT_008_22", "type": "alert", "status": "triggered", "created_at": "2026-05-28T07:00:21Z", "service": {"id": "PDEV_SVC_008", "type": "service_reference", "summary": "osd-largecluster.xyz9.p1.openshiftapps.com-hive-cluster"}, "body": {"type": "alert_body", "details": {"alert_name": "MachineHealthCheckUnterminatedShortCircuitSRE", "cluster_id": "c1d2e3f4-5678-9abc-def0-123456789001", "firing": "Labels:\n - alertname = MachineHealthCheckUnterminatedShortCircuitSRE\n - name = worker-me-south-1b", "link": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/MachineHealthCheckUnterminatedShortCircuitSRE.md", "num_firing": "1", "num_resolved": "0", "ocm_link": "https://console.redhat.com/openshift/details/c1d2e3f4-5678-9abc-def0-123456789001"}}},
+    {"id": "PDEV_ALERT_008_23", "type": "alert", "status": "triggered", "created_at": "2026-05-28T07:00:22Z", "service": {"id": "PDEV_SVC_008", "type": "service_reference", "summary": "osd-largecluster.xyz9.p1.openshiftapps.com-hive-cluster"}, "body": {"type": "alert_body", "details": {"alert_name": "MachineHealthCheckUnterminatedShortCircuitSRE", "cluster_id": "c1d2e3f4-5678-9abc-def0-123456789001", "firing": "Labels:\n - alertname = MachineHealthCheckUnterminatedShortCircuitSRE\n - name = worker-af-south-1a", "link": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/MachineHealthCheckUnterminatedShortCircuitSRE.md", "num_firing": "1", "num_resolved": "0", "ocm_link": "https://console.redhat.com/openshift/details/c1d2e3f4-5678-9abc-def0-123456789001"}}},
+    {"id": "PDEV_ALERT_008_24", "type": "alert", "status": "triggered", "created_at": "2026-05-28T07:00:23Z", "service": {"id": "PDEV_SVC_008", "type": "service_reference", "summary": "osd-largecluster.xyz9.p1.openshiftapps.com-hive-cluster"}, "body": {"type": "alert_body", "details": {"alert_name": "MachineHealthCheckUnterminatedShortCircuitSRE", "cluster_id": "c1d2e3f4-5678-9abc-def0-123456789001", "firing": "Labels:\n - alertname = MachineHealthCheckUnterminatedShortCircuitSRE\n - name = worker-af-south-1b", "link": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/MachineHealthCheckUnterminatedShortCircuitSRE.md", "num_firing": "1", "num_resolved": "0", "ocm_link": "https://console.redhat.com/openshift/details/c1d2e3f4-5678-9abc-def0-123456789001"}}},
+    {"id": "PDEV_ALERT_008_25", "type": "alert", "status": "triggered", "created_at": "2026-05-28T07:00:24Z", "service": {"id": "PDEV_SVC_008", "type": "service_reference", "summary": "osd-largecluster.xyz9.p1.openshiftapps.com-hive-cluster"}, "body": {"type": "alert_body", "details": {"alert_name": "MachineHealthCheckUnterminatedShortCircuitSRE", "cluster_id": "c1d2e3f4-5678-9abc-def0-123456789001", "firing": "Labels:\n - alertname = MachineHealthCheckUnterminatedShortCircuitSRE\n - name = worker-eu-central-1a", "link": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/MachineHealthCheckUnterminatedShortCircuitSRE.md", "num_firing": "1", "num_resolved": "0", "ocm_link": "https://console.redhat.com/openshift/details/c1d2e3f4-5678-9abc-def0-123456789001"}}}
+  ],
+  "PDEV_INC_009": [
+    {
+      "id": "PDEV_ALERT_009A",
+      "type": "alert",
+      "status": "triggered",
+      "created_at": "2026-05-28T06:00:00Z",
+      "service": {"id": "PDEV_SVC_009", "type": "service_reference", "summary": "osd-multicluster2.def3.p1.openshiftapps.com-hive-cluster"},
+      "body": {"type": "alert_body", "details": {"alert_name": "console-ErrorBudgetBurn", "cluster_id": "aaaaaaaa-1111-2222-3333-444444444444", "firing": "Labels:\n - alertname = console-ErrorBudgetBurn\n - severity = critical\nAnnotations:\n - description = Console error budget burning too fast\nSource: https://console.redhat.com/monitoring", "link": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/console-ErrorBudgetBurn.md", "num_firing": "1", "num_resolved": "0", "ocm_link": "https://console.redhat.com/openshift/details/aaaaaaaa-1111-2222-3333-444444444444"}}
+    },
+    {
+      "id": "PDEV_ALERT_009B",
+      "type": "alert",
+      "status": "triggered",
+      "created_at": "2026-05-28T06:01:00Z",
+      "service": {"id": "PDEV_SVC_009", "type": "service_reference", "summary": "osd-multicluster2.def3.p1.openshiftapps.com-hive-cluster"},
+      "body": {"type": "alert_body", "details": {"alert_name": "console-ErrorBudgetBurn", "cluster_id": "bbbbbbbb-5555-6666-7777-888888888888", "firing": "Labels:\n - alertname = console-ErrorBudgetBurn\n - severity = critical\nAnnotations:\n - description = Console error budget burning fast on second cluster\nSource: https://console.redhat.com/monitoring", "link": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/console-ErrorBudgetBurn.md", "num_firing": "1", "num_resolved": "0", "ocm_link": "https://console.redhat.com/openshift/details/bbbbbbbb-5555-6666-7777-888888888888"}}
+    },
+    {
+      "id": "PDEV_ALERT_009C",
+      "type": "alert",
+      "status": "triggered",
+      "created_at": "2026-05-28T06:02:00Z",
+      "service": {"id": "PDEV_SVC_009", "type": "service_reference", "summary": "osd-multicluster2.def3.p1.openshiftapps.com-hive-cluster"},
+      "body": {"type": "alert_body", "details": {"alert_name": "console-ErrorBudgetBurn", "cluster_id": "cccccccc-9999-aaaa-bbbb-cccccccccccc", "firing": "Labels:\n - alertname = console-ErrorBudgetBurn\n - severity = critical\nAnnotations:\n - description = Console error budget burning fast on third cluster\nSource: https://console.redhat.com/monitoring", "link": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/console-ErrorBudgetBurn.md", "num_firing": "1", "num_resolved": "0", "ocm_link": "https://console.redhat.com/openshift/details/cccccccc-9999-aaaa-bbbb-cccccccccccc"}}
+    }
+  ],
+  "PDEV_INC_010": [
+    {
+      "id": "PDEV_ALERT_010",
+      "type": "alert",
+      "status": "triggered",
+      "created_at": "2026-05-28T05:00:00Z",
+      "service": {"id": "PDEV_SVC_010", "type": "service_reference", "summary": "osd-ackedcluster.ghi4.p1.openshiftapps.com-hive-cluster"},
+      "body": {"type": "alert_body", "details": {"alert_name": "api-ErrorBudgetBurn", "cluster_id": "dddddddd-1234-5678-9012-eeeeeeeeeeee", "firing": "Labels:\n - alertname = api-ErrorBudgetBurn\n - severity = critical\nAnnotations:\n - description = API error budget burning fast\nSource: https://console.redhat.com/monitoring", "link": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/api-ErrorBudgetBurn.md", "num_firing": "1", "num_resolved": "0", "ocm_link": "https://console.redhat.com/openshift/details/dddddddd-1234-5678-9012-eeeeeeeeeeee"}}
+    }
+  ],
+  "PDEV_INC_011": [
+    {
+      "id": "PDEV_ALERT_011",
+      "type": "alert",
+      "status": "triggered",
+      "created_at": "2026-05-28T04:00:00Z",
+      "service": {"id": "PDEV_SVC_011", "type": "service_reference", "summary": "osd-mutatedtitle.jkl5.p1.openshiftapps.com-hive-cluster"},
+      "body": {"type": "alert_body", "details": {"alert_name": "CannotRetrieveUpdatesSRE", "cluster_id": "ffffffff-abcd-ef01-2345-678901234567", "firing": "Labels:\n - alertname = CannotRetrieveUpdatesSRE\n - severity = critical\nAnnotations:\n - description = Unable to retrieve cluster updates\nSource: https://console.redhat.com/monitoring", "link": "https://github.com/openshift/ops-sop/blob/master/v4/alerts/CannotRetrieveUpdatesSRE.md", "num_firing": "1", "num_resolved": "0", "ocm_link": "https://console.redhat.com/openshift/details/ffffffff-abcd-ef01-2345-678901234567"}}
+    }
+  ],
+  "PDEV_INC_012": [
+    {
+      "id": "PDEV_ALERT_012",
+      "type": "alert",
+      "status": "triggered",
+      "created_at": "2026-05-28T03:00:00Z",
+      "service": {"id": "PDEV_SVC_012", "type": "service_reference", "summary": "rhobs-hcp-prod-critical-us-west-2"},
+      "body": {"type": "alert_body", "details": {"alert_name": "KubeAPIErrorBudgetBurn", "cluster_id": "1b20416f-4022-4ce8-8bde-5a6e450114eb", "dashboard": "https://grafana.app-sre.devshift.net/d/cf6ntunq7rb40c/rhobs-next-central-rosa-hcp-dashboard?orgId=1&var-cluster_id=1b20416f-4022-4ce8-8bde-5a6e450114eb", "firing": "\n\n  - alertname: KubeAPIErrorBudgetBurn\n    cluster_id: 1b20416f-4022-4ce8-8bde-5a6e450114eb\n    namespace: ocm-production-1b20416f-4022\n    description: KubeAPI error budget is burning for HCP 1b20416f-4022-4ce8-8bde-5a6e450114eb\n\n", "link": "https://github.com/openshift/ops-sop/blob/master/hypershift/alerts/KubeAPIErrorBudgetBurn.md", "num_firing": "1", "num_resolved": "0", "ocm_link": "https://console.redhat.com/openshift/details/1b20416f-4022-4ce8-8bde-5a6e450114eb", "resolved": "\n\n"}}
+    }
+  ]
+}

--- a/testdata/fixtures/config.json
+++ b/testdata/fixtures/config.json
@@ -1,0 +1,51 @@
+{
+  "user": {
+    "id": "PDEV_USER_001",
+    "name": "Dev User",
+    "email": "dev@example.com",
+    "type": "user",
+    "self": "https://api.pagerduty.com/users/PDEV_USER_001",
+    "html_url": "https://example.pagerduty.com/users/PDEV_USER_001"
+  },
+  "teams": [
+    {
+      "id": "PDEV_TEAM_001",
+      "name": "SREP On-Call",
+      "type": "team",
+      "self": "https://api.pagerduty.com/teams/PDEV_TEAM_001",
+      "html_url": "https://example.pagerduty.com/teams/PDEV_TEAM_001"
+    }
+  ],
+  "team_members": [
+    {
+      "id": "PDEV_USER_001",
+      "name": "Dev User",
+      "email": "dev@example.com",
+      "type": "user"
+    },
+    {
+      "id": "PDEV_USER_002",
+      "name": "Alice Engineer",
+      "email": "alice@example.com",
+      "type": "user"
+    },
+    {
+      "id": "PDEV_USER_003",
+      "name": "Bob Oncall",
+      "email": "bob@example.com",
+      "type": "user"
+    }
+  ],
+  "escalation_policies": {
+    "DEFAULT": {
+      "id": "PDEV_POLICY_DEFAULT",
+      "name": "SREP Default Escalation",
+      "type": "escalation_policy"
+    },
+    "SILENT_DEFAULT": {
+      "id": "PDEV_POLICY_SILENT",
+      "name": "SREP Silent Escalation",
+      "type": "escalation_policy"
+    }
+  }
+}

--- a/testdata/fixtures/incidents.json
+++ b/testdata/fixtures/incidents.json
@@ -1,0 +1,431 @@
+[
+  {
+    "id": "PDEV_INC_001",
+    "type": "incident",
+    "self": "https://api.pagerduty.com/incidents/PDEV_INC_001",
+    "html_url": "https://example.pagerduty.com/incidents/PDEV_INC_001",
+    "incident_number": 50001,
+    "title": "ClusterOperatorDown CRITICAL (1)",
+    "status": "triggered",
+    "urgency": "high",
+    "created_at": "2026-05-28T14:30:00Z",
+    "last_status_change_at": "2026-05-28T14:30:00Z",
+    "service": {
+      "id": "PDEV_SVC_001",
+      "type": "service_reference",
+      "summary": "osd-testcluster.p1.openshiftapps.com-hive-cluster",
+      "self": "https://api.pagerduty.com/services/PDEV_SVC_001",
+      "html_url": "https://example.pagerduty.com/services/PDEV_SVC_001"
+    },
+    "escalation_policy": {
+      "id": "PDEV_POLICY_DEFAULT",
+      "type": "escalation_policy_reference",
+      "summary": "SREP Default Escalation"
+    },
+    "assignments": [
+      {
+        "at": "2026-05-28T14:30:00Z",
+        "assignee": {
+          "id": "PDEV_USER_001",
+          "type": "user_reference",
+          "summary": "Dev User"
+        }
+      }
+    ],
+    "acknowledgements": []
+  },
+  {
+    "id": "PDEV_INC_002",
+    "type": "incident",
+    "self": "https://api.pagerduty.com/incidents/PDEV_INC_002",
+    "html_url": "https://example.pagerduty.com/incidents/PDEV_INC_002",
+    "incident_number": 50002,
+    "title": "etcdDatabaseQuotaLowSpace CRITICAL (3)",
+    "status": "triggered",
+    "urgency": "high",
+    "created_at": "2026-05-28T13:45:00Z",
+    "last_status_change_at": "2026-05-28T13:45:00Z",
+    "service": {
+      "id": "PDEV_SVC_002",
+      "type": "service_reference",
+      "summary": "osd-multicluster.abc1.p1.openshiftapps.com-hive-cluster",
+      "self": "https://api.pagerduty.com/services/PDEV_SVC_002",
+      "html_url": "https://example.pagerduty.com/services/PDEV_SVC_002"
+    },
+    "escalation_policy": {
+      "id": "PDEV_POLICY_DEFAULT",
+      "type": "escalation_policy_reference",
+      "summary": "SREP Default Escalation"
+    },
+    "assignments": [
+      {
+        "at": "2026-05-28T13:45:00Z",
+        "assignee": {
+          "id": "PDEV_USER_002",
+          "type": "user_reference",
+          "summary": "Alice Engineer"
+        }
+      }
+    ],
+    "acknowledgements": []
+  },
+  {
+    "id": "PDEV_INC_003",
+    "type": "incident",
+    "self": "https://api.pagerduty.com/incidents/PDEV_INC_003",
+    "html_url": "https://example.pagerduty.com/incidents/PDEV_INC_003",
+    "incident_number": 50003,
+    "title": "[FIRING:1] ClusterProvisioningDelay - production hivep04ew2 uhc-production-2qjmjvgq7808oqt2hrg190r76h7v4etu hive-controllers hive (edf-mas ProvisionFailed metrics production openshift-v4.21.16 hive gcp openshift-customer-monitoring/app-sre UnknownError high srep)",
+    "status": "triggered",
+    "urgency": "high",
+    "created_at": "2026-05-28T12:15:00Z",
+    "last_status_change_at": "2026-05-28T12:15:00Z",
+    "service": {
+      "id": "PDEV_SVC_003",
+      "type": "service_reference",
+      "summary": "app-sre-alertmanager",
+      "self": "https://api.pagerduty.com/services/PDEV_SVC_003",
+      "html_url": "https://example.pagerduty.com/services/PDEV_SVC_003"
+    },
+    "escalation_policy": {
+      "id": "PDEV_POLICY_DEFAULT",
+      "type": "escalation_policy_reference",
+      "summary": "SREP Default Escalation"
+    },
+    "assignments": [
+      {
+        "at": "2026-05-28T12:15:00Z",
+        "assignee": {
+          "id": "PDEV_USER_001",
+          "type": "user_reference",
+          "summary": "Dev User"
+        }
+      }
+    ],
+    "acknowledgements": []
+  },
+  {
+    "id": "PDEV_INC_004",
+    "type": "incident",
+    "self": "https://api.pagerduty.com/incidents/PDEV_INC_004",
+    "html_url": "https://example.pagerduty.com/incidents/PDEV_INC_004",
+    "incident_number": 50004,
+    "title": "[HCP] [RHOBS] (Critical) ClusterOperatorDown for HCP: a4ba96fe-ac69-4573-a78b-17d38eeaab99",
+    "status": "triggered",
+    "urgency": "high",
+    "created_at": "2026-05-28T11:00:00Z",
+    "last_status_change_at": "2026-05-28T11:00:00Z",
+    "service": {
+      "id": "PDEV_SVC_004",
+      "type": "service_reference",
+      "summary": "rhobs-hcp-prod-critical-us-east-1",
+      "self": "https://api.pagerduty.com/services/PDEV_SVC_004",
+      "html_url": "https://example.pagerduty.com/services/PDEV_SVC_004"
+    },
+    "escalation_policy": {
+      "id": "PDEV_POLICY_DEFAULT",
+      "type": "escalation_policy_reference",
+      "summary": "SREP Default Escalation"
+    },
+    "assignments": [
+      {
+        "at": "2026-05-28T11:00:00Z",
+        "assignee": {
+          "id": "PDEV_USER_003",
+          "type": "user_reference",
+          "summary": "Bob Oncall"
+        }
+      }
+    ],
+    "acknowledgements": []
+  },
+  {
+    "id": "PDEV_INC_005",
+    "type": "incident",
+    "self": "https://api.pagerduty.com/incidents/PDEV_INC_005",
+    "html_url": "https://example.pagerduty.com/incidents/PDEV_INC_005",
+    "incident_number": 50005,
+    "title": "[HCP] [RHOBS Infra] (Warning) RMOAPIRequestErrorRate",
+    "status": "triggered",
+    "urgency": "low",
+    "created_at": "2026-05-28T10:30:00Z",
+    "last_status_change_at": "2026-05-28T10:30:00Z",
+    "service": {
+      "id": "PDEV_SVC_005",
+      "type": "service_reference",
+      "summary": "rhobs-infra-prod-us-east-1",
+      "self": "https://api.pagerduty.com/services/PDEV_SVC_005",
+      "html_url": "https://example.pagerduty.com/services/PDEV_SVC_005"
+    },
+    "escalation_policy": {
+      "id": "PDEV_POLICY_DEFAULT",
+      "type": "escalation_policy_reference",
+      "summary": "SREP Default Escalation"
+    },
+    "assignments": [
+      {
+        "at": "2026-05-28T10:30:00Z",
+        "assignee": {
+          "id": "PDEV_USER_001",
+          "type": "user_reference",
+          "summary": "Dev User"
+        }
+      }
+    ],
+    "acknowledgements": []
+  },
+  {
+    "id": "PDEV_INC_006",
+    "type": "incident",
+    "self": "https://api.pagerduty.com/incidents/PDEV_INC_006",
+    "html_url": "https://example.pagerduty.com/incidents/PDEV_INC_006",
+    "incident_number": 50006,
+    "title": "testcluster.5uqt.p1.openshiftapps.com has gone missing",
+    "status": "triggered",
+    "urgency": "high",
+    "created_at": "2026-05-28T09:00:00Z",
+    "last_status_change_at": "2026-05-28T09:00:00Z",
+    "service": {
+      "id": "PDEV_SVC_006",
+      "type": "service_reference",
+      "summary": "prod-deadmanssnitch",
+      "self": "https://api.pagerduty.com/services/PDEV_SVC_006",
+      "html_url": "https://example.pagerduty.com/services/PDEV_SVC_006"
+    },
+    "escalation_policy": {
+      "id": "PDEV_POLICY_DEFAULT",
+      "type": "escalation_policy_reference",
+      "summary": "SREP Default Escalation"
+    },
+    "assignments": [
+      {
+        "at": "2026-05-28T09:00:00Z",
+        "assignee": {
+          "id": "PDEV_USER_002",
+          "type": "user_reference",
+          "summary": "Alice Engineer"
+        }
+      }
+    ],
+    "acknowledgements": []
+  },
+  {
+    "id": "PDEV_INC_007",
+    "type": "incident",
+    "self": "https://api.pagerduty.com/incidents/PDEV_INC_007",
+    "html_url": "https://example.pagerduty.com/incidents/PDEV_INC_007",
+    "incident_number": 50007,
+    "title": "OHSS-54116: Access request tracker for cluster '2m89uoc2k3hg86u969bss1q0godb07ek'",
+    "status": "triggered",
+    "urgency": "high",
+    "created_at": "2026-05-28T08:30:00Z",
+    "last_status_change_at": "2026-05-28T08:30:00Z",
+    "service": {
+      "id": "PDEV_SVC_007",
+      "type": "service_reference",
+      "summary": "cee-srep-sev1-escalation-pager",
+      "self": "https://api.pagerduty.com/services/PDEV_SVC_007",
+      "html_url": "https://example.pagerduty.com/services/PDEV_SVC_007"
+    },
+    "escalation_policy": {
+      "id": "PDEV_POLICY_DEFAULT",
+      "type": "escalation_policy_reference",
+      "summary": "SREP Default Escalation"
+    },
+    "assignments": [
+      {
+        "at": "2026-05-28T08:30:00Z",
+        "assignee": {
+          "id": "PDEV_USER_001",
+          "type": "user_reference",
+          "summary": "Dev User"
+        }
+      }
+    ],
+    "acknowledgements": []
+  },
+  {
+    "id": "PDEV_INC_008",
+    "type": "incident",
+    "self": "https://api.pagerduty.com/incidents/PDEV_INC_008",
+    "html_url": "https://example.pagerduty.com/incidents/PDEV_INC_008",
+    "incident_number": 50008,
+    "title": "MachineHealthCheckUnterminatedShortCircuitSRE CRITICAL (25)",
+    "status": "triggered",
+    "urgency": "high",
+    "created_at": "2026-05-28T07:00:00Z",
+    "last_status_change_at": "2026-05-28T07:00:00Z",
+    "service": {
+      "id": "PDEV_SVC_008",
+      "type": "service_reference",
+      "summary": "osd-largecluster.xyz9.p1.openshiftapps.com-hive-cluster",
+      "self": "https://api.pagerduty.com/services/PDEV_SVC_008",
+      "html_url": "https://example.pagerduty.com/services/PDEV_SVC_008"
+    },
+    "escalation_policy": {
+      "id": "PDEV_POLICY_DEFAULT",
+      "type": "escalation_policy_reference",
+      "summary": "SREP Default Escalation"
+    },
+    "assignments": [
+      {
+        "at": "2026-05-28T07:00:00Z",
+        "assignee": {
+          "id": "PDEV_USER_003",
+          "type": "user_reference",
+          "summary": "Bob Oncall"
+        }
+      }
+    ],
+    "acknowledgements": []
+  },
+  {
+    "id": "PDEV_INC_009",
+    "type": "incident",
+    "self": "https://api.pagerduty.com/incidents/PDEV_INC_009",
+    "html_url": "https://example.pagerduty.com/incidents/PDEV_INC_009",
+    "incident_number": 50009,
+    "title": "console-ErrorBudgetBurn CRITICAL (1)",
+    "status": "triggered",
+    "urgency": "high",
+    "created_at": "2026-05-28T06:00:00Z",
+    "last_status_change_at": "2026-05-28T06:00:00Z",
+    "service": {
+      "id": "PDEV_SVC_009",
+      "type": "service_reference",
+      "summary": "osd-multicluster2.def3.p1.openshiftapps.com-hive-cluster",
+      "self": "https://api.pagerduty.com/services/PDEV_SVC_009",
+      "html_url": "https://example.pagerduty.com/services/PDEV_SVC_009"
+    },
+    "escalation_policy": {
+      "id": "PDEV_POLICY_DEFAULT",
+      "type": "escalation_policy_reference",
+      "summary": "SREP Default Escalation"
+    },
+    "assignments": [
+      {
+        "at": "2026-05-28T06:00:00Z",
+        "assignee": {
+          "id": "PDEV_USER_001",
+          "type": "user_reference",
+          "summary": "Dev User"
+        }
+      }
+    ],
+    "acknowledgements": []
+  },
+  {
+    "id": "PDEV_INC_010",
+    "type": "incident",
+    "self": "https://api.pagerduty.com/incidents/PDEV_INC_010",
+    "html_url": "https://example.pagerduty.com/incidents/PDEV_INC_010",
+    "incident_number": 50010,
+    "title": "api-ErrorBudgetBurn CRITICAL (1)",
+    "status": "acknowledged",
+    "urgency": "high",
+    "created_at": "2026-05-28T05:00:00Z",
+    "last_status_change_at": "2026-05-28T05:15:00Z",
+    "service": {
+      "id": "PDEV_SVC_010",
+      "type": "service_reference",
+      "summary": "osd-ackedcluster.ghi4.p1.openshiftapps.com-hive-cluster",
+      "self": "https://api.pagerduty.com/services/PDEV_SVC_010",
+      "html_url": "https://example.pagerduty.com/services/PDEV_SVC_010"
+    },
+    "escalation_policy": {
+      "id": "PDEV_POLICY_DEFAULT",
+      "type": "escalation_policy_reference",
+      "summary": "SREP Default Escalation"
+    },
+    "assignments": [
+      {
+        "at": "2026-05-28T05:00:00Z",
+        "assignee": {
+          "id": "PDEV_USER_001",
+          "type": "user_reference",
+          "summary": "Dev User"
+        }
+      }
+    ],
+    "acknowledgements": [
+      {
+        "at": "2026-05-28T05:15:00Z",
+        "acknowledger": {
+          "id": "PDEV_USER_001",
+          "type": "user_reference",
+          "summary": "Dev User"
+        }
+      }
+    ]
+  },
+  {
+    "id": "PDEV_INC_011",
+    "type": "incident",
+    "self": "https://api.pagerduty.com/incidents/PDEV_INC_011",
+    "html_url": "https://example.pagerduty.com/incidents/PDEV_INC_011",
+    "incident_number": 50011,
+    "title": "[SL Sent] [OHSS-54318] CannotRetrieveUpdatesSRE CRITICAL (1)",
+    "status": "triggered",
+    "urgency": "high",
+    "created_at": "2026-05-28T04:00:00Z",
+    "last_status_change_at": "2026-05-28T04:00:00Z",
+    "service": {
+      "id": "PDEV_SVC_011",
+      "type": "service_reference",
+      "summary": "osd-mutatedtitle.jkl5.p1.openshiftapps.com-hive-cluster",
+      "self": "https://api.pagerduty.com/services/PDEV_SVC_011",
+      "html_url": "https://example.pagerduty.com/services/PDEV_SVC_011"
+    },
+    "escalation_policy": {
+      "id": "PDEV_POLICY_DEFAULT",
+      "type": "escalation_policy_reference",
+      "summary": "SREP Default Escalation"
+    },
+    "assignments": [
+      {
+        "at": "2026-05-28T04:00:00Z",
+        "assignee": {
+          "id": "PDEV_USER_002",
+          "type": "user_reference",
+          "summary": "Alice Engineer"
+        }
+      }
+    ],
+    "acknowledgements": []
+  },
+  {
+    "id": "PDEV_INC_012",
+    "type": "incident",
+    "self": "https://api.pagerduty.com/incidents/PDEV_INC_012",
+    "html_url": "https://example.pagerduty.com/incidents/PDEV_INC_012",
+    "incident_number": 50012,
+    "title": "[HCP] [RHOBS] (Warning) KubeAPIErrorBudgetBurn for HCP: 1b20416f-4022-4ce8-8bde-5a6e450114eb",
+    "status": "triggered",
+    "urgency": "high",
+    "created_at": "2026-05-28T03:00:00Z",
+    "last_status_change_at": "2026-05-28T03:00:00Z",
+    "service": {
+      "id": "PDEV_SVC_012",
+      "type": "service_reference",
+      "summary": "rhobs-hcp-prod-critical-us-west-2",
+      "self": "https://api.pagerduty.com/services/PDEV_SVC_012",
+      "html_url": "https://example.pagerduty.com/services/PDEV_SVC_012"
+    },
+    "escalation_policy": {
+      "id": "PDEV_POLICY_DEFAULT",
+      "type": "escalation_policy_reference",
+      "summary": "SREP Default Escalation"
+    },
+    "assignments": [
+      {
+        "at": "2026-05-28T03:00:00Z",
+        "assignee": {
+          "id": "PDEV_USER_003",
+          "type": "user_reference",
+          "summary": "Bob Oncall"
+        }
+      }
+    ],
+    "acknowledgements": []
+  }
+]

--- a/testdata/fixtures/notes.json
+++ b/testdata/fixtures/notes.json
@@ -1,0 +1,34 @@
+{
+  "PDEV_INC_012": [
+    {
+      "id": "PDEV_NOTE_001",
+      "content": "Investigating HCP cluster 1b20416f - checking management cluster logs and hosted control plane pod health.",
+      "created_at": "2026-05-28T03:15:00Z",
+      "user": {
+        "id": "PDEV_USER_001",
+        "type": "user_reference",
+        "summary": "Dev User"
+      }
+    },
+    {
+      "id": "PDEV_NOTE_002",
+      "content": "Found ingress operator pods CrashLooping on the management cluster. Checking subnet tags and worker node availability.",
+      "created_at": "2026-05-28T03:30:00Z",
+      "user": {
+        "id": "PDEV_USER_002",
+        "type": "user_reference",
+        "summary": "Alice Engineer"
+      }
+    },
+    {
+      "id": "PDEV_NOTE_003",
+      "content": "Root cause identified: customer deleted required subnet tags. Sent service log to customer with remediation steps. Monitoring for recovery.",
+      "created_at": "2026-05-28T03:45:00Z",
+      "user": {
+        "id": "PDEV_USER_003",
+        "type": "user_reference",
+        "summary": "Bob Oncall"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Full dev mode for UI development without a PagerDuty connection:
- `--dev` / `-D` flag, `SREPD_DEV=true` env var
- DevPagerDutyClient implementing all 12 PagerDutyClientInterface methods with mutable in-memory state
- 12 fixture incidents covering all 6 alert types (osd_hive, appsre, rhobs_hcp, rhobs_infra, deadmanssnitch, cee_escalation)
- Write operations (ack, silence, note) modify in-memory state
- 15 TDD tests, +2026 lines

Closes #201, closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)