### PR TITLE
Chord help displays in help section instead of status bar

### DIFF
--- a/docs/plans/059-chord-help-update.md
+++ b/docs/plans/059-chord-help-update.md
@@ -1,0 +1,79 @@
+# 059: Update Chord Help Display
+
+**Issue**: #223
+**Branch**: srepd/chord-help-update
+**Status**: In Progress
+
+## Problem
+
+The chord key help (ctrl+x ?) displays its content in the status bar at the
+top of the screen. This is inconsistent with how regular help works -- the
+standard help message renders at the bottom of the window. The chord help
+should temporarily replace (or integrate with) the standard help display.
+
+## Solution
+
+Add a `chordHelpActive` boolean to the model. When the chord help action
+fires (ctrl+x ?), set this flag and expand help to full mode. In `View()`,
+when `chordHelpActive` is true, render a chord-specific help keymap instead
+of the regular one. The flag is cleared on any subsequent keypress.
+
+## Design
+
+### Model changes
+
+New field on `model`:
+- `chordHelpActive bool` -- when true, the help section at the bottom shows
+  chord bindings instead of the regular keymap
+
+### chordShowHelp handler
+
+Instead of calling `setStatus()`, the handler:
+1. Sets `m.chordHelpActive = true`
+2. Sets `m.help.ShowAll = true` (ensures full help is visible)
+3. Does NOT set status (keeps status bar clean)
+
+### View() integration
+
+The help keymap selection in `View()` gains a third condition:
+
+```
+if m.chordHelpActive {
+    helpKeyMap = chordHelpKeyMap
+} else if m.input.Focused() {
+    helpKeyMap = inputModeKeyMap
+} else {
+    helpKeyMap = defaultKeyMap
+}
+```
+
+### Clearing chordHelpActive
+
+The flag is cleared at the top of `keyMsgHandler` before any other
+processing, so a single keypress dismisses the chord help and returns to
+normal help display.
+
+### chordHelpKeyMap
+
+New keymap type `chordKeymap` implementing `help.KeyMap`. Its `FullHelp()`
+returns chord bindings as the sole column. Its `ShortHelp()` shows a
+dismissal hint.
+
+## Files Changed
+
+| File | Action |
+|------|--------|
+| `pkg/tui/model.go` | Add `chordHelpActive` field |
+| `pkg/tui/chords.go` | Update `chordShowHelp`, add `chordKeymap` type |
+| `pkg/tui/views.go` | Add `chordHelpActive` branch in help keymap selection |
+| `pkg/tui/msgHandlers.go` | Clear `chordHelpActive` on keypress |
+| `pkg/tui/chords_test.go` | Update and add tests for new behavior |
+| `docs/plans/059-chord-help-update.md` | This plan |
+
+## Tests (TDD -- written first)
+
+1. `TestChordShowHelp_SetsChordHelpActive` -- pressing ctrl+x ? sets chordHelpActive
+2. `TestChordShowHelp_DoesNotSetStatus` -- chord help no longer uses status bar
+3. `TestChordHelp_ClearedOnKeypress` -- any key clears chordHelpActive
+4. `TestChordHelp_ViewRendersChordKeymap` -- View() uses chord keymap when active
+5. Update existing `TestChord_ValidSecondKey` to reflect new behavior

--- a/pkg/tui/chords.go
+++ b/pkg/tui/chords.go
@@ -57,10 +57,37 @@ func resolveChord(key string) *chordAction {
 	return nil
 }
 
-// chordShowHelp displays the list of available chord commands in the status bar.
+// chordShowHelp displays the list of available chord commands in the help
+// section at the bottom of the screen, temporarily replacing the regular help.
 func chordShowHelp(m model) (tea.Model, tea.Cmd) {
-	m.setStatus(chordHelpText(m.chordPrefix))
+	m.chordHelpActive = true
+	m.help.ShowAll = true
 	return m, nil
+}
+
+// chordKeymap implements help.KeyMap to display chord bindings in the help section.
+type chordKeymap struct {
+	prefix string
+}
+
+func (k chordKeymap) ShortHelp() []key.Binding {
+	return []key.Binding{
+		key.NewBinding(
+			key.WithKeys("any"),
+			key.WithHelp("any key", "dismiss chord help"),
+		),
+	}
+}
+
+func (k chordKeymap) FullHelp() [][]key.Binding {
+	var bindings []key.Binding
+	for _, entry := range chordRegistry {
+		bindings = append(bindings, key.NewBinding(
+			key.WithKeys(k.prefix+" "+entry.Key),
+			key.WithHelp(k.prefix+" "+entry.Key, entry.Description),
+		))
+	}
+	return [][]key.Binding{bindings}
 }
 
 // chordViewLog is a placeholder for the future debug log viewer (Issue #203).

--- a/pkg/tui/chords_test.go
+++ b/pkg/tui/chords_test.go
@@ -76,6 +76,78 @@ func TestChord_ValidSecondKey(t *testing.T) {
 	})
 }
 
