### PR TITLE
Restructure log levels: meaningful INFO, demote noise to DEBUG

### DIFF
--- a/docs/plans/061-restructure-log-levels.md
+++ b/docs/plans/061-restructure-log-levels.md
@@ -1,0 +1,57 @@
+# Restructure log levels: demote noise to DEBUG, keep meaningful SRE actions as INFO
+
+## Context
+
+Current INFO level logs are noisy status updates (setStatus UI messages,
+cache operations, data fetching counts) that are not useful for compliance
+or operational review. INFO should be reserved for meaningful SRE actions:
+acknowledging, silencing, re-escalating, logging into clusters, adding notes,
+and querying Claude. Status updates and internal machinery belong at DEBUG.
+
+Related: PR #179 (logging cleanup), PR #197 (journal identifier).
+
+## Plan
+
+1. Demote `setStatus` in `model.go` from `log.Info` to `log.Debug` -- this
+   single change eliminates the majority of noise since all UI status
+   messages flow through `setStatus()`.
+
+2. Add new INFO-level logs for meaningful SRE actions that currently lack them:
+   - Incident acknowledged (in `tui.go` acknowledgedIncidentsMsg handler)
+   - Incident re-escalated (in `tui.go` reEscalatedIncidentsMsg handler)
+   - Incident silenced (in `tui.go` silenceSelectedIncidentMsg handler)
+   - Cluster login initiated (in `tui.go` loginMsg handler)
+   - Cluster login finished (in `tui.go` loginFinishedMsg handler)
+   - Note added to incident (in `tui.go` addedIncidentNoteMsg handler)
+   - Claude query initiated (in `claude.go` handleClaudePrompt)
+   - Claude response received (in `claude.go` handleClaudeResponse)
+   - Incident opened in browser (in `tui.go` openBrowserMsg handler)
+   - SOP opened in browser (in `tui.go` openSOPMsg handler)
+   - Incident resolved notification (in `tui.go` updatedIncidentListMsg handler)
+
+3. Demote launcher toolbox detection from INFO to DEBUG in `launcher.go` --
+   this is a startup diagnostic message, not an SRE action.
+
+4. Keep existing INFO logs in `cmd/root.go` unchanged -- they are startup/
+   config messages that are appropriate at INFO level.
+
+5. Keep the existing `silenceIncidents()` INFO log in `commands.go` -- it
+   logs a meaningful action (silence requested) with structured fields.
+
+## Files
+
+- `pkg/tui/model.go` -- demote `setStatus` log from INFO to DEBUG
+- `pkg/tui/tui.go` -- add INFO logs for ack, re-escalate, silence, login, note, resolve, browser, SOP
+- `pkg/tui/claude.go` -- add INFO logs for claude query and response
+- `pkg/launcher/launcher.go` -- demote toolbox detection from INFO to DEBUG
+- `pkg/tui/model_test.go` -- add tests verifying setStatus uses DEBUG
+- `pkg/tui/tui_test.go` -- add tests verifying INFO logs for SRE actions
+
+## Verification
+
+- `make test` passes
+- `make lint` passes
+- `grep -n 'log.Info' pkg/tui/model.go` returns zero results (all demoted)
+- `grep -n 'log.Info' pkg/tui/tui.go` shows only meaningful SRE action logs
+- `grep -n 'log.Info' pkg/launcher/launcher.go` returns zero results
+- `grep -n 'log.Info' pkg/tui/commands.go` shows only silenceIncidents action log

--- a/pkg/launcher/launcher.go
+++ b/pkg/launcher/launcher.go
@@ -70,7 +70,7 @@ func NewClusterLauncherWithToolbox(terminal string, clusterLoginCommand string, 
 	}
 
 	if inToolbox {
-		log.Info("Toolbox detected: terminal commands will be prefixed with flatpak-spawn --host")
+		log.Debug("Toolbox detected: terminal commands will be prefixed with flatpak-spawn --host")
 	}
 
 	err := launcher.validate()

