### PR TITLE
Add tabbed navigation for alerts and notes in incident viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Press `h` to toggle the help overlay inside srepd.
 | `ctrl+q`/`ctrl+c` | Quit | `1`-`9` | Select cluster |
 | `i`/`:` | Ask Claude | | |
 | `ctrl+x` + key | Chord commands | `ctrl+x ?` | Show chord help |
+| `Tab`/`Shift+Tab` | Switch tabs (incident view) | `←`/`→` | Navigate alerts/notes |
 
 Chord commands use a configurable prefix (default `ctrl+x`) followed by a second key. Set `chord_prefix` in config to change.
 

--- a/docs/plans/055-tabbed-navigation.md
+++ b/docs/plans/055-tabbed-navigation.md
@@ -1,0 +1,102 @@
+# 055: Tabbed Navigation for Incident Viewer
+
+**Issue**: #199
+**Branch**: srepd/tabbed-navigation
+**Status**: In Progress
+
+## Problem
+
+Incidents with many alerts (10+) display all alerts at once in a long
+scrollable view. Same with notes. This makes it hard to scan individual
+alerts or notes.
+
+## Solution
+
+Add tabbed navigation to the incident viewer. Three top-level tabs:
+`[Details] [Alerts (N)] [Notes (N)]`, with left/right arrows to switch
+between tabs. Within Alerts/Notes tabs, left/right or number keys (1-9)
+to page through individual items.
+
+## Design
+
+### Model changes (model.go)
+
+Add three new fields to the `model` struct:
+
+- `activeTab int` -- 0=details, 1=alerts, 2=notes
+- `activeAlertIdx int` -- 0-based index of currently shown alert
+- `activeNoteIdx int` -- 0-based index of currently shown note
+
+Reset all three to 0 in `clearSelectedIncident()`.
+
+### Template changes (views.go)
+
+Split the current `incidentTemplate` into three separate templates:
+
+- `detailsTabTemplate` -- incident metadata (ID, title, service,
+  urgency, created, status, assignments, acknowledgements)
+- `alertTabTemplate` -- single alert rendering (name, cluster, SOP,
+  service, created, status, severity, type)
+- `noteTabTemplate` -- single note rendering (content, user, created)
+
+Add a `renderTabHeader()` function that renders the tab bar:
+`[Details] [Alerts (5)] [Notes (3)]` with the active tab highlighted.
+
+Modify the `template()` method to select which template to render based
+on `activeTab`, and pass the appropriate data slice index.
+
+### Key binding changes (keymap.go)
+
+Add new key bindings to the keymap struct:
+
+- `TabNext` -- Tab or right arrow to switch to next tab
+- `TabPrev` -- shift+tab or left arrow to switch to previous tab
+
+These are only active in incident viewer mode (switchIncidentFocusMode).
+
+### Message handler changes (msgHandlers.go)
+
+In `switchIncidentFocusMode()`:
+
+- Left/right arrows switch tabs at the top level
+- Within Alerts/Notes tabs, left/right also pages through items
+  (Tab/Shift+Tab switch tabs exclusively)
+- Number keys 1-9 jump to specific alert/note index
+- Bounds checking: clamp index to valid range
+
+### Data flow
+
+- `selectedIncidentAlerts[activeAlertIdx]` feeds the alert template
+- `selectedIncidentNotes[activeNoteIdx]` feeds the note template
+- When alerts/notes are not loaded yet, show loading indicator
+
+## Tests (TDD -- write first)
+
+1. `TestTabSwitch_LeftRight` -- Tab key cycles through tabs 0->1->2->0
+2. `TestAlertTab_ShowsSingleAlert` -- renders exactly one alert
+3. `TestAlertTab_Navigation` -- left/right changes activeAlertIdx
+4. `TestNoteTab_ShowsSingleNote` -- renders exactly one note
+5. `TestTabBoundsCheck` -- index clamped to valid range
+6. `TestTabReset_OnClearSelectedIncident` -- tab state resets
+7. `TestDetailsTab_Template` -- details tab renders metadata only
+8. `TestTabHeader_Rendering` -- tab bar shows counts and highlights
+9. `TestNumberKeys_JumpToIndex` -- digit keys select specific item
+10. `TestViewport_ScrollReset` -- viewport resets to top on tab switch
+
+## Files Modified
+
+- `pkg/tui/model.go` -- add tab state fields, reset in clear
+- `pkg/tui/views.go` -- split template, add tab header, tab templates
+- `pkg/tui/msgHandlers.go` -- tab navigation in incident focus mode
+- `pkg/tui/keymap.go` -- add TabNext/TabPrev key bindings
+- `pkg/tui/model_test.go` -- tab state tests
+- `pkg/tui/views_test.go` -- template rendering tests
+- `pkg/tui/msgHandlers_test.go` -- navigation tests
+
+## Risks
+
+- Changing the incident template is a visual change; need to ensure
+  the details tab renders identically to the current full view minus
+  alerts and notes sections.
+- Left/right arrows are used by the viewport for horizontal scrolling;
+  need to intercept them before the viewport consumes them.

--- a/pkg/tui/keymap.go
+++ b/pkg/tui/keymap.go
@@ -20,6 +20,8 @@ func (k keymap) FullHelp() [][]key.Binding {
 		{k.Ack, k.Note, k.Login, k.Open, k.SOP, k.UnAck, k.Silence},
 		// Column 3: Settings & toggles, Quit at bottom
 		{k.Team, k.Refresh, k.AutoRefresh, k.AutoAck, k.Urgency, k.ToggleActionLog, k.ViewLog, k.Quit},
+		// Column 4: Tab navigation (incident viewer)
+		{k.TabNext, k.TabPrev, k.ItemNext, k.ItemPrev},
 	}
 
 	// Column 4: Chord commands (generated from chordActions registry)