+func TestChordShowHelp_SetsChordHelpActive(t *testing.T) {
+	t.Run("pressing ctrl+x ? sets chordHelpActive and expands help", func(t *testing.T) {
+		m := createTestModel()
+		m.chordPrefix = "ctrl+x"
+		m.help = newHelp()
+		m.chordPending = true
+
+		// Press '?' to trigger chord help
+		questionKeyMsg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}}
+		result, _ := m.Update(questionKeyMsg)
+		updatedModel := result.(model)
+
+		assert.True(t, updatedModel.chordHelpActive,
+			"chordHelpActive should be true after chord help is triggered")
+		assert.True(t, updatedModel.help.ShowAll,
+			"help.ShowAll should be true to display full chord help")
+	})
+}
+
+func TestChordShowHelp_DoesNotSetStatus(t *testing.T) {
+	t.Run("chord help does not use the status bar", func(t *testing.T) {
+		m := createTestModel()
+		m.chordPrefix = "ctrl+x"
+		m.help = newHelp()
+		m.chordPending = true
+		m.status = ""
+
+		// Press '?' to trigger chord help
+		questionKeyMsg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}}
+		result, _ := m.Update(questionKeyMsg)
+		updatedModel := result.(model)
+
+		assert.Empty(t, updatedModel.status,
+			"status bar should remain empty when chord help is shown")
+	})
+}
+
+func TestChordHelp_ClearedOnKeypress(t *testing.T) {
+	t.Run("any keypress clears chordHelpActive", func(t *testing.T) {
+		m := createTestModel()
+		m.chordPrefix = "ctrl+x"
+		m.help = newHelp()
+		m.chordHelpActive = true
+		m.help.ShowAll = true
+
+		// Press any key (e.g., 'j' for down)
+		jKeyMsg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}}
+		result, _ := m.Update(jKeyMsg)
+		updatedModel := result.(model)
+
+		assert.False(t, updatedModel.chordHelpActive,
+			"chordHelpActive should be cleared after any keypress")
+	})
+
+	t.Run("pressing chord prefix while chord help is active clears it and enters chord mode", func(t *testing.T) {
+		m := createTestModel()
+		m.chordPrefix = "ctrl+x"
+		m.help = newHelp()
+		m.chordHelpActive = true
+		m.help.ShowAll = true
+
+		// Press ctrl+x again
+		result, _ := m.Update(chordPrefixKeyMsg())
+		updatedModel := result.(model)
+
+		assert.False(t, updatedModel.chordHelpActive,
+			"chordHelpActive should be cleared when entering new chord mode")
+		assert.True(t, updatedModel.chordPending,
+			"chordPending should be set after pressing chord prefix")
+	})
+}
+
 func TestChord_UnknownSecondKey(t *testing.T) {
 	t.Run("pressing unknown second key shows error status", func(t *testing.T) {
 		m := createTestModel()
@@ -214,6 +286,48 @@ func TestChordHelpText(t *testing.T) {
 		text := chordHelpText("ctrl+x")
 		assert.NotEmpty(t, text, "chord help text should not be empty")
 		assert.Contains(t, text, "ctrl+x", "help text should mention the prefix")
+	})
+}
+
+func TestChordHelp_ViewRendersChordKeymap(t *testing.T) {
+	t.Run("View renders chord help bindings when chordHelpActive", func(t *testing.T) {
+		m := createTestModel()
+		m.chordPrefix = "ctrl+x"
+		m.help = newHelp()
+		m.help.ShowAll = true
+		m.chordHelpActive = true
+
+		// Set window size so View can render
+		windowSize = tea.WindowSizeMsg{Width: 120, Height: 40}
+
+		view := m.View()
+
+		// The chord help should contain chord-specific entries
+		assert.Contains(t, view, "show chord help",
+			"View should render chord help descriptions when chordHelpActive is true")
+		assert.Contains(t, view, "view debug log",
+			"View should render chord debug log description when chordHelpActive is true")
+	})
+}
+
+func TestChordKeymap_ImplementsHelpKeyMap(t *testing.T) {
+	t.Run("chordKeymap ShortHelp returns dismissal hint", func(t *testing.T) {
+		km := chordKeymap{prefix: "ctrl+x"}
+		short := km.ShortHelp()
+		assert.NotEmpty(t, short, "ShortHelp should return at least one binding")
+	})
+
+	t.Run("chordKeymap FullHelp returns chord bindings", func(t *testing.T) {
+		km := chordKeymap{prefix: "ctrl+x"}
+		full := km.FullHelp()
+		assert.NotEmpty(t, full, "FullHelp should return at least one column")
+		// Should have bindings for each chord registry entry
+		totalBindings := 0
+		for _, col := range full {
+			totalBindings += len(col)
+		}
+		assert.GreaterOrEqual(t, totalBindings, len(chordRegistry),
+			"FullHelp should have at least as many bindings as chord registry entries")
 	})
 }
 

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -113,6 +113,9 @@ type model struct {
 	chordPending bool
 	// chordPrefix is the configurable prefix key for chord commands (default "ctrl+x").
 	chordPrefix string
+	// chordHelpActive is true when chord help is being displayed in the help
+	// section at the bottom of the screen, temporarily replacing the regular help.
+	chordHelpActive bool
 
 	// claudeQuerying is true while a Claude CLI query is in progress
 	claudeQuerying bool

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -161,6 +161,11 @@ func (m model) keyMsgHandler(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleConfirmationInput(msg.(tea.KeyMsg))
 	}
 
+	// Clear chord help overlay on any keypress so the regular help returns
+	if m.chordHelpActive {
+		m.chordHelpActive = false
+	}
+
 	keyStr := msg.(tea.KeyMsg).String()
 
 	// Chord state machine: runs before focus-mode dispatch so chords work

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -182,7 +182,9 @@ func (m model) View() string {
 
 	// Choose the appropriate keymap based on focus mode
 	var helpKeyMap help.KeyMap
-	if m.input.Focused() {
+	if m.chordHelpActive {
+		helpKeyMap = chordKeymap{prefix: m.chordPrefix}
+	} else if m.input.Focused() {
 		helpKeyMap = inputModeKeyMap
 	} else {
 		helpKeyMap = defaultKeyMap


### PR DESCRIPTION
## Summary
ctrl+x ? now shows chord commands in the bottom help section (replacing the regular keymap) until any key is pressed, instead of a brief status bar message.

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)