--- a/pkg/tui/claude.go
+++ b/pkg/tui/claude.go
@@ -120,6 +120,11 @@ func (m model) handleClaudePrompt(msg claudePromptMsg, hasClaudeCode func() bool
 		return m, nil
 	}
 
+	incidentID := ""
+	if m.selectedIncident != nil {
+		incidentID = m.selectedIncident.ID
+	}
+	log.Info("claude query initiated", "incident_id", incidentID, "prompt", truncatePrompt(msg.prompt, 80))
 	m.setStatus(fmt.Sprintf("querying Claude: %s", truncatePrompt(msg.prompt, 40)))
 	m.claudeQuerying = true
 	m.apiInProgress = true
@@ -160,6 +165,7 @@ func (m model) handleClaudeResponse(msg claudeResponseMsg) (tea.Model, tea.Cmd) 
 	m.incidentViewer.SetContent(content)
 	m.incidentViewer.GotoTop()
 	m.viewingIncident = true
+	log.Info("claude response received")
 	m.setStatus("Claude response received")
 
 	return m, nil

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -389,7 +389,7 @@ func (m *model) syncSelectedIncidentToHighlightedRow() tea.Cmd {
 }
 
 func (m *model) setStatus(msg string) {
-	log.Info("setStatus", "status", msg)
+	log.Debug("setStatus", "status", msg)
 	m.status = msg
 }
 

