### PR TITLE
Improve alert tab rendering and fix dev fixture assignment (#248)

### DIFF
--- a/docs/plans/067-alert-tab-rendering.md
+++ b/docs/plans/067-alert-tab-rendering.md
@@ -1,0 +1,19 @@
+# Improve alert tab rendering
+
+## Context
+
+Alert tab displayed raw text for alert names and SOP links instead
+of markdown links. Dev fixture PDEV_INC_012 was assigned to the
+wrong user, hiding it from the default view.
+
+## Changes
+
+- Alert ID bold at top, alert name as [Name](url) link
+- SOP rendered as [filename.md](url) with filename extracted from path
+- Removed redundant Alert: bullet line
+- Reassigned PDEV_INC_012 to Dev User
+
+## Verification
+
+- make test-all passes
+- Dev mode and production render alerts with clickable links

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -604,6 +604,13 @@ var funcMap = template.FuncMap{
 	"add1": func(i int) int {
 		return i + 1
 	},
+	"SOPName": func(url string) string {
+		parts := strings.Split(url, "/")
+		if len(parts) > 0 {
+			return parts[len(parts)-1]
+		}
+		return url
+	},
 }
 
 func renderIncidentMarkdown(m *model, content string) (string, error) {
@@ -714,15 +721,15 @@ Acknowledged by: {{ range $i, $ack := .Acknowledged -}}
 {{- end -}}
 `
 
-// alertTabTemplate renders a single alert with navigation header (kept for backward compatibility)
 const alertTabTemplate = `
 ### Alert {{ add1 .Index }}/{{ .Total }}
 
-### {{ if .Alert.Name }}{{ .Alert.Name }}{{ else }}{{ .Alert.ID }}{{ end }} ({{ .Alert.Status }}){{ if .Alert.Severity }} [{{ .Alert.Severity }}]{{ end }}{{ if .Alert.AlertType }} ({{ .Alert.AlertType }}){{ end }}
+**{{ .Alert.ID }}** ({{ .Alert.Status }}){{ if .Alert.Severity }} [{{ .Alert.Severity }}]{{ end }}{{ if .Alert.AlertType }} ({{ .Alert.AlertType }}){{ end }}
+
+{{ if .Alert.HTMLURL }}{{ if .Alert.Name }}{{ ToLink .Alert.Name .Alert.HTMLURL }}{{ else }}{{ ToLink .Alert.ID .Alert.HTMLURL }}{{ end }}{{ else }}{{ if .Alert.Name }}{{ .Alert.Name }}{{ else }}{{ .Alert.ID }}{{ end }}{{ end }}
 
 * Cluster: {{ .Alert.Cluster }}
-* SOP: {{ if .Alert.Link }}{{ ToLink "SOP" .Alert.Link }}{{ else }}_none_{{ end }}
-* Alert: {{ ToLink .Alert.ID .Alert.HTMLURL }}
+* SOP: {{ if .Alert.Link }}{{ ToLink (SOPName .Alert.Link) .Alert.Link }}{{ else }}_none_{{ end }}
 * Service: {{ .Alert.Service }}
 * Created: {{ .Alert.Created }}
 `

--- a/pkg/tui/views_test.go
+++ b/pkg/tui/views_test.go
@@ -514,11 +514,11 @@ func TestIncidentTemplate_AlertRendersAsMarkdownLink(t *testing.T) {
 
 	result := renderAlertsTestContent(t, summary)
 
-	// SOP should render as a markdown link using ToLink
-	assert.Contains(t, result, "[SOP](https://example.com/sop/cluster-operator-down)")
+	// SOP should render as a markdown link with filename
+	assert.Contains(t, result, "[cluster-operator-down](https://example.com/sop/cluster-operator-down)")
 
-	// Alert PD URL should render as a markdown link using ToLink
-	assert.Contains(t, result, "[ALERT001](https://example.pagerduty.com/alerts/ALERT001)")
+	// Alert name should render as a markdown link to the alert
+	assert.Contains(t, result, "[ClusterOperatorDown](https://example.pagerduty.com/alerts/ALERT001)")
 }
 
 func TestIncidentTemplate_AlertRendersSOPNoneWhenMissing(t *testing.T) {
@@ -609,8 +609,8 @@ func TestIncidentTemplate_AlertNameAsHeading(t *testing.T) {
 
 	result := renderAlertsTestContent(t, summary)
 
-	// Alert name should appear as a ### heading
-	assert.Contains(t, result, "### KubePersistentVolumeFillingUp (triggered)")
+	// Alert name should appear as a link
+	assert.Contains(t, result, "[KubePersistentVolumeFillingUp](https://example.pagerduty.com/alerts/ALERT004)")
 }
 
 func TestIncidentTemplate_AlertWithEmptyName(t *testing.T) {
@@ -639,9 +639,8 @@ func TestIncidentTemplate_AlertWithEmptyName(t *testing.T) {
 
 	result := renderAlertsTestContent(t, summary)
 
-	// Should still render gracefully with empty fields
-	// The heading should fall back to the alert ID when Name is empty
-	assert.Contains(t, result, "### ALERT005 (triggered)")
+	// Should fall back to alert ID as link text when Name is empty
+	assert.Contains(t, result, "[ALERT005](https://example.pagerduty.com/alerts/ALERT005)")
 	// Should contain _none_ for SOP
 	assert.Contains(t, result, "_none_")
 }
@@ -775,10 +774,10 @@ func TestAlertTab_ShowsSingleAlert(t *testing.T) {
 		require.NoError(t, err)
 		result := buf.String()
 
-		assert.Contains(t, result, "KubePodNotReady")
+		assert.Contains(t, result, "[KubePodNotReady](https://example.pagerduty.com/alerts/ALERT020)")
 		assert.Contains(t, result, "my-cluster-id")
-		assert.Contains(t, result, "1/5")         // 1-based display of index 0 out of 5
-		assert.NotContains(t, result, "ALERT999") // Does not contain other alerts
+		assert.Contains(t, result, "1/5")
+		assert.NotContains(t, result, "ALERT999")
 	})
 }
 
@@ -973,14 +972,12 @@ func TestIncidentTemplate_SpacingBetweenAlerts(t *testing.T) {
 
 	result := renderAlertsTestContent(t, summary)
 
-	// Both alerts should be present
-	assert.Contains(t, result, "### FirstAlert (triggered)")
-	assert.Contains(t, result, "### SecondAlert (triggered)")
+	// Both alerts should be present as links
+	assert.Contains(t, result, "[FirstAlert]")
+	assert.Contains(t, result, "[SecondAlert]")
 
-	// There should be a horizontal rule (---) between alerts for clear visual separation
+	// There should be a horizontal rule (---) between alerts
 	assert.Contains(t, result, "---")
-	// The separator should appear between the two alerts, with the ---
-	// separating the first alert's details from the second alert's heading
 	assert.Contains(t, result, "* Created: 2025-01-01\n\n---\n")
 	assert.Contains(t, result, "---\n\n### Alert 2/2")
 }
@@ -1096,8 +1093,8 @@ func TestRenderTabContent_AlertsTab(t *testing.T) {
 
 		content, err := m.renderTabContent()
 		assert.NoError(t, err)
-		assert.Contains(t, content, "A1")
-		assert.Contains(t, content, "A2")
+		assert.Contains(t, content, "**A1**")
+		assert.Contains(t, content, "**A2**")
 		assert.Contains(t, content, "1/2")
 		assert.Contains(t, content, "2/2")
 	})

--- a/testdata/fixtures/incidents.json
+++ b/testdata/fixtures/incidents.json
@@ -420,9 +420,9 @@
       {
         "at": "2026-05-28T03:00:00Z",
         "assignee": {
-          "id": "PDEV_USER_003",
+          "id": "PDEV_USER_001",
           "type": "user_reference",
-          "summary": "Bob Oncall"
+          "summary": "Dev User"
         }
       }
     ],


### PR DESCRIPTION
## Summary
- Alert tab: bold alert ID, alert name as clickable [Name](url) link, SOP as [filename.md](url)
- Removed redundant Alert: bullet (moved to link at top)
- Reassigned PDEV_INC_012 fixture to Dev User for default view visibility

## Test plan
- [x] All tests pass locally
- [ ] CI

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)