@@ -55,6 +57,10 @@ type keymap struct {
 	Open            key.Binding
 	SOP             key.Binding
 	ViewLog         key.Binding
+	TabNext         key.Binding
+	TabPrev         key.Binding
+	ItemNext        key.Binding
+	ItemPrev        key.Binding
 }
 
 type inputKeymap struct {
@@ -182,6 +188,22 @@ var defaultKeyMap = keymap{
 	ViewLog: key.NewBinding(
 		key.WithKeys("ctrl+d"),
 		key.WithHelp("ctrl+d", "view debug log"),
+	),
+	TabNext: key.NewBinding(
+		key.WithKeys("tab"),
+		key.WithHelp("tab", "next tab"),
+	),
+	TabPrev: key.NewBinding(
+		key.WithKeys("shift+tab"),
+		key.WithHelp("shift+tab", "prev tab"),
+	),
+	ItemNext: key.NewBinding(
+		key.WithKeys("right"),
+		key.WithHelp("->", "next item"),
+	),
+	ItemPrev: key.NewBinding(
+		key.WithKeys("left"),
+		key.WithHelp("<-", "prev item"),
 	),
 }
 

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -116,6 +116,11 @@ type model struct {
 
 	// claudeQuerying is true while a Claude CLI query is in progress
 	claudeQuerying bool
+
+	// Incident viewer tab state
+	activeTab      int // 0=details, 1=alerts, 2=notes
+	activeAlertIdx int // which alert is shown (0-based) in the alerts tab
+	activeNoteIdx  int // which note is shown (0-based) in the notes tab
 }
 
 func InitialModel(
@@ -261,6 +266,10 @@ func (m *model) clearSelectedIncident(reason interface{}) {
 	m.pendingConfirmation = nil
 	m.clusterSelectMode = false
 	m.clusterSelectOptions = nil
+	// Reset tab state
+	m.activeTab = 0
+	m.activeAlertIdx = 0
+	m.activeNoteIdx = 0
 	log.Debug("clearSelectedIncident", "selectedIncident", m.selectedIncident, "cleared", true, "reason", reason)
 }
 

--- a/pkg/tui/model_test.go
+++ b/pkg/tui/model_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -439,31 +440,48 @@ func TestUpdatedIncidentListNoPrefetch(t *testing.T) {
 func TestProgressiveRendering(t *testing.T) {
 	tests := []struct {
 		name                 string
+		activeTab            int
 		incidentNotesLoaded  bool
 		incidentAlertsLoaded bool
-		expectedNotesContent string
-		expectedAlertsMarker string
+		expectedContains     []string
+		expectedNotContains  []string
 	}{
 		{
-			name:                 "Shows loading message for notes when not loaded",
+			name:                 "Tab header shows loading indicator for notes when not loaded",
+			activeTab:            0,
 			incidentNotesLoaded:  false,
 			incidentAlertsLoaded: true,
-			expectedNotesContent: "Loading notes...",
-			expectedAlertsMarker: "",
+			expectedContains:     []string{"Notes (...)"},
+			expectedNotContains:  []string{"Alerts (...)"},
 		},
 		{
-			name:                 "Shows loading message for alerts when not loaded",
+			name:                 "Tab header shows loading indicator for alerts when not loaded",
+			activeTab:            0,
 			incidentNotesLoaded:  true,
 			incidentAlertsLoaded: false,
-			expectedNotesContent: "",
-			expectedAlertsMarker: "Loading alerts...",
+			expectedContains:     []string{"Alerts (...)"},
+			expectedNotContains:  []string{"Notes (...)"},
 		},
 		{
-			name:                 "Shows both loading messages when neither loaded",
+			name:                 "Tab header shows both loading indicators when neither loaded",
+			activeTab:            0,
 			incidentNotesLoaded:  false,
 			incidentAlertsLoaded: false,
-			expectedNotesContent: "Loading notes...",
-			expectedAlertsMarker: "Loading alerts...",
+			expectedContains:     []string{"Notes (...)", "Alerts (...)"},
+		},
+		{
+			name:                 "Alerts tab shows loading message when alerts not loaded",
+			activeTab:            1,
+			incidentNotesLoaded:  true,
+			incidentAlertsLoaded: false,
+			expectedContains:     []string{"Loading alerts..."},
+		},
+		{
+			name:                 "Notes tab shows loading message when notes not loaded",
+			activeTab:            2,
+			incidentNotesLoaded:  false,
+			incidentAlertsLoaded: true,
+			expectedContains:     []string{"Loading notes..."},
 		},
 	}
 
@@ -481,6 +499,7 @@ func TestProgressiveRendering(t *testing.T) {
 
 			m := model{
 				selectedIncident:     incident,
+				activeTab:            tt.activeTab,
 				incidentNotesLoaded:  tt.incidentNotesLoaded,
 				incidentAlertsLoaded: tt.incidentAlertsLoaded,
 				incidentCache:        make(map[string]*cachedIncidentData),
@@ -489,12 +508,12 @@ func TestProgressiveRendering(t *testing.T) {
 			content, err := m.template()
 			assert.NoError(t, err, "Template should render without error")
 
-			if tt.expectedNotesContent != "" {
-				assert.Contains(t, content, tt.expectedNotesContent, "Should contain notes loading message")
+			for _, expected := range tt.expectedContains {
+				assert.Contains(t, content, expected, "Should contain %q", expected)
 			}
 
-			if tt.expectedAlertsMarker != "" {
-				assert.Contains(t, content, tt.expectedAlertsMarker, "Should contain alerts loading message")
+			for _, notExpected := range tt.expectedNotContains {
+				assert.NotContains(t, content, notExpected, "Should not contain %q", notExpected)
 			}
 		})
 	}
@@ -1390,6 +1409,391 @@ func TestSyncSelectedIncident_SameIncidentReturnsNil(t *testing.T) {
 		assert.Equal(t, "Q444", m.selectedIncident.ID)
 		assert.Nil(t, cmd, "should return nil command when incident is already selected")
 	})
+}
+
+func TestTabReset_OnClearSelectedIncident(t *testing.T) {
+	t.Run("clearSelectedIncident resets tab state to defaults", func(t *testing.T) {
+		m := createTestModel()
+		m.selectedIncident = &pagerduty.Incident{
+			APIObject: pagerduty.APIObject{ID: "Q123"},
+		}
+		m.viewingIncident = true
+		m.activeTab = 2
+		m.activeAlertIdx = 3
+		m.activeNoteIdx = 1
+
+		m.clearSelectedIncident("test reset")
+
+		assert.Equal(t, 0, m.activeTab, "activeTab should reset to 0")
+		assert.Equal(t, 0, m.activeAlertIdx, "activeAlertIdx should reset to 0")
+		assert.Equal(t, 0, m.activeNoteIdx, "activeNoteIdx should reset to 0")
+	})
+}
+
+func TestTabSwitch_LeftRight(t *testing.T) {
+	tests := []struct {
+		name        string
+		initialTab  int
+		keyMsg      tea.KeyMsg
+		expectedTab int
+	}{
+		{
+			name:        "Tab key cycles from Details to Alerts",
+			initialTab:  0,
+			keyMsg:      tea.KeyMsg{Type: tea.KeyTab},
+			expectedTab: 1,
+		},
+		{
+			name:        "Tab key cycles from Alerts to Notes",
+			initialTab:  1,
+			keyMsg:      tea.KeyMsg{Type: tea.KeyTab},
+			expectedTab: 2,
+		},
+		{
+			name:        "Tab key wraps from Notes back to Details",
+			initialTab:  2,
+			keyMsg:      tea.KeyMsg{Type: tea.KeyTab},
+			expectedTab: 0,
+		},
+		{
+			name:        "Shift+Tab cycles from Details to Notes (backward wrap)",
+			initialTab:  0,
+			keyMsg:      tea.KeyMsg{Type: tea.KeyShiftTab},
+			expectedTab: 2,
+		},
+		{
+			name:        "Shift+Tab cycles from Notes to Alerts",
+			initialTab:  2,
+			keyMsg:      tea.KeyMsg{Type: tea.KeyShiftTab},
+			expectedTab: 1,
+		},
+		{
+			name:        "Shift+Tab cycles from Alerts to Details",
+			initialTab:  1,
+			keyMsg:      tea.KeyMsg{Type: tea.KeyShiftTab},
+			expectedTab: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := createTestModel()
+			m.viewingIncident = true
+			m.activeTab = tt.initialTab
+			m.selectedIncident = &pagerduty.Incident{
+				APIObject: pagerduty.APIObject{ID: "Q123"},
+			}
+			m.incidentAlertsLoaded = true
+			m.incidentNotesLoaded = true
+			m.selectedIncidentAlerts = []pagerduty.IncidentAlert{
+				{APIObject: pagerduty.APIObject{ID: "A1"}},
+			}
+			m.selectedIncidentNotes = []pagerduty.IncidentNote{
+				{ID: "N1"},
+			}
+
+			result, _ := m.Update(tt.keyMsg)
+			updatedModel := result.(model)
+
+			assert.Equal(t, tt.expectedTab, updatedModel.activeTab,
+				"activeTab should be %d after key press", tt.expectedTab)
+		})
+	}
+}
+
+func TestAlertTab_Navigation(t *testing.T) {
+	tests := []struct {
+		name             string
+		initialAlertIdx  int
+		alertCount       int
+		keyMsg           tea.KeyMsg
+		expectedAlertIdx int
+	}{
+		{
+			name:             "Right arrow advances alert index",
+			initialAlertIdx:  0,
+			alertCount:       3,
+			keyMsg:           tea.KeyMsg{Type: tea.KeyRight},
+			expectedAlertIdx: 1,
+		},
+		{
+			name:             "Left arrow decrements alert index",
+			initialAlertIdx:  2,
+			alertCount:       3,
+			keyMsg:           tea.KeyMsg{Type: tea.KeyLeft},
+			expectedAlertIdx: 1,
+		},
+		{
+			name:             "Right arrow wraps from last to first",
+			initialAlertIdx:  2,
+			alertCount:       3,
+			keyMsg:           tea.KeyMsg{Type: tea.KeyRight},
+			expectedAlertIdx: 0,
+		},
+		{
+			name:             "Left arrow wraps from first to last",
+			initialAlertIdx:  0,
+			alertCount:       3,
+			keyMsg:           tea.KeyMsg{Type: tea.KeyLeft},
+			expectedAlertIdx: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := createTestModel()
+			m.viewingIncident = true
+			m.activeTab = 1 // Alerts tab
+			m.activeAlertIdx = tt.initialAlertIdx
+			m.selectedIncident = &pagerduty.Incident{
+				APIObject: pagerduty.APIObject{ID: "Q123"},
+			}
+			m.incidentAlertsLoaded = true
+
+			var alerts []pagerduty.IncidentAlert
+			for i := 0; i < tt.alertCount; i++ {
+				alerts = append(alerts, pagerduty.IncidentAlert{
+					APIObject: pagerduty.APIObject{ID: fmt.Sprintf("A%d", i)},
+				})
+			}
+			m.selectedIncidentAlerts = alerts
+
+			result, _ := m.Update(tt.keyMsg)
+			updatedModel := result.(model)
+
+			assert.Equal(t, tt.expectedAlertIdx, updatedModel.activeAlertIdx,
+				"activeAlertIdx should be %d", tt.expectedAlertIdx)
+		})
+	}
+}
+
+func TestNoteTab_Navigation(t *testing.T) {
+	tests := []struct {
+		name            string
+		initialNoteIdx  int
+		noteCount       int
+		keyMsg          tea.KeyMsg
+		expectedNoteIdx int
+	}{
+		{
+			name:            "Right arrow advances note index",
+			initialNoteIdx:  0,
+			noteCount:       3,
+			keyMsg:          tea.KeyMsg{Type: tea.KeyRight},
+			expectedNoteIdx: 1,
+		},
+		{
+			name:            "Left arrow decrements note index",
+			initialNoteIdx:  2,
+			noteCount:       3,
+			keyMsg:          tea.KeyMsg{Type: tea.KeyLeft},
+			expectedNoteIdx: 1,
+		},
+		{
+			name:            "Right arrow wraps from last to first",
+			initialNoteIdx:  2,
+			noteCount:       3,
+			keyMsg:          tea.KeyMsg{Type: tea.KeyRight},
+			expectedNoteIdx: 0,
+		},
+		{
+			name:            "Left arrow wraps from first to last",
+			initialNoteIdx:  0,
+			noteCount:       3,
+			keyMsg:          tea.KeyMsg{Type: tea.KeyLeft},
+			expectedNoteIdx: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := createTestModel()
+			m.viewingIncident = true
+			m.activeTab = 2 // Notes tab
+			m.activeNoteIdx = tt.initialNoteIdx
+			m.selectedIncident = &pagerduty.Incident{
+				APIObject: pagerduty.APIObject{ID: "Q123"},
+			}
+			m.incidentNotesLoaded = true
+
+			var notes []pagerduty.IncidentNote
+			for i := 0; i < tt.noteCount; i++ {
+				notes = append(notes, pagerduty.IncidentNote{
+					ID: fmt.Sprintf("N%d", i),
+				})
+			}
+			m.selectedIncidentNotes = notes
+
+			result, _ := m.Update(tt.keyMsg)
+			updatedModel := result.(model)
+
+			assert.Equal(t, tt.expectedNoteIdx, updatedModel.activeNoteIdx,
+				"activeNoteIdx should be %d", tt.expectedNoteIdx)
+		})
+	}
+}
+
+func TestTabBoundsCheck(t *testing.T) {
+	tests := []struct {
+		name             string
+		activeTab        int
+		alertIdx         int
+		noteIdx          int
+		alertCount       int
+		noteCount        int
+		keyMsg           tea.KeyMsg
+		expectedAlertIdx int
+		expectedNoteIdx  int
+	}{
+		{
+			name:             "Alert index clamped with single alert - right wraps to 0",
+			activeTab:        1,
+			alertIdx:         0,
+			alertCount:       1,
+			keyMsg:           tea.KeyMsg{Type: tea.KeyRight},
+			expectedAlertIdx: 0,
+		},
+		{
+			name:            "Note index clamped with single note - right wraps to 0",
+			activeTab:       2,
+			noteIdx:         0,
+			noteCount:       1,
+			keyMsg:          tea.KeyMsg{Type: tea.KeyRight},
+			expectedNoteIdx: 0,
+		},
+		{
+			name:             "Number key out of range is ignored for alerts",
+			activeTab:        1,
+			alertIdx:         0,
+			alertCount:       2,
+			keyMsg:           tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}},
+			expectedAlertIdx: 0,
+		},
+		{
+			name:            "Number key out of range is ignored for notes",
+			activeTab:       2,
+			noteIdx:         0,
+			noteCount:       2,
+			keyMsg:          tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}},
+			expectedNoteIdx: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := createTestModel()
+			m.viewingIncident = true
+			m.activeTab = tt.activeTab
+			m.activeAlertIdx = tt.alertIdx
+			m.activeNoteIdx = tt.noteIdx
+			m.selectedIncident = &pagerduty.Incident{
+				APIObject: pagerduty.APIObject{ID: "Q123"},
+			}
+			m.incidentAlertsLoaded = true
+			m.incidentNotesLoaded = true
+
+			var alerts []pagerduty.IncidentAlert
+			for i := 0; i < tt.alertCount; i++ {
+				alerts = append(alerts, pagerduty.IncidentAlert{
+					APIObject: pagerduty.APIObject{ID: fmt.Sprintf("A%d", i)},
+				})
+			}
+			m.selectedIncidentAlerts = alerts
+
+			var notes []pagerduty.IncidentNote
+			for i := 0; i < tt.noteCount; i++ {
+				notes = append(notes, pagerduty.IncidentNote{
+					ID: fmt.Sprintf("N%d", i),
+				})
+			}
+			m.selectedIncidentNotes = notes
+
+			result, _ := m.Update(tt.keyMsg)
+			updatedModel := result.(model)
+
+			if tt.activeTab == 1 {
+				assert.Equal(t, tt.expectedAlertIdx, updatedModel.activeAlertIdx)
+			}
+			if tt.activeTab == 2 {
+				assert.Equal(t, tt.expectedNoteIdx, updatedModel.activeNoteIdx)
+			}
+		})
+	}
+}
+
+func TestNumberKeys_JumpToIndex(t *testing.T) {
+	tests := []struct {
+		name             string
+		activeTab        int
+		count            int
+		keyMsg           tea.KeyMsg
+		expectedAlertIdx int
+		expectedNoteIdx  int
+	}{
+		{
+			name:             "Pressing 1 jumps to first alert",
+			activeTab:        1,
+			count:            5,
+			keyMsg:           tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}},
+			expectedAlertIdx: 0,
+		},
+		{
+			name:             "Pressing 3 jumps to third alert",
+			activeTab:        1,
+			count:            5,
+			keyMsg:           tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}},
+			expectedAlertIdx: 2,
+		},
+		{
+			name:            "Pressing 2 jumps to second note",
+			activeTab:       2,
+			count:           3,
+			keyMsg:          tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}},
+			expectedNoteIdx: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := createTestModel()
+			m.viewingIncident = true
+			m.activeTab = tt.activeTab
+			m.selectedIncident = &pagerduty.Incident{
+				APIObject: pagerduty.APIObject{ID: "Q123"},
+			}
+			m.incidentAlertsLoaded = true
+			m.incidentNotesLoaded = true
+
+			var alerts []pagerduty.IncidentAlert
+			var notes []pagerduty.IncidentNote
+
+			if tt.activeTab == 1 {
+				for i := 0; i < tt.count; i++ {
+					alerts = append(alerts, pagerduty.IncidentAlert{
+						APIObject: pagerduty.APIObject{ID: fmt.Sprintf("A%d", i)},
+					})
+				}
+			} else {
+				for i := 0; i < tt.count; i++ {
+					notes = append(notes, pagerduty.IncidentNote{
+						ID: fmt.Sprintf("N%d", i),
+					})
+				}
+			}
+			m.selectedIncidentAlerts = alerts
+			m.selectedIncidentNotes = notes
+
+			result, _ := m.Update(tt.keyMsg)
+			updatedModel := result.(model)
+
+			if tt.activeTab == 1 {
+				assert.Equal(t, tt.expectedAlertIdx, updatedModel.activeAlertIdx)
+			}
+			if tt.activeTab == 2 {
+				assert.Equal(t, tt.expectedNoteIdx, updatedModel.activeNoteIdx)
+			}
+		})
+	}
 }
 
 func TestWindowSizeMsgHandler_SmallWindow(t *testing.T) {

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -605,6 +605,56 @@ func switchIncidentFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Return immediately - no need to process anything else or update viewport
 			return m, prefetchCmd
 
+		// Tab navigation: switch between Details/Alerts/Notes tabs
+		case key.Matches(msg, defaultKeyMap.TabNext):
+			m.activeTab = (m.activeTab + 1) % tabCount
+			m.incidentViewer.GotoTop()
+			handledKey = true
+			return m, func() tea.Msg { return renderIncidentMsg("tab switch") }
+
+		case key.Matches(msg, defaultKeyMap.TabPrev):
+			m.activeTab = (m.activeTab + tabCount - 1) % tabCount
+			m.incidentViewer.GotoTop()
+			handledKey = true
+			return m, func() tea.Msg { return renderIncidentMsg("tab switch") }
+
+		// Item navigation: left/right within Alerts/Notes tabs
+		case key.Matches(msg, defaultKeyMap.ItemNext):
+			handledKey = true
+			switch m.activeTab {
+			case tabAlerts:
+				if len(m.selectedIncidentAlerts) > 0 {
+					m.activeAlertIdx = (m.activeAlertIdx + 1) % len(m.selectedIncidentAlerts)
+					m.incidentViewer.GotoTop()
+					return m, func() tea.Msg { return renderIncidentMsg("alert next") }
+				}
+			case tabNotes:
+				if len(m.selectedIncidentNotes) > 0 {
+					m.activeNoteIdx = (m.activeNoteIdx + 1) % len(m.selectedIncidentNotes)
+					m.incidentViewer.GotoTop()
+					return m, func() tea.Msg { return renderIncidentMsg("note next") }
+				}
+			}
+			return m, nil
+
+		case key.Matches(msg, defaultKeyMap.ItemPrev):
+			handledKey = true
+			switch m.activeTab {
+			case tabAlerts:
+				if len(m.selectedIncidentAlerts) > 0 {
+					m.activeAlertIdx = (m.activeAlertIdx + len(m.selectedIncidentAlerts) - 1) % len(m.selectedIncidentAlerts)
+					m.incidentViewer.GotoTop()
+					return m, func() tea.Msg { return renderIncidentMsg("alert prev") }
+				}
+			case tabNotes:
+				if len(m.selectedIncidentNotes) > 0 {
+					m.activeNoteIdx = (m.activeNoteIdx + len(m.selectedIncidentNotes) - 1) % len(m.selectedIncidentNotes)
+					m.incidentViewer.GotoTop()
+					return m, func() tea.Msg { return renderIncidentMsg("note prev") }
+				}
+			}
+			return m, nil
+
 		case key.Matches(msg, defaultKeyMap.Refresh):
 			return m, func() tea.Msg { return getIncidentMsg(m.selectedIncident.ID) }
 
@@ -665,6 +715,33 @@ func switchIncidentFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, func() tea.Msg { return openSOPMsg("sop") }
 
+		default:
+			// Number keys 1-9 jump to specific alert/note index
+			if m.activeTab == tabAlerts || m.activeTab == tabNotes {
+				keyStr := msg.String()
+				if len(keyStr) == 1 && keyStr[0] >= '1' && keyStr[0] <= '9' {
+					idx := int(keyStr[0]-'0') - 1
+					switch m.activeTab {
+					case tabAlerts:
+						if idx < len(m.selectedIncidentAlerts) {
+							m.activeAlertIdx = idx
+							m.incidentViewer.GotoTop()
+							handledKey = true
+							return m, func() tea.Msg { return renderIncidentMsg("alert jump") }
+						}
+					case tabNotes:
+						if idx < len(m.selectedIncidentNotes) {
+							m.activeNoteIdx = idx
+							m.incidentViewer.GotoTop()
+							handledKey = true
+							return m, func() tea.Msg { return renderIncidentMsg("note jump") }
+						}
+					}
+					// Out of range -- ignore
+					handledKey = true
+					return m, nil
+				}
+			}
 		}
 	}
 

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -635,7 +635,6 @@ func switchIncidentFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 
 		case key.Matches(msg, defaultKeyMap.ItemPrev):
