### PR TITLE
Add CI check enforcing README updates for config/key/flag changes

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -25,6 +25,20 @@ jobs:
       - name: Check for plan document
         run: make plan-check
 
+  readme-check:
+    name: README Update Check
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check README update
+        run: make readme-check
+
   fmt:
     name: Format Check
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ direct `ocm backplane` login.
 | `make clean` | Remove build artifacts |
 | `make tidy` | Run `go mod tidy` |
 | `make plan-check` | Verify plan document exists for this branch |
+| `make readme-check` | Ensure README updated when config/keys/flags change |
 | `make test-all` | Run all checks: fmt-check, vet, lint, test |
 
 Pass extra test flags via `TESTOPTS`, e.g.:

--- a/Makefile
+++ b/Makefile
@@ -121,14 +121,14 @@ readme-check: ## Ensure README is updated when config/keys/flags change
 	NEEDS_README=false; \
 	for f in $$CHANGED; do \
 		case "$$f" in \
-			pkg/tui/keymap.go|cmd/config.go|cmd/root.go) NEEDS_README=true ;; \
+			pkg/tui/keymap.go|cmd/config.go|cmd/root.go|pkg/tui/commands.go) NEEDS_README=true ;; \
 		esac; \
 	done; \
 	if [ "$$NEEDS_README" = "true" ]; then \
 		if ! echo "$$CHANGED" | grep -q "README.md"; then \
-			echo "ERROR: Changes to keymap.go, config.go, or root.go require a README.md update"; \
+			echo "ERROR: Changes to keymap.go, config.go, root.go, or commands.go require a README.md update"; \
 			echo "Changed files that trigger this check:"; \
-			echo "$$CHANGED" | grep -E "keymap.go|config.go|root.go"; \
+			echo "$$CHANGED" | grep -E "keymap.go|config.go|root.go|commands.go"; \
 			exit 1; \
 		fi; \
 		echo "README.md update found - OK"; \

--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,30 @@ plan-check: ## Check that a plan document exists for this branch
 	echo "Plan document(s) found:"; \
 	echo "$$PLAN_FILES" | sed 's/^/  /'
 
+.PHONY: readme-check
+readme-check: ## Ensure README is updated when config/keys/flags change
+	@echo "Checking if README update is needed..."
+	@MERGE_BASE=$$(git merge-base HEAD origin/main 2>/dev/null || echo ""); \
+	if [ -z "$$MERGE_BASE" ]; then exit 0; fi; \
+	CHANGED=$$(git diff --name-only "$$MERGE_BASE"...HEAD); \
+	NEEDS_README=false; \
+	for f in $$CHANGED; do \
+		case "$$f" in \
+			pkg/tui/keymap.go|cmd/config.go|cmd/root.go) NEEDS_README=true ;; \
+		esac; \
+	done; \
+	if [ "$$NEEDS_README" = "true" ]; then \
+		if ! echo "$$CHANGED" | grep -q "README.md"; then \
+			echo "ERROR: Changes to keymap.go, config.go, or root.go require a README.md update"; \
+			echo "Changed files that trigger this check:"; \
+			echo "$$CHANGED" | grep -E "keymap.go|config.go|root.go"; \
+			exit 1; \
+		fi; \
+		echo "README.md update found - OK"; \
+	else \
+		echo "No config/key/flag changes detected - README check skipped"; \
+	fi
+
 .PHONY: test-all
 test-all: fmt-check vet lint test ## Run all checks (fmt, vet, lint, test)
 	@echo "All checks passed."

--- a/docs/plans/056-readme-ci-check.md
+++ b/docs/plans/056-readme-ci-check.md
@@ -1,0 +1,40 @@
+# 056 - README CI Check
+
+## Context
+
+When PRs modify files that define user-facing configuration, key bindings,
+or CLI flags, the README.md should be updated to reflect those changes.
+Without enforcement, documentation drift accumulates as contributors
+change behavior without updating the README.
+
+This is modeled after the existing `plan-check` CI job (see plan 003)
+which enforces plan document presence on every PR.
+
+## Plan
+
+Add a `make readme-check` target and a corresponding GitHub Actions CI
+job that fails PRs which modify any of the following files without also
+including a README.md change:
+
+- `pkg/tui/keymap.go` (key bindings)
+- `cmd/config.go` (viper config keys, flags)
+- `cmd/root.go` (CLI flags, env vars)
+
+The check gracefully exits when there is no merge base (e.g. on the
+default branch or initial commits).
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `Makefile` | Add `readme-check` target after `plan-check` |
+| `.github/workflows/go-ci.yml` | Add `readme-check` job (PR-only, like `plan-doc`) |
+| `docs/plans/056-readme-ci-check.md` | This plan document |
+
+## Verification
+
+- `go test ./... -count=1` passes (no Go code changed)
+- `make readme-check` runs without error on this branch (no trigger
+  files modified)
+- CI workflow YAML is valid and the new job mirrors the structure of
+  the existing `plan-doc` job


### PR DESCRIPTION
## Summary

- Adds `make readme-check` target that detects PRs modifying `pkg/tui/keymap.go`, `cmd/config.go`, or `cmd/root.go` without a corresponding `README.md` update
- Adds `readme-check` CI job in `go-ci.yml` (PR-only, mirrors the existing `plan-doc` job structure)
- Updates AGENTS.md build commands table with the new target

## Rationale

Documentation drift accumulates when contributors change user-facing behavior (key bindings, config keys, CLI flags) without updating the README. This check catches that at PR time, the same way `plan-check` enforces plan documents.

## Test plan

- [x] `go test ./... -count=1` passes (no Go code changed)
- [x] `make readme-check` runs cleanly on this branch (no trigger files modified, exits 0)
- [ ] CI `readme-check` job runs and passes on this PR
- [ ] Verify the check fails correctly by creating a test branch that modifies `cmd/root.go` without touching `README.md`

Created with assistance from Claude <claude@anthropic.com>

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>