### PR TITLE
Fix Codecov CI integration

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -124,15 +124,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
-      - name: Run coverage
-        run: make coverage
+      - name: Generate coverage
+        run: go test ./... -coverprofile=coverage.out -covermode=atomic
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           files: coverage.out
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ secrets.CODECOV_TOKEN }}
         continue-on-error: true
 
   build:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@
 
 [![Go Version](https://img.shields.io/github/go-mod/go-version/clcollins/srepd)](https://golang.org)
 [![Build Status](https://github.com/clcollins/srepd/actions/workflows/go-ci.yml/badge.svg)](https://github.com/clcollins/srepd/actions/workflows/go-ci.yml)
+[![codecov](https://codecov.io/gh/clcollins/srepd/graph/badge.svg)](https://codecov.io/gh/clcollins/srepd)
 [![Go Report Card](https://goreportcard.com/badge/github.com/clcollins/srepd)](https://goreportcard.com/report/github.com/clcollins/srepd)
+[![Go Reference](https://pkg.go.dev/badge/github.com/clcollins/srepd.svg)](https://pkg.go.dev/github.com/clcollins/srepd)
+[![GitHub Release](https://img.shields.io/github/v/release/clcollins/srepd)](https://github.com/clcollins/srepd/releases)
 [![License](https://img.shields.io/github/license/clcollins/srepd)](https://github.com/clcollins/srepd/blob/main/LICENSE)
 
 A PagerDuty terminal user interface focused on common SRE tasks.

--- a/docs/plans/058-fix-codecov-ci.md
+++ b/docs/plans/058-fix-codecov-ci.md
@@ -1,0 +1,25 @@
+# 058: Fix Codecov CI Integration
+
+## Problem
+
+The Codecov upload step in CI was broken in three ways:
+
+1. **Outdated action version**: `codecov/codecov-action@v4` should be `@v5`.
+2. **Token passed incorrectly**: v5 expects the token under `with:`, not `env:`.
+3. **Coverage file deleted before upload**: `make coverage` removes `coverage.out`
+   at the end of its run, so the subsequent upload step had no file to upload.
+
+## Changes
+
+### `.github/workflows/go-ci.yml`
+
+- Replaced `make coverage` with a direct `go test` command that generates
+  `coverage.out` without cleaning it up. The `make coverage` target remains
+  useful for local development (it prints a summary and cleans up after itself).
+- Upgraded `codecov/codecov-action` from `v4` to `v5`.
+- Moved `CODECOV_TOKEN` from `env:` to `with: token:` as required by v5.
+
+## Validation
+
+- `go test ./... -count=1` passes locally.
+- CI workflow syntax validated by review.


### PR DESCRIPTION
## Summary

- Upgrade `codecov/codecov-action` from v4 to v5
- Move `CODECOV_TOKEN` from `env:` to `with: token:` (required by v5)
- Replace `make coverage` with direct `go test` so `coverage.out` survives for the upload step

## Problem

The Codecov upload in CI was silently failing for three reasons:

1. **Outdated action**: v4 is deprecated; v5 is current.
2. **Token location**: v5 requires the token under `with:`, not `env:`.
3. **Missing file**: `make coverage` deletes `coverage.out` after generating it, so the upload step had nothing to upload.

## Test plan

- [x] `go test ./... -count=1` passes locally
- [ ] CI pipeline passes on this PR
- [ ] Codecov upload step succeeds (visible in CI logs)

Created with assistance from Claude <claude@anthropic.com>

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>