-			handledKey = true
 			switch m.activeTab {
 			case tabAlerts:
 				if len(m.selectedIncidentAlerts) > 0 {
@@ -723,19 +722,15 @@ func switchIncidentFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 						if idx < len(m.selectedIncidentAlerts) {
 							m.activeAlertIdx = idx
 							m.incidentViewer.GotoTop()
-							handledKey = true
 							return m, func() tea.Msg { return renderIncidentMsg("alert jump") }
 						}
 					case tabNotes:
 						if idx < len(m.selectedIncidentNotes) {
 							m.activeNoteIdx = idx
 							m.incidentViewer.GotoTop()
-							handledKey = true
 							return m, func() tea.Msg { return renderIncidentMsg("note jump") }
 						}
 					}
-					// Out of range -- ignore
-					handledKey = true
 					return m, nil
 				}
 			}

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -609,18 +609,15 @@ func switchIncidentFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(msg, defaultKeyMap.TabNext):
 			m.activeTab = (m.activeTab + 1) % tabCount
 			m.incidentViewer.GotoTop()
-			handledKey = true
 			return m, func() tea.Msg { return renderIncidentMsg("tab switch") }
 
 		case key.Matches(msg, defaultKeyMap.TabPrev):
 			m.activeTab = (m.activeTab + tabCount - 1) % tabCount
 			m.incidentViewer.GotoTop()
