### PR TITLE
Demote missing optional config key log from WARN to DEBUG

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ SREPD reads `~/.config/srepd/srepd.yaml` and supports `SREPD_` environment varia
 | `cluster_login_command` | `string` | `ocm backplane login %%CLUSTER_ID%%` | Cluster login command |
 | `ignoredusers` | `[]string` | (none) | PagerDuty user IDs to exclude |
 | `toolbox_mode` | `string` | `auto` | Toolbox detection: `auto`, `true`, or `false` |
+| `chord_prefix` | `string` | `ctrl+x` | Prefix key for chord commands |
 
 ### Example
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -192,7 +192,7 @@ func validateConfig() error {
 	for k := range optionalKeys {
 		_, ok := settings[k]
 		if !ok {
-			log.Warn("cmd.validateConfig()", "msg", "missing optional key", "key", k, "default_value", defaultOptionalKeys[k])
+			log.Debug("cmd.validateConfig()", "msg", "missing optional key", "key", k, "default_value", defaultOptionalKeys[k])
 			viper.Set(k, defaultOptionalKeys[k])
 		}
 	}

--- a/docs/plans/070-config-optional-key-log-level.md
+++ b/docs/plans/070-config-optional-key-log-level.md
@@ -1,0 +1,6 @@
+# 070: Change optional config key log level from WARN to DEBUG
+
+Optional config keys (toolbox_mode, chord_prefix, etc.) log at WARN on startup when absent.
+These are expected to be missing for most users and should not produce visible warnings.
+Change the log.Warn call in cmd/config.go validateConfig() to log.Debug.
+No behavioral change; only reduces default log noise.


### PR DESCRIPTION
## Summary
- Changed `log.Warn` to `log.Debug` for "missing optional key" messages in `cmd/config.go`
- Optional keys like `toolbox_mode` and `chord_prefix` no longer produce WARN noise at startup

## Test plan
- [x] All tests pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)