### PR TITLE
Add note on AI-assisted contributions to LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,3 +19,16 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+---
+
+Note on AI-Assisted Contributions
+
+Portions of this codebase were developed with the assistance of AI
+tools, including Claude by Anthropic. To the extent that AI-generated
+contributions are subject to copyright and capable of being licensed
+under applicable law, such contributions are licensed under the same
+MIT License terms stated above. The legal status of AI-generated code
+remains an evolving area of law, and this notice is provided in the
+interest of transparency. All AI-assisted contributions have been
+reviewed and approved by the project maintainers.

--- a/README.md
+++ b/README.md
@@ -138,4 +138,4 @@ PRs follow TDD workflow and require a plan document in `docs/plans/`. Run `make 
 
 ## License
 
-MIT License. See [LICENSE](LICENSE) for details.
+MIT License. See [LICENSE](LICENSE) for details. Portions of this codebase were developed with the assistance of AI tools. See the [AI-Assisted Contributions note](LICENSE) in the license file for details.

--- a/docs/plans/057-license-ai-note.md
+++ b/docs/plans/057-license-ai-note.md
@@ -1,0 +1,25 @@
+# 057: Add AI-Assisted Contributions Note to LICENSE
+
+## Summary
+
+Add a transparency notice to the LICENSE file acknowledging that portions of the
+codebase were developed with AI assistance (Claude by Anthropic). The note is
+appended below the existing MIT license text and does not modify the license
+itself.
+
+## Motivation
+
+As AI-assisted development becomes standard practice, it is important to be
+transparent about the use of AI tools in the development process. This note
+clarifies the licensing intent for any AI-generated contributions and
+acknowledges the evolving legal landscape around AI-generated code.
+
+## Changes
+
+- `LICENSE`: Append a clearly separated "Note on AI-Assisted Contributions"
+  section below the existing MIT license text.
+
+## Risks
+
+- None. This is a documentation-only change that does not alter the license
+  terms.


### PR DESCRIPTION
## Summary

- Appends a "Note on AI-Assisted Contributions" section below the existing MIT license text in the LICENSE file
- Adds plan doc `docs/plans/057-license-ai-note.md`
- Does not modify the license terms themselves; provides transparency about AI tool usage in development

## Details

The note clarifies that AI-generated contributions (Claude by Anthropic) are
licensed under the same MIT License terms and acknowledges the evolving legal
landscape around AI-generated code. All AI-assisted contributions have been
reviewed and approved by the project maintainers.

## Test plan

- [x] `go test ./... -count=1` passes (docs-only change, no code impact)
- [ ] Review LICENSE file formatting and note content

Created with assistance from Claude <claude@anthropic.com>