-			handledKey = true
 			return m, func() tea.Msg { return renderIncidentMsg("tab switch") }
 
 		// Item navigation: left/right within Alerts/Notes tabs
 		case key.Matches(msg, defaultKeyMap.ItemNext):
-			handledKey = true
 			switch m.activeTab {
 			case tabAlerts:
 				if len(m.selectedIncidentAlerts) > 0 {

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -329,14 +329,6 @@ func refreshArea(autoRefresh bool, autoAck bool, showLowUrgency bool) string {
 }
 
 func (m model) template() (string, error) {
-	template, err := template.New("incident").Funcs(funcMap).Parse(incidentTemplate)
-	if err != nil {
-		// TODO: Figure out how to handle this with a proper errMsg
-		return "", err
-	}
-
-	o := new(bytes.Buffer)
-
 	// Progressive rendering: show what we have, mark missing parts as loading
 	var alerts []pagerduty.IncidentAlert
 	var notes []pagerduty.IncidentNote
@@ -344,29 +336,95 @@ func (m model) template() (string, error) {
 	if m.incidentAlertsLoaded {
 		alerts = m.selectedIncidentAlerts
 	} else {
-		// Alerts not loaded yet - will show "Loading alerts..." in template
 		alerts = nil
 	}
 
 	if m.incidentNotesLoaded {
 		notes = m.selectedIncidentNotes
 	} else {
-		// Notes not loaded yet - will show "Loading notes..." in template
 		notes = nil
 	}
 
 	summary := summarize(m.selectedIncident, alerts, notes)
-	// Add loading state info to summary for template to use
 	summary.AlertsLoading = !m.incidentAlertsLoaded
 	summary.NotesLoading = !m.incidentNotesLoaded
 
-	err = template.Execute(o, summary)
-	if err != nil {
-		// TODO: Figure out how to handle this with a proper errMsg
-		return "", err
+	// Render tab header
+	alertCount := len(alerts)
+	noteCount := len(notes)
+	tabHeader := renderTabHeader(m.activeTab, alertCount, noteCount, summary.AlertsLoading, summary.NotesLoading)
+
+	var content string
+
+	switch m.activeTab {
+	case tabAlerts:
+		if summary.AlertsLoading {
+			content = tabHeader + "\n\n_Loading alerts..._\n"
+		} else if len(summary.Alerts) == 0 {
+			content = tabHeader + "\n\n_No alerts_\n"
+		} else {
+			idx := m.activeAlertIdx
+			if idx >= len(summary.Alerts) {
+				idx = len(summary.Alerts) - 1
+			}
+			data := singleAlertTabData{
+				Alert: summary.Alerts[idx],
+				Index: idx,
+				Total: len(summary.Alerts),
+			}
+			tmpl, err := template.New("alert").Funcs(funcMap).Parse(alertTabTemplate)
+			if err != nil {
+				return "", err
+			}
+			o := new(bytes.Buffer)
+			err = tmpl.Execute(o, data)
+			if err != nil {
+				return "", err
+			}
+			content = tabHeader + "\n" + o.String()
+		}
+
+	case tabNotes:
+		if summary.NotesLoading {
+			content = tabHeader + "\n\n_Loading notes..._\n"
+		} else if len(summary.Notes) == 0 {
+			content = tabHeader + "\n\n_No notes_\n"
+		} else {
+			idx := m.activeNoteIdx
+			if idx >= len(summary.Notes) {
+				idx = len(summary.Notes) - 1
+			}
+			data := singleNoteTabData{
+				Note:  summary.Notes[idx],
+				Index: idx,
+				Total: len(summary.Notes),
+			}
+			tmpl, err := template.New("note").Funcs(funcMap).Parse(noteTabTemplate)
+			if err != nil {
+				return "", err
+			}
+			o := new(bytes.Buffer)
+			err = tmpl.Execute(o, data)
+			if err != nil {
+				return "", err
+			}
+			content = tabHeader + "\n" + o.String()
+		}
+
+	default: // tabDetails
+		tmpl, err := template.New("details").Funcs(funcMap).Parse(detailsTabTemplate)
+		if err != nil {
+			return "", err
+		}
+		o := new(bytes.Buffer)
+		err = tmpl.Execute(o, summary)
+		if err != nil {
+			return "", err
+		}
+		content = tabHeader + "\n" + o.String()
 	}
 
-	return o.String(), nil
+	return content, nil
 }
 
 func addNoteTemplate(id string, title string, service string) (string, error) {
@@ -548,6 +606,9 @@ var funcMap = template.FuncMap{
 	"Last": func(i, length int) bool {
 		return i == length-1
 	},
+	"add1": func(i int) int {
+		return i + 1
+	},
 }
 
 const incidentTemplate = `
@@ -622,6 +683,106 @@ func renderIncidentMarkdown(m *model, content string) (string, error) {
 
 	return str, nil
 }
+
+// Tab constants
+const (
+	tabDetails = 0
+	tabAlerts  = 1
+	tabNotes   = 2
+	tabCount   = 3
+)
+
+// singleAlertTabData is the data passed to the alertTabTemplate
+type singleAlertTabData struct {
+	Alert alertSummary
+	Index int // 0-based
+	Total int
+}
+
+// singleNoteTabData is the data passed to the noteTabTemplate
+type singleNoteTabData struct {
+	Note  noteSummary
+	Index int // 0-based
+	Total int
+}
+
+// renderTabHeader renders the tab bar with counts and highlights the active tab.
+// Example: " [Details]  Alerts (5)  Notes (3) "
+func renderTabHeader(activeTab int, alertCount int, noteCount int, alertsLoading bool, notesLoading bool) string {
+	tabs := make([]string, tabCount)
+	tabs[tabDetails] = "Details"
+
+	if alertsLoading {
+		tabs[tabAlerts] = "Alerts (...)"
+	} else {
+		tabs[tabAlerts] = fmt.Sprintf("Alerts (%d)", alertCount)
+	}
+
+	if notesLoading {
+		tabs[tabNotes] = "Notes (...)"
+	} else {
+		tabs[tabNotes] = fmt.Sprintf("Notes (%d)", noteCount)
+	}
+
+	var parts []string
+	for i, tab := range tabs {
+		if i == activeTab {
+			parts = append(parts, fmt.Sprintf("[%s]", tab))
+		} else {
+			parts = append(parts, fmt.Sprintf(" %s ", tab))
+		}
+	}
+
+	return strings.Join(parts, " ")
+}
+
+// detailsTabTemplate renders only the incident metadata (no alerts or notes)
+const detailsTabTemplate = `
+{{- if .Priority -}}
+# {{ .Priority }} {{ .ID }} - {{ .Status }}
+{{- else -}}
+# {{ .ID }} - {{ .Status }}
+{{- end }}
+
+{{ ToLink .Title .HTMLURL }}
+
+* Service: {{ .Service }}
+* Urgency: {{ .Urgency }}
+* Created: {{ .Created }}
+
+{{ if not .Acknowledged -}}
+Assigned to:{{ range $assignee := .Assigned }}
++ *{{ $assignee }}* *(not yet acknowledged)*
+{{ end }}
+{{- else -}}
+{{ $length := len .Acknowledged }}
+Acknowledged by: {{ range $i, $ack := .Acknowledged -}}
+{{ if Last $i $length }}**{{ $ack }}**{{ else }}**{{ $ack }},**{{ end }}
+{{ end }}
+{{- end -}}
+`
+
+// alertTabTemplate renders a single alert with navigation header
+const alertTabTemplate = `
+### Alert {{ add1 .Index }}/{{ .Total }}
+
+### {{ if .Alert.Name }}{{ .Alert.Name }}{{ else }}{{ .Alert.ID }}{{ end }} ({{ .Alert.Status }}){{ if .Alert.Severity }} [{{ .Alert.Severity }}]{{ end }}{{ if .Alert.AlertType }} ({{ .Alert.AlertType }}){{ end }}
+
+* Cluster: {{ .Alert.Cluster }}
+* SOP: {{ if .Alert.Link }}{{ ToLink "SOP" .Alert.Link }}{{ else }}_none_{{ end }}
+* Alert: {{ ToLink .Alert.ID .Alert.HTMLURL }}
+* Service: {{ .Alert.Service }}
+* Created: {{ .Alert.Created }}
+`
+
+// noteTabTemplate renders a single note with navigation header
+const noteTabTemplate = `
+### Note {{ add1 .Index }}/{{ .Total }}
+
+> {{ .Note.Content }}
+
+-- {{ .Note.User }} @ {{ .Note.Created }}
+`
 
 const noteTemplate = `
 

--- a/pkg/tui/views_test.go
+++ b/pkg/tui/views_test.go
@@ -660,6 +660,189 @@ func TestIncidentTemplate_BoldIncidentID(t *testing.T) {
 	}
 }
 
+func TestDetailsTab_Template(t *testing.T) {
+	t.Run("details tab renders metadata without alerts or notes", func(t *testing.T) {
+		summary := incidentSummary{
+			ID:           "INC010",
+			Title:        "Test Incident for Details Tab",
+			HTMLURL:      "https://example.pagerduty.com/incidents/INC010",
+			Service:      "Test Service",
+			Urgency:      "high",
+			Created:      "2025-01-01T00:00:00Z",
+			Status:       "triggered",
+			Acknowledged: []string{"SRE User"},
+			Alerts: []alertSummary{
+				{
+					ID:      "ALERT010",
+					Name:    "SomeAlert",
+					HTMLURL: "https://example.pagerduty.com/alerts/ALERT010",
+					Service: "Alert Service",
+					Created: "2025-01-01T00:00:00Z",
+					Status:  "triggered",
+					Cluster: "cluster-id",
+				},
+			},
+			Notes: []noteSummary{
+				{
+					ID:      "NOTE010",
+					User:    "Someone",
+					Content: "A note",
+					Created: "2025-01-01T00:00:00Z",
+				},
+			},
+		}
+
+		tmpl, err := template.New("details").Funcs(funcMap).Parse(detailsTabTemplate)
+		require.NoError(t, err)
+
+		var buf bytes.Buffer
+		err = tmpl.Execute(&buf, summary)
+		require.NoError(t, err)
+		result := buf.String()
+
+		// Should contain incident metadata
+		assert.Contains(t, result, "INC010")
+		assert.Contains(t, result, "Test Incident for Details Tab")
+		assert.Contains(t, result, "Test Service")
+		assert.Contains(t, result, "high")
+		assert.Contains(t, result, "triggered")
+
+		// Should NOT contain alert or note content
+		assert.NotContains(t, result, "ALERT010")
+		assert.NotContains(t, result, "SomeAlert")
+		assert.NotContains(t, result, "NOTE010")
+		assert.NotContains(t, result, "A note")
+	})
+}
+
+func TestAlertTab_ShowsSingleAlert(t *testing.T) {
+	t.Run("alert tab template renders a single alert", func(t *testing.T) {
+		data := singleAlertTabData{
+			Alert: alertSummary{
+				ID:      "ALERT020",
+				Name:    "KubePodNotReady",
+				Link:    "https://example.com/sop/kube-pod-not-ready",
+				HTMLURL: "https://example.pagerduty.com/alerts/ALERT020",
+				Service: "Alert Service",
+				Created: "2025-06-01T10:00:00Z",
+				Status:  "triggered",
+				Cluster: "my-cluster-id",
+			},
+			Index: 0,
+			Total: 5,
+		}
+
+		tmpl, err := template.New("alert").Funcs(funcMap).Parse(alertTabTemplate)
+		require.NoError(t, err)
+
+		var buf bytes.Buffer
+		err = tmpl.Execute(&buf, data)
+		require.NoError(t, err)
+		result := buf.String()
+
+		assert.Contains(t, result, "KubePodNotReady")
+		assert.Contains(t, result, "my-cluster-id")
+		assert.Contains(t, result, "1/5")         // 1-based display of index 0 out of 5
+		assert.NotContains(t, result, "ALERT999") // Does not contain other alerts
+	})
+}
+
+func TestNoteTab_ShowsSingleNote(t *testing.T) {
+	t.Run("note tab template renders a single note", func(t *testing.T) {
+		data := singleNoteTabData{
+			Note: noteSummary{
+				ID:      "NOTE020",
+				User:    "Jane SRE",
+				Content: "Investigated and found root cause",
+				Created: "2025-06-01T12:00:00Z",
+			},
+			Index: 1,
+			Total: 3,
+		}
+
+		tmpl, err := template.New("note").Funcs(funcMap).Parse(noteTabTemplate)
+		require.NoError(t, err)
+
+		var buf bytes.Buffer
+		err = tmpl.Execute(&buf, data)
+		require.NoError(t, err)
+		result := buf.String()
+
+		assert.Contains(t, result, "Jane SRE")
+		assert.Contains(t, result, "Investigated and found root cause")
+		assert.Contains(t, result, "2/3") // 1-based display of index 1 out of 3
+	})
+}
+
+func TestTabHeader_Rendering(t *testing.T) {
+	tests := []struct {
+		name                string
+		activeTab           int
+		alertCount          int
+		noteCount           int
+		alertsLoading       bool
+		notesLoading        bool
+		expectedContains    []string
+		expectedNotContains []string
+	}{
+		{
+			name:       "Details tab active shows highlighted Details",
+			activeTab:  0,
+			alertCount: 5,
+			noteCount:  3,
+			expectedContains: []string{
+				"Details",
+				"Alerts (5)",
+				"Notes (3)",
+			},
+		},
+		{
+			name:       "Alerts tab active shows count",
+			activeTab:  1,
+			alertCount: 10,
+			noteCount:  0,
+			expectedContains: []string{
+				"Details",
+				"Alerts (10)",
+				"Notes (0)",
+			},
+		},
+		{
+			name:          "Loading alerts shows loading indicator",
+			activeTab:     1,
+			alertCount:    0,
+			noteCount:     2,
+			alertsLoading: true,
+			expectedContains: []string{
+				"Alerts (...)",
+			},
+		},
+		{
+			name:         "Loading notes shows loading indicator",
+			activeTab:    2,
+			alertCount:   1,
+			noteCount:    0,
+			notesLoading: true,
+			expectedContains: []string{
+				"Notes (...)",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := renderTabHeader(tt.activeTab, tt.alertCount, tt.noteCount, tt.alertsLoading, tt.notesLoading)
+
+			for _, expected := range tt.expectedContains {
+				assert.Contains(t, result, expected, "tab header should contain %q", expected)
+			}
+			for _, notExpected := range tt.expectedNotContains {
+				assert.NotContains(t, result, notExpected, "tab header should not contain %q", notExpected)
+			}
+		})
+	}
+}
+
 func TestIncidentTemplate_NotesIndented(t *testing.T) {
 	summary := incidentSummary{
 		ID:           "INC001",


### PR DESCRIPTION
## Summary
Replaces the single scrollable incident view with three tabbed sections:
- **[Details]** — incident metadata, assignments, acknowledgements
- **[Alerts (N)]** — one alert at a time, left/right to navigate
- **[Notes (N)]** — one note at a time, left/right to navigate

Navigation:
- Tab/Shift+Tab switches between top-level tabs
- Left/Right arrows navigate individual alerts/notes (wrapping)
- Number keys 1-9 jump directly to a specific alert/note
- Viewport scrolls to top on tab/item switch

Closes #199

## Test plan
- [x] 10 new test functions covering tab switching, bounds checking, number keys
- [x] `go test ./... -count=1` passes all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)