### PR TITLE
Fix make release: serialize builds and support release notes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,11 +206,11 @@ ensure-goreleaser: ## Ensure goreleaser is installed
 	@which goreleaser >/dev/null 2>&1 || go install github.com/goreleaser/goreleaser/v2@${GORELEASER_VERSION}
 
 .PHONY: release
-release: ensure-goreleaser ## Create a release using goreleaser
+release: ensure-goreleaser ## Create a release using goreleaser (RELEASE_NOTES=/path/to/notes.md optional)
 	@echo "Creating a release..."
 	GITHUB_TOKEN=$$(jq -r .goreleaser_token ~/.config/goreleaser/goreleaser_token) && \
 	export GITHUB_TOKEN && \
-	goreleaser release --clean
+	goreleaser release --clean --parallelism 1 $(if $(RELEASE_NOTES),--release-notes $(RELEASE_NOTES),)
 
 .PHONY: clean
 clean: ## Clean up build artifacts

--- a/docs/plans/068-fix-make-release.md
+++ b/docs/plans/068-fix-make-release.md
@@ -1,0 +1,17 @@
+# Fix make release target
+
+## Context
+
+goreleaser builds 4 platform binaries in parallel, which exhausts
+process limits in the Fedora Toolbox container. Also, there was no
+way to pass custom release notes to the release target.
+
+## Changes
+
+- Add --parallelism 1 to goreleaser release command
+- Add optional RELEASE_NOTES variable for custom changelog
+
+## Verification
+
+- make release builds sequentially without resource exhaustion
+- make release RELEASE_NOTES=/path/to/notes.md passes notes through


### PR DESCRIPTION
## Summary
- Added `--parallelism 1` to goreleaser in `make release` to prevent resource exhaustion in Toolbox
- Added optional `RELEASE_NOTES` variable: `make release RELEASE_NOTES=/path/to/notes.md`

## Test plan
- [x] `make release` builds sequentially
- [x] Used successfully for v1.0.0 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)