--- a/pkg/tui/model_test.go
+++ b/pkg/tui/model_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 	"github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/log"
 	"github.com/clcollins/srepd/pkg/pd"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1657,6 +1659,167 @@ func TestNumberKeys_JumpToIndex(t *testing.T) {
 			if tt.activeSection == sectionNotes {
 				assert.Equal(t, tt.expectedNoteIdx, updatedModel.activeNoteIdx)
 			}
+		})
+	}
+}
+
+// captureLogOutput runs a function while capturing log output at the given level.
+// Returns the captured log output as a string.
+func captureLogOutput(level log.Level, fn func()) string {
+	var buf bytes.Buffer
+	logger := log.NewWithOptions(os.Stderr, log.Options{})
+	logger.SetOutput(&buf)
+	logger.SetLevel(level)
+
+	origLogger := log.Default()
+	log.SetDefault(logger)
+	defer log.SetDefault(origLogger)
+
+	fn()
+	return buf.String()
+}
+
+func TestSetStatusLogsAtDebugLevel(t *testing.T) {
+	t.Run("setStatus logs at DEBUG not INFO", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := log.NewWithOptions(os.Stderr, log.Options{})
+		logger.SetOutput(&buf)
+		logger.SetLevel(log.InfoLevel)
+
+		// Temporarily replace the default logger
+		origLogger := log.Default()
+		log.SetDefault(logger)
+		defer log.SetDefault(origLogger)
+
+		m := createTestModel()
+
+		// With INFO level, setStatus should NOT produce output (it logs at DEBUG)
+		buf.Reset()
+		m.setStatus("showing 1/1 incident...")
+		assert.Empty(t, buf.String(), "setStatus should not produce output at INFO level")
+		assert.Equal(t, "showing 1/1 incident...", m.status, "status should still be set on the model")
+
+		// With DEBUG level, setStatus SHOULD produce output
+		logger.SetLevel(log.DebugLevel)
+		buf.Reset()
+		m.setStatus("got incident Q123")
+		assert.NotEmpty(t, buf.String(), "setStatus should produce output at DEBUG level")
+		assert.Contains(t, buf.String(), "got incident Q123", "log output should contain the status message")
+	})
+}
+
+func TestSREActionsLogAtInfoLevel(t *testing.T) {
+	tests := []struct {
+		name          string
+		msg           tea.Msg
+		setupModel    func(*model)
+		expectedInLog string
+		description   string
+	}{
+		{
+			name: "acknowledged incidents logs at INFO",
+			msg: acknowledgedIncidentsMsg{
+				incidents: []pagerduty.Incident{
+					{APIObject: pagerduty.APIObject{ID: "Q123"}},
+				},
+				err: nil,
+			},
+			setupModel: func(m *model) {
+				m.config = &pd.Config{
+					CurrentUser: &pagerduty.User{
+						APIObject: pagerduty.APIObject{ID: "U123"},
+					},
+				}
+			},
+			expectedInLog: "acknowledged incident",
+			description:   "acknowledging an incident should produce an INFO log",
+		},
+		{
+			name: "re-escalated incidents logs at INFO",
+			msg:  reEscalatedIncidentsMsg([]pagerduty.Incident{{APIObject: pagerduty.APIObject{ID: "Q456"}}}),
+			setupModel: func(m *model) {
+				m.config = &pd.Config{
+					CurrentUser: &pagerduty.User{
+						APIObject: pagerduty.APIObject{ID: "U123"},
+					},
+				}
+			},
+			expectedInLog: "re-escalated incident",
+			description:   "re-escalating an incident should produce an INFO log",
+		},
+		{
+			name: "note added logs at INFO",
+			msg: addedIncidentNoteMsg{
+				note: &pagerduty.IncidentNote{ID: "N123", Content: "test note"},
+				err:  nil,
+			},
+			setupModel: func(m *model) {
+				m.selectedIncident = &pagerduty.Incident{
+					APIObject: pagerduty.APIObject{ID: "Q789"},
+				}
+			},
+			expectedInLog: "added note",
+			description:   "adding a note should produce an INFO log",
+		},
+		{
+			name: "login finished successfully logs at INFO",
+			msg:  loginFinishedMsg{err: nil},
+			setupModel: func(m *model) {
+				m.selectedIncident = &pagerduty.Incident{
+					APIObject: pagerduty.APIObject{ID: "Q111"},
+				}
+			},
+			expectedInLog: "login completed",
+			description:   "successful login should produce an INFO log",
+		},
+		{
+			name: "resolved incidents logs at INFO",
+			msg: updatedIncidentListMsg{
+				incidents: []pagerduty.Incident{
+					{APIObject: pagerduty.APIObject{ID: "Q456"}, Title: "Incident 2"},
+				},
+				err: nil,
+			},
+			setupModel: func(m *model) {
+				m.config = &pd.Config{
+					CurrentUser: &pagerduty.User{
+						APIObject: pagerduty.APIObject{ID: "U123"},
+					},
+				}
+				m.incidentList = []pagerduty.Incident{
+					{
+						APIObject:          pagerduty.APIObject{ID: "Q123"},
+						Title:              "Incident 1",
+						Service:            pagerduty.APIObject{Summary: "svc-1"},
+						LastStatusChangeAt: time.Now().Format(time.RFC3339),
+					},
+					{
+						APIObject:          pagerduty.APIObject{ID: "Q456"},
+						Title:              "Incident 2",
+						Service:            pagerduty.APIObject{Summary: "svc-2"},
+						LastStatusChangeAt: time.Now().Format(time.RFC3339),
+					},
+				}
+			},
+			expectedInLog: "incident resolved",
+			description:   "resolved incidents should produce an INFO log",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := createTestModel()
+			if tt.setupModel != nil {
+				tt.setupModel(&m)
+			}
+
+			output := captureLogOutput(log.InfoLevel, func() {
+				result, _ := m.Update(tt.msg)
+				m = result.(model)
+			})
+
+			assert.Contains(t, output, tt.expectedInLog,
+				"%s: expected INFO log containing %q", tt.description, tt.expectedInLog)
 		})
 	}
 }

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -385,6 +385,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		if len(resolvedIDs) > 0 {
+			for _, id := range resolvedIDs {
+				log.Info("incident resolved", "incident_id", id)
+			}
 			resolvedMsg := fmt.Sprintf("Resolved: %s", strings.Join(resolvedIDs, ", "))
 			cmds = append(cmds, m.flashNotification(resolvedMsg))
 		}
