### PR TITLE
Guard all incident actions against nil selection

### DIFF
--- a/docs/plans/059-fix-actions-no-selection.md
+++ b/docs/plans/059-fix-actions-no-selection.md
@@ -1,0 +1,66 @@
+# 059: Fix actions executing without selected incident
+
+**Issue**: #224
+**Branch**: srepd/fix-actions-no-selection
+**Status**: Complete
+
+## Problem
+
+Actions triggered when there is no incident selected execute anyway instead of
+returning a "no incident selected" status message. For example, pressing Enter
+when no incident is highlighted opens an incident viewer with empty/placeholder
+data instead of showing a status message.
+
+## Root Cause
+
+Several key handlers in `switchTableFocusMode` and `switchIncidentFocusMode`
+were missing the `SelectedRow() == nil` guard or `selectedIncident == nil` check
+before proceeding with their action.
+
+## Changes
+
+### `pkg/tui/msgHandlers.go`
+
+**Table focus mode (`switchTableFocusMode`):**
+- **Enter key**: Added `SelectedRow() == nil` check before opening the incident
+  viewer. Previously would open a viewer with empty/loading placeholder data.
+- **SOP key**: Added the full three-step guard pattern (SelectedRow check, sync,
+  selectedIncident check) that was already used by Ack, Silence, UnAck, Note,
+  and Open handlers.
+
+**Incident focus mode (`switchIncidentFocusMode`):**
+- **Refresh**: Added `selectedIncident == nil` guard to prevent nil pointer
+  dereference when accessing `m.selectedIncident.ID`.
+- **Ack**: Added `selectedIncident == nil` guard.
+- **UnAck**: Replaced empty-string fallback pattern with early-return guard.
+  Previously would show a confirmation prompt with an empty incident ID.
+- **Silence**: Same fix as UnAck.
+- **Note**: Added `selectedIncident == nil` guard before the `incidentDataLoaded`
+  check.
+- **Login**: Added `selectedIncident == nil` guard before the
+  `incidentAlertsLoaded` check.
+- **Open**: Added `selectedIncident == nil` guard before the `incidentDataLoaded`
+  check.
+- **SOP**: Added `selectedIncident == nil` guard before the
+  `incidentAlertsLoaded` check.
+
+### `pkg/tui/msgHandlers_test.go`
+
+Added tests for every guarded path:
+- `TestTableMode_EnterKeyWithNoRows`
+- `TestTableMode_SOPKeyWithNoRows`
+- `TestTableMode_SOPKeyWithNoSelectedIncident`
+- `TestTableMode_LoginKeyWithNoRows`
+- `TestIncidentViewMode_AckWithNilSelectedIncident`
+- `TestIncidentViewMode_UnAckWithNilSelectedIncident`
+- `TestIncidentViewMode_SilenceWithNilSelectedIncident`
+- `TestIncidentViewMode_NoteWithNilSelectedIncident`
+- `TestIncidentViewMode_LoginWithNilSelectedIncident`
+- `TestIncidentViewMode_OpenWithNilSelectedIncident`
+- `TestIncidentViewMode_SOPWithNilSelectedIncident`
+- `TestIncidentViewMode_RefreshWithNilSelectedIncident`
+
+## Testing
+
+All tests pass with `make test-all`. No behavior changes for normal use cases
+where an incident is properly selected.

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -350,6 +350,10 @@ func switchTableFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 		// fetch full incident data from the API before proceeding.
 
 		case key.Matches(msg, defaultKeyMap.Enter):
+			if m.table.SelectedRow() == nil {
+				m.setStatus("no incident highlighted")
+				return m, nil
+			}
 			// Clear any pending confirmation on view transition
 			m.pendingConfirmation = nil
 			// Check if we have cached data for this incident
@@ -491,6 +495,15 @@ func switchTableFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Batch(m.flashNotification(fmt.Sprintf("Opened %s in browser", m.selectedIncident.ID)), openBrowserCmd(c, m.selectedIncident.HTMLURL))
 
 		case key.Matches(msg, defaultKeyMap.SOP):
