### PR TITLE
Add codecov.yml config and local patch coverage check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,18 +61,39 @@ Pass extra test flags via `TESTOPTS`, e.g.:
 - Type assertions must use the comma-ok pattern
 - Tests before code (TDD)
 - Each PR must pass all CI checks
-- **All tests must pass locally before committing.** Run
-  `make test-all` (or at minimum `go test ./... -count=1`)
-  and verify zero failures before creating a commit or PR.
-  Do not push code that fails tests.
+- **Run the FULL local CI suite before every commit.** Run
+  all checks in parallel before pushing. Do not push code
+  that fails any check.
+
+## Pre-Commit Checks (MANDATORY)
+
+Run ALL of these in parallel before every commit/push:
+
+```bash
+# Run all 6 in parallel:
+gofmt -s -l cmd pkg                              # fmt-check
+go vet ./...                                     # vet
+go test ./... -count=1                           # unit tests
+CGO_ENABLED=1 go test -race ./... -count=1       # race detection
+ls docs/plans/*.md                               # plan doc exists
+# If keymap.go/config.go/root.go/commands.go changed:
+git diff origin/main --name-only | grep README   # readme updated
+```
+
+If `golangci-lint` is installed, also run:
+```bash
+golangci-lint run --timeout 5m                   # lint
+```
+
+**Every check must pass. Fix failures before committing.**
 
 ## PR Workflow
 
 1. Create feature branch: `srepd/<description>`
 2. Write failing tests
 3. Implement minimum code to pass tests
-4. Run `make test-all` locally — **all tests must pass**
-5. If any test fails, fix it before proceeding
+4. Run the full pre-commit checks (see above) — **all must pass**
+5. Fix any failures before proceeding
 6. Push and create PR against `main`
 7. CI runs all checks via `make` targets
 8. Review, approve, merge

--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,40 @@ test-coverage-threshold: ## Enforce minimum coverage threshold
 	echo "PASS: Coverage $$total% meets threshold $(COVERAGE_THRESHOLD)%"; \
 	rm -f coverage.out
 
+PATCH_COVERAGE_TARGET ?= 70
+
+.PHONY: test-coverage-patch
+test-coverage-patch: ## Check coverage of changed files (approximates Codecov patch coverage)
+	@echo "Checking patch coverage for changed files (target $(PATCH_COVERAGE_TARGET)%)..."
+	@MERGE_BASE=$$(git merge-base HEAD origin/main 2>/dev/null || echo ""); \
+	if [ -z "$$MERGE_BASE" ]; then \
+		echo "WARN: could not determine merge base; skipping patch coverage"; \
+		exit 0; \
+	fi; \
+	CHANGED=$$(git diff --name-only "$$MERGE_BASE"...HEAD -- '*.go' | grep -v '_test.go' || echo ""); \
+	if [ -z "$$CHANGED" ]; then \
+		echo "No changed Go files - patch coverage check skipped"; \
+		exit 0; \
+	fi; \
+	go test ./... -coverprofile=coverage.out -covermode=atomic > /dev/null 2>&1; \
+	FAIL=false; \
+	for f in $$CHANGED; do \
+		pkg=$$(dirname $$f | sed 's|^|github.com/clcollins/srepd/|'); \
+		cov=$$(go tool cover -func=coverage.out 2>/dev/null | grep "^$$pkg" | awk '{sum+=$$3; n++} END {if(n>0) printf "%.0f", sum/n; else print "N/A"}'); \
+		if [ "$$cov" != "N/A" ] && [ $$(echo "$$cov < $(PATCH_COVERAGE_TARGET)" | bc 2>/dev/null || echo 0) -eq 1 ]; then \
+			echo "  WARN: $$f package coverage $$cov% < $(PATCH_COVERAGE_TARGET)%"; \
+			FAIL=true; \
+		else \
+			echo "  OK: $$f (package coverage $$cov%)"; \
+		fi; \
+	done; \
+	rm -f coverage.out; \
+	if [ "$$FAIL" = "true" ]; then \
+		echo "WARN: Some changed packages have coverage below $(PATCH_COVERAGE_TARGET)%"; \
+	else \
+		echo "PASS: All changed packages meet $(PATCH_COVERAGE_TARGET)% coverage target"; \
+	fi
+
 .PHONY: test-all
 test-all: fmt-check vet lint test test-race ## Run all checks
 	@echo "All checks passed."

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 55%
+        threshold: 2%
+    patch:
+      default:
+        target: 70%
+        threshold: 5%

--- a/docs/plans/059-agents-md-precommit-checks.md
+++ b/docs/plans/059-agents-md-precommit-checks.md
@@ -1,0 +1,22 @@
+# Require full parallel CI suite in AGENTS.md pre-commit checks
+
+## Context
+
+Agents and developers were skipping CI checks before pushing,
+causing repeated CI failures on PRs (lint, format, README check).
+The AGENTS.md instructions said "run make test-all" but that was
+vague and didn't cover all checks.
+
+## Plan
+
+Replace the vague instruction with an explicit parallel checklist
+of all 7 CI checks that must pass before every commit/push.
+
+## Files Modified
+
+- `AGENTS.md` — replaced Key Invariants and PR Workflow sections
+  with explicit pre-commit check commands
+
+## Verification
+
+- All 7 checks pass locally before pushing

--- a/docs/plans/060-codecov-config-patch-coverage.md
+++ b/docs/plans/060-codecov-config-patch-coverage.md
@@ -1,0 +1,24 @@
+# Add Codecov config and local patch coverage check
+
+## Context
+
+Codecov posts informational status checks on PRs but nothing
+enforces coverage on changed code. Need codecov.yml for remote
+enforcement and a local approximation for pre-push checks.
+
+## Plan
+
+1. Add `codecov.yml` with project target 55% and patch target 70%
+2. Add `make test-coverage-patch` for local approximation
+3. The local check identifies changed Go files, measures their
+   package coverage, and warns if below 70%
+
+## Files
+
+- `codecov.yml` — new, Codecov configuration
+- `Makefile` — add test-coverage-patch target
+
+## Verification
+
+- Codecov status checks appear on PRs with pass/fail
+- `make test-coverage-patch` runs locally and reports


### PR DESCRIPTION
## Summary
- Add `codecov.yml` with project target 55% and patch target 70% (Codecov will fail PRs with low coverage on changed lines)
- Add `make test-coverage-patch` for local approximation of patch coverage

## Test plan
- [x] All 7 `make` checks pass locally (fmt, vet, lint, test, race, plan, readme)
- [ ] Codecov status check appears on PRs with thresholds

🤖 Generated with [Claude Code](https://claude.com/claude-code)