@@ -535,6 +538,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
+		log.Info("added note to incident", "incident_id", m.selectedIncident.ID)
+
 		// Flash notification for note addition
 		cmds = append(cmds, m.flashNotification(fmt.Sprintf("Added note to %s", m.selectedIncident.ID)))
 
@@ -585,6 +590,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			"%%INCIDENT_ID%%": m.selectedIncident.ID,
 		}
 
+		log.Info("login initiated", "incident_id", m.selectedIncident.ID, "cluster_id", cluster)
 		cmds = append(cmds, login(vars, m.launcher, m.selectedIncident, m.selectedIncidentAlerts, m.selectedIncidentNotes))
 
 	case clusterSelectedMsg:
@@ -601,12 +607,18 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			"%%INCIDENT_ID%%": m.selectedIncident.ID,
 		}
 
+		log.Info("login initiated", "incident_id", m.selectedIncident.ID, "cluster_id", cluster)
 		cmds = append(cmds, login(vars, m.launcher, m.selectedIncident, m.selectedIncidentAlerts, m.selectedIncidentNotes))
 
 	case loginFinishedMsg:
 		if msg.err != nil {
 			m.status = fmt.Sprintf("failed to login: %s", msg.err)
 			return m, func() tea.Msg { return errMsg{msg.err} }
+		}
+		if m.selectedIncident != nil {
+			log.Info("login completed", "incident_id", m.selectedIncident.ID)
+		} else {
+			log.Info("login completed")
 		}
 
 	case openBrowserMsg:
@@ -619,6 +631,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		log.Debug("openBrowserMsg", "incident", m.selectedIncident.ID, "title", m.selectedIncident.Title, "service", m.selectedIncident.Service.Summary)
+		log.Info("opened incident in browser", "incident_id", m.selectedIncident.ID)
 
 		c := []string{defaultBrowserOpenCommand}
 		return m, tea.Batch(m.flashNotification(fmt.Sprintf("Opened %s in browser", m.selectedIncident.ID)), openBrowserCmd(c, m.selectedIncident.HTMLURL))
@@ -638,6 +651,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		log.Debug("openSOPMsg", "incident", m.selectedIncident.ID, "link", link)
+		log.Info("opened SOP in browser", "incident_id", m.selectedIncident.ID, "link", link)
 
 		c := []string{defaultBrowserOpenCommand}
 		return m, tea.Batch(m.flashNotification(fmt.Sprintf("Opened SOP for %s", m.selectedIncident.ID)), openBrowserCmd(c, link))
@@ -788,6 +802,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, func() tea.Msg { return errMsg{msg.err} }
 		}
 		incidentIDs := strings.Join(getIDsFromIncidents(msg.incidents), " ")
+		log.Info("acknowledged incident", "incident_id", incidentIDs)
 
 		return m, tea.Batch(
 			m.flashNotification(fmt.Sprintf("Acknowledged %s", incidentIDs)),
@@ -824,6 +839,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case reEscalatedIncidentsMsg:
 		m.apiInProgress = false
 		incidentIDs := strings.Join(getIDsFromIncidents(msg), " ")
+		log.Info("re-escalated incident", "incident_id", incidentIDs)
 
 		return m, tea.Batch(
 			m.flashNotification(fmt.Sprintf("Re-escalated %s", incidentIDs)),
@@ -837,6 +853,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		incidentID := m.selectedIncident.ID
+		log.Info("silenced incident", "incident_id", incidentID)
 		policyKey := getEscalationPolicyKey(m.selectedIncident.Service.ID, m.config.EscalationPolicies)
 
 		m.apiInProgress = true


### PR DESCRIPTION
## Summary
- Demoted setStatus() from INFO to DEBUG (biggest noise reduction)
- Added 11 INFO logs for meaningful SRE actions: ack, silence, re-escalate, login, note, resolve, browser, SOP, claude query
- Demoted toolbox detection from INFO to DEBUG
- 2 new tests verifying log levels

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)