+			if m.table.SelectedRow() == nil {
+				m.setStatus("no incident highlighted")
+				return m, nil
+			}
+			m.syncSelectedIncidentToHighlightedRow()
+			if m.selectedIncident == nil {
+				m.setStatus("no incident selected")
+				return m, nil
+			}
 			if !m.incidentAlertsLoaded {
 				m.setStatus("Loading incident alerts, please wait...")
 				return m, nil
@@ -626,34 +639,46 @@ func switchIncidentFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 
 		case key.Matches(msg, defaultKeyMap.Refresh):
+			if m.selectedIncident == nil {
+				m.setStatus("no incident selected")
+				return m, nil
+			}
 			return m, func() tea.Msg { return getIncidentMsg(m.selectedIncident.ID) }
 
 		case key.Matches(msg, defaultKeyMap.Ack):
+			if m.selectedIncident == nil {
+				m.setStatus("no incident selected")
+				return m, nil
+			}
 			return m, func() tea.Msg { return acknowledgeIncidentsMsg{} }
 
 		case key.Matches(msg, defaultKeyMap.UnAck):
-			incidentID := ""
-			if m.selectedIncident != nil {
-				incidentID = m.selectedIncident.ID
+			if m.selectedIncident == nil {
+				m.setStatus("no incident selected")
+				return m, nil
 			}
 			m.pendingConfirmation = &confirmActionState{
-				prompt: fmt.Sprintf("Re-escalate %s? [y/n]", incidentID),
+				prompt: fmt.Sprintf("Re-escalate %s? [y/n]", m.selectedIncident.ID),
 				action: func() tea.Msg { return unAcknowledgeIncidentsMsg{} },
 			}
 			return m, nil
 
 		case key.Matches(msg, defaultKeyMap.Silence):
-			incidentID := ""
-			if m.selectedIncident != nil {
-				incidentID = m.selectedIncident.ID
+			if m.selectedIncident == nil {
+				m.setStatus("no incident selected")
+				return m, nil
 			}
 			m.pendingConfirmation = &confirmActionState{
-				prompt: fmt.Sprintf("Silence %s? [y/n]", incidentID),
+				prompt: fmt.Sprintf("Silence %s? [y/n]", m.selectedIncident.ID),
 				action: func() tea.Msg { return silenceSelectedIncidentMsg{} },
 			}
 			return m, nil
 
 		case key.Matches(msg, defaultKeyMap.Note):
+			if m.selectedIncident == nil {
+				m.setStatus("no incident selected")
+				return m, nil
+			}
 			// Note template requires full incident data (HTMLURL, Title, Service.Summary)
 			if !m.incidentDataLoaded {
 				m.setStatus("Loading incident details, please wait...")
@@ -662,6 +687,10 @@ func switchIncidentFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, func() tea.Msg { return parseTemplateForNoteMsg("add note") }
 
 		case key.Matches(msg, defaultKeyMap.Login):
+			if m.selectedIncident == nil {
+				m.setStatus("no incident selected")
+				return m, nil
+			}
 			// Login requires alerts to extract cluster_id
 			if !m.incidentAlertsLoaded {
 				m.setStatus("Loading incident alerts, please wait...")
@@ -670,6 +699,10 @@ func switchIncidentFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, func() tea.Msg { return loginMsg("login") }
 
 		case key.Matches(msg, defaultKeyMap.Open):
+			if m.selectedIncident == nil {
+				m.setStatus("no incident selected")
+				return m, nil
+			}
 			// Browser open requires HTMLURL from full incident data
 			if !m.incidentDataLoaded {
 				m.setStatus("Loading incident details, please wait...")
@@ -678,6 +711,10 @@ func switchIncidentFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, func() tea.Msg { return openBrowserMsg("incident") }
 
 		case key.Matches(msg, defaultKeyMap.SOP):
+			if m.selectedIncident == nil {
+				m.setStatus("no incident selected")
+				return m, nil
+			}
 			// SOP link requires alerts to extract the link field
 			if !m.incidentAlertsLoaded {
 				m.setStatus("Loading incident alerts, please wait...")

--- a/pkg/tui/msgHandlers_test.go
+++ b/pkg/tui/msgHandlers_test.go
@@ -262,6 +262,222 @@ func TestTableMode_SilenceKeyWithNoSelectedIncident(t *testing.T) {
 		"Silence key should not return a command before confirmation")
 }
 
+// enterKeyMsg returns a tea.KeyMsg that matches the Enter key binding.
+func enterKeyMsg() tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyEnter}
+}
+
+// sopKeyMsg returns a tea.KeyMsg that matches the SOP key binding ('s').
+func sopKeyMsg() tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}}
+}
+
+// loginKeyMsg returns a tea.KeyMsg that matches the Login key binding ('l').
+func loginKeyMsg() tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}}
+}
+
+// refreshKeyMsg returns a tea.KeyMsg that matches the Refresh key binding ('r').
+func refreshKeyMsg() tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}}
+}
+
+func TestTableMode_EnterKeyWithNoRows(t *testing.T) {
+	// Scenario: Table has no rows at all. Pressing Enter key should gracefully
+	// report "no incident highlighted" instead of opening an empty incident viewer.
+
+	m := createTestModel()
+	m.table = table.New(table.WithFocused(true))
+
+	result, cmd := m.Update(enterKeyMsg())
+	updatedModel := result.(model)
+
+	assert.Contains(t, updatedModel.status, "no incident",
+		"Enter key with empty table should report no incident")
+	assert.False(t, updatedModel.viewingIncident,
+		"Should not open incident viewer when no row is highlighted")
+	assert.Nil(t, cmd,
+		"Enter key with empty table should not return a command")
+}
+
+func TestTableMode_SOPKeyWithNoRows(t *testing.T) {
+	// Scenario: Table has no rows at all. Pressing SOP key should gracefully
+	// handle this (status message about no incident, no panic).
+
+	m := createTestModel()
+	m.table = table.New(table.WithFocused(true))
+
+	result, cmd := m.Update(sopKeyMsg())
+	updatedModel := result.(model)
+
+	assert.Contains(t, updatedModel.status, "no incident",
+		"SOP key with empty table should report no incident")
+	assert.Nil(t, cmd,
+		"SOP key with empty table should not return a command")
+}
+
+func TestTableMode_SOPKeyWithNoSelectedIncident(t *testing.T) {
+	// Scenario: The table has rows with incidents highlighted, but
+	// selectedIncident is nil. Pressing SOP key should sync the highlighted
+	// row and proceed (sync happens inside the handler).
+
+	incidents := []pagerduty.Incident{
+		{
+			APIObject:          pagerduty.APIObject{ID: "Q111", HTMLURL: "https://example.pagerduty.com/incidents/Q111"},
+			Title:              "Test Alert",
+			Service:            pagerduty.APIObject{ID: "SVC1", Summary: "test-service"},
+			LastStatusChangeAt: time.Now().Format(time.RFC3339),
+		},
+	}
+
+	m := createTestModelWithTableRows(incidents)
+	m.selectedIncident = nil
+
+	// Press the SOP key
+	result, _ := m.Update(sopKeyMsg())
+	updatedModel := result.(model)
+
+	// The status should NOT be "no incident highlighted" - there IS a row highlighted
+	assert.NotEqual(t, "no incident highlighted", updatedModel.status,
+		"SOP key should not report 'no incident highlighted' when a row is highlighted")
+}
+
+func TestTableMode_LoginKeyWithNoRows(t *testing.T) {
+	// Scenario: Table has no rows at all. Pressing Login key should gracefully
+	// handle this via doIfIncidentSelected.
+
+	m := createTestModel()
+	m.table = table.New(table.WithFocused(true))
+
+	result, cmd := m.Update(loginKeyMsg())
+	updatedModel := result.(model)
+
+	// doIfIncidentSelected checks SelectedRow() and returns a setStatusMsg
+	// The cmd when executed should produce a "no incident selected" status
+	assert.NotNil(t, cmd, "Login key should return a status command even with no rows")
+	msg := cmd()
+	statusMsg, ok := msg.(setStatusMsg)
+	assert.True(t, ok, "Should return a setStatusMsg")
+	assert.Contains(t, statusMsg.string, "no incident",
+		"Should indicate no incident selected")
+
+	_ = updatedModel
+}
+
+// --- Incident view mode: actions with nil selectedIncident ---
+
+func TestIncidentViewMode_AckWithNilSelectedIncident(t *testing.T) {
+	m := createTestModel()
+	m.viewingIncident = true
+	m.selectedIncident = nil
+
+	result, cmd := m.Update(ackKeyMsg())
+	updatedModel := result.(model)
+
+	assert.Contains(t, updatedModel.status, "no incident selected",
+		"Ack in incident view with nil selectedIncident should report no incident selected")
+	assert.Nil(t, cmd,
+		"No command should be returned when selectedIncident is nil")
+}
+
+func TestIncidentViewMode_UnAckWithNilSelectedIncident(t *testing.T) {
+	m := createTestModel()
+	m.viewingIncident = true
+	m.selectedIncident = nil
+
+	result, cmd := m.Update(unAckKeyMsg())
+	updatedModel := result.(model)
+
+	assert.Contains(t, updatedModel.status, "no incident selected",
+		"UnAck in incident view with nil selectedIncident should report no incident selected")
+	assert.Nil(t, cmd,
+		"No command should be returned when selectedIncident is nil")
+}
+
+func TestIncidentViewMode_SilenceWithNilSelectedIncident(t *testing.T) {
+	m := createTestModel()
+	m.viewingIncident = true
+	m.selectedIncident = nil
+
+	result, cmd := m.Update(silenceKeyMsg())
+	updatedModel := result.(model)
+
+	assert.Contains(t, updatedModel.status, "no incident selected",
+		"Silence in incident view with nil selectedIncident should report no incident selected")
+	assert.Nil(t, cmd,
+		"No command should be returned when selectedIncident is nil")
+}
+
+func TestIncidentViewMode_NoteWithNilSelectedIncident(t *testing.T) {
+	m := createTestModel()
+	m.viewingIncident = true
+	m.selectedIncident = nil
+
+	result, cmd := m.Update(noteKeyMsg())
+	updatedModel := result.(model)
+
+	assert.Contains(t, updatedModel.status, "no incident selected",
+		"Note in incident view with nil selectedIncident should report no incident selected")
+	assert.Nil(t, cmd,
+		"No command should be returned when selectedIncident is nil")
+}
+
+func TestIncidentViewMode_LoginWithNilSelectedIncident(t *testing.T) {
+	m := createTestModel()
+	m.viewingIncident = true
+	m.selectedIncident = nil
+
+	result, cmd := m.Update(loginKeyMsg())
+	updatedModel := result.(model)
+
+	assert.Contains(t, updatedModel.status, "no incident selected",
+		"Login in incident view with nil selectedIncident should report no incident selected")
+	assert.Nil(t, cmd,
+		"No command should be returned when selectedIncident is nil")
+}
+
+func TestIncidentViewMode_OpenWithNilSelectedIncident(t *testing.T) {
+	m := createTestModel()
+	m.viewingIncident = true
+	m.selectedIncident = nil
+
+	result, cmd := m.Update(openKeyMsg())
+	updatedModel := result.(model)
+
+	assert.Contains(t, updatedModel.status, "no incident selected",
+		"Open in incident view with nil selectedIncident should report no incident selected")
+	assert.Nil(t, cmd,
+		"No command should be returned when selectedIncident is nil")
+}
+
+func TestIncidentViewMode_SOPWithNilSelectedIncident(t *testing.T) {
+	m := createTestModel()
+	m.viewingIncident = true
+	m.selectedIncident = nil
+
+	result, cmd := m.Update(sopKeyMsg())
+	updatedModel := result.(model)
+
+	assert.Contains(t, updatedModel.status, "no incident selected",
+		"SOP in incident view with nil selectedIncident should report no incident selected")
+	assert.Nil(t, cmd,
+		"No command should be returned when selectedIncident is nil")
+}
+
+func TestIncidentViewMode_RefreshWithNilSelectedIncident(t *testing.T) {
+	m := createTestModel()
+	m.viewingIncident = true
+	m.selectedIncident = nil
+
+	result, cmd := m.Update(refreshKeyMsg())
+	updatedModel := result.(model)
+
+	assert.Contains(t, updatedModel.status, "no incident selected",
+		"Refresh in incident view with nil selectedIncident should report no incident selected")
+	assert.Nil(t, cmd,
+		"No command should be returned when selectedIncident is nil")
+}
+
 func TestClusterSelect_DigitSelectsCluster(t *testing.T) {
 	m := createTestModel()
 	m.clusterSelectMode = true


### PR DESCRIPTION
## Summary
Added nil-selection guards to 10 action handlers in msgHandlers.go:
- Table mode: Enter, SOP
- Incident view: Refresh, Ack, UnAck, Silence, Note, Login, Open, SOP
- 12 new tests

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)