### PR TITLE
Add macOS log viewer support with OS-aware log path selection

### DIFF
--- a/docs/plans/061-macos-log-viewer.md
+++ b/docs/plans/061-macos-log-viewer.md
@@ -1,0 +1,47 @@
+# 061: macOS Log Viewer Support
+
+**Issue**: #196
+**Branch**: srepd/macos-log-viewer
+**Status**: In Progress
+
+## Problem
+
+The `defaultLogFilePath()` function in `pkg/tui/model.go` hardcodes the Linux log path (`~/.config/srepd/debug.log`). On macOS, the conventional log location is `~/Library/Logs/srepd.log`. The log viewer pane (issue #203) needs to read from the correct path based on the host OS.
+
+## Solution
+
+Make `defaultLogFilePath()` OS-aware using `runtime.GOOS` to select the correct path, matching the platform detection already used in `cmd/root.go`'s `determineLogDestination()`.
+
+- Linux: `~/.config/srepd/debug.log`
+- macOS (darwin): `~/Library/Logs/srepd.log`
+- Other: returns empty string (no log file available)
+
+Also fix `InitialModelWithConfig()` which is missing the `logViewer` and `logFilePath` initialization, ensuring dev mode has the same log viewer support.
+
+## Implementation Plan
+
+### defaultLogFilePath (model.go)
+
+- Import `runtime` and `path/filepath`
+- Use `runtime.GOOS` to select the correct log file path
+- Use `filepath.Join` for path construction (cross-platform safe)
+- Return empty string for unsupported platforms
+
+### InitialModelWithConfig (model.go)
+
+- Add missing `logViewer: newLogViewer()` initialization
+- Add missing `logFilePath: defaultLogFilePath()` initialization
+
+## Test Plan
+
+1. `TestDefaultLogFilePath_Linux` - returns `~/.config/srepd/debug.log` equivalent on linux
+2. `TestDefaultLogFilePath_Darwin` - returns `~/Library/Logs/srepd.log` equivalent on darwin
+3. `TestDefaultLogFilePath_Unsupported` - returns empty string for unknown OS
+4. `TestLogFilePathForOS` - helper function tests with explicit GOOS parameter
+
+Since `runtime.GOOS` is a constant and cannot be changed at test time, extract the OS-dependent logic into a `logFilePathForOS(goos string)` function that can be tested with arbitrary OS values. The `defaultLogFilePath()` function calls it with `runtime.GOOS`.
+
+## Files Modified
+
+- `pkg/tui/model.go` - OS-aware `defaultLogFilePath()`, new `logFilePathForOS()`, fix `InitialModelWithConfig`
+- `pkg/tui/model_test.go` - tests for `logFilePathForOS()` and `defaultLogFilePath()`

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -3,6 +3,8 @@ package tui
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"runtime"
 	"time"
 
 	"charm.land/glamour/v2"
@@ -212,6 +214,8 @@ func InitialModelWithConfig(
 		table:            newTableWithStyles(),
 		input:            newTextInput(),
 		incidentViewer:   newIncidentViewer(),
+		logViewer:        newLogViewer(),
+		logFilePath:      defaultLogFilePath(),
 		spinner:          s,
 		markdownRenderer: renderer,
 		apiInProgress:    false,
@@ -446,11 +450,27 @@ func newLogViewer() viewport.Model {
 	return vp
 }
 
-// defaultLogFilePath returns the default path for the srepd debug log file.
-func defaultLogFilePath() string {
+// logFilePathForOS returns the platform-appropriate log file path for the
+// given GOOS value. This is separated from defaultLogFilePath so it can be
+// tested with arbitrary OS values (runtime.GOOS is a compile-time constant).
+func logFilePathForOS(goos string) string {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return ""
 	}
-	return home + "/.config/srepd/debug.log"
+
+	switch goos {
+	case "linux":
+		return filepath.Join(home, ".config", "srepd", "debug.log")
+	case "darwin":
+		return filepath.Join(home, "Library", "Logs", "srepd.log")
+	default:
+		return ""
+	}
+}
+
+// defaultLogFilePath returns the default path for the srepd debug log file,
+// selected based on the current operating system.
+func defaultLogFilePath() string {
+	return logFilePathForOS(runtime.GOOS)
 }

--- a/pkg/tui/model_test.go
+++ b/pkg/tui/model_test.go
@@ -2,6 +2,9 @@ package tui
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -1623,4 +1626,75 @@ func TestWindowSizeMsgHandler_SmallWindow(t *testing.T) {
 				"viewport height must be positive to avoid panic in visibleLines")
 		})
 	}
+}
+
+func TestLogFilePathForOS(t *testing.T) {
+	home, err := os.UserHomeDir()
+	require.NoError(t, err, "should be able to get user home dir")
+
+	tests := []struct {
+		name     string
+		goos     string
+		expected string
+	}{
+		{
+			name:     "Linux returns XDG config path",
+			goos:     "linux",
+			expected: filepath.Join(home, ".config", "srepd", "debug.log"),
+		},
+		{
+			name:     "Darwin returns Library/Logs path",
+			goos:     "darwin",
+			expected: filepath.Join(home, "Library", "Logs", "srepd.log"),
+		},
+		{
+			name:     "Unsupported OS returns empty string",
+			goos:     "windows",
+			expected: "",
+		},
+		{
+			name:     "Empty OS string returns empty string",
+			goos:     "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := logFilePathForOS(tt.goos)
+			assert.Equal(t, tt.expected, result, "logFilePathForOS(%q) mismatch", tt.goos)
+		})
+	}
+}
+
+func TestDefaultLogFilePath(t *testing.T) {
+	t.Run("returns non-empty path on supported platforms", func(t *testing.T) {
+		// defaultLogFilePath() calls logFilePathForOS(runtime.GOOS)
+		// On Linux (CI) and macOS (dev), it should return a valid path
+		if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
+			t.Skip("test only runs on linux or darwin")
+		}
+
+		result := defaultLogFilePath()
+		assert.NotEmpty(t, result, "defaultLogFilePath should return a non-empty path on %s", runtime.GOOS)
+
+		// Verify it uses the correct OS-specific path segment
+		switch runtime.GOOS {
+		case "linux":
+			assert.Contains(t, result, filepath.Join(".config", "srepd", "debug.log"),
+				"Linux path should contain .config/srepd/debug.log")
+		case "darwin":
+			assert.Contains(t, result, filepath.Join("Library", "Logs", "srepd.log"),
+				"Darwin path should contain Library/Logs/srepd.log")
+		}
+	})
+}
+
+func TestDefaultLogFilePath_MatchesLogFilePathForOS(t *testing.T) {
+	t.Run("defaultLogFilePath is consistent with logFilePathForOS for current OS", func(t *testing.T) {
+		expected := logFilePathForOS(runtime.GOOS)
+		actual := defaultLogFilePath()
+		assert.Equal(t, expected, actual,
+			"defaultLogFilePath() should equal logFilePathForOS(runtime.GOOS)")
+	})
 }


### PR DESCRIPTION
## Summary
- `logFilePathForOS()` selects log path by OS: Linux `~/.config/srepd/debug.log`, macOS `~/Library/Logs/srepd.log`
- Fixed `InitialModelWithConfig` missing `logViewer`/`logFilePath` init
- 3 new tests

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)