### PR TITLE
Add incident merge, alert namespace/description display

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Press `h` to toggle the help overlay inside srepd.
 | `ctrl+r` | Toggle auto-refresh | `u` | Toggle urgency filter |
 | `ctrl+a` | Toggle auto-acknowledge | `ctrl+l` | View debug log |
 | `ctrl+q`/`ctrl+c` | Quit | `1`-`9` | Select cluster |
-| `i`/`:` | Ask Claude | | |
+| `i`/`:` | Ask Claude | `m` | Merge incident |
 | `ctrl+x` + key | Chord commands | `ctrl+x ?` | Show chord help |
 | `Tab`/`Shift+Tab` | Switch tabs (incident view) | `↑`/`↓` | Scroll within tab |
 

--- a/docs/plans/072-merge-incidents.md
+++ b/docs/plans/072-merge-incidents.md
@@ -1,0 +1,21 @@
+# Merge incident into another incident
+
+## Context
+
+SREs need to merge duplicate PagerDuty incidents from the TUI.
+ctrl+m opens a scrollable incident selection view, user picks
+a target, and the source is merged into it via PD API.
+
+## Changes
+
+- Add MergeIncidentsWithContext to PD client interface, mock, dev, ratelimit
+- Add merge mode with scrollable table (same format as main view)
+- ctrl+m triggers merge, t toggles team/individual, Enter confirms
+- Confirmation prompt before dispatching merge
+- Flash notification and INFO log on completion
+
+## Verification
+
+- make test-all passes
+- Dev mode: ctrl+m shows merge target list, Enter/Escape work
+- Real PD: merge completes and incident disappears

--- a/pkg/alert/normalize.go
+++ b/pkg/alert/normalize.go
@@ -28,9 +28,9 @@ type NormalizedAlert struct {
 	DashboardLink string   // Grafana/monitoring dashboard URL
 	ClusterName   string   // Human-readable cluster name or URL
 	Region        string   // AWS region (e.g., "us-east-1")
-	Namespace   string // Kubernetes namespace
-	Description string // Alert description from firing field
-	Condition   string // Failure condition (e.g., "ProvisionFailed")
+	Namespace     string   // Kubernetes namespace
+	Description   string   // Alert description from firing field
+	Condition     string   // Failure condition (e.g., "ProvisionFailed")
 	Reason        string   // Failure reason (e.g., "BootstrapFailed")
 	Tags          []string // SRE-added title tags: ["SL Sent", "OHSS-54318", ...]
 	FiringCount   int      // Number of firing alerts

--- a/pkg/alert/normalize.go
+++ b/pkg/alert/normalize.go
@@ -28,8 +28,9 @@ type NormalizedAlert struct {
 	DashboardLink string   // Grafana/monitoring dashboard URL
 	ClusterName   string   // Human-readable cluster name or URL
 	Region        string   // AWS region (e.g., "us-east-1")
-	Namespace     string   // Kubernetes namespace
-	Condition     string   // Failure condition (e.g., "ProvisionFailed")
+	Namespace   string // Kubernetes namespace
+	Description string // Alert description from firing field
+	Condition   string // Failure condition (e.g., "ProvisionFailed")
 	Reason        string   // Failure reason (e.g., "BootstrapFailed")
 	Tags          []string // SRE-added title tags: ["SL Sent", "OHSS-54318", ...]
 	FiringCount   int      // Number of firing alerts

--- a/pkg/alert/normalize_test.go
+++ b/pkg/alert/normalize_test.go
@@ -477,3 +477,41 @@ func TestNormalizeAlert_OSDHive_SeverityNormalization(t *testing.T) {
 		})
 	}
 }
+
+func TestRHOBSHCP_ExtractsNamespaceAndDescription(t *testing.T) {
+	alert := pagerduty.IncidentAlert{
+		Service: pagerduty.APIObject{Summary: "rhobs-hcp-prod-critical-us-west-2"},
+		Body: map[string]interface{}{
+			"details": map[string]interface{}{
+				"alert_name": "ClusterOperatorDown",
+				"cluster_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+				"firing":     "\n\n  - alertname: ClusterOperatorDown\n    cluster_id: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\n    namespace: ocm-production-aaaabbbbccccddddeeee-test-us-east-2\n    description: The ingress operator is unavailable for aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.\n\n",
+				"link":       "https://github.com/openshift/ops-sop/blob/master/hypershift/alerts/ClusterOperatorDown.md",
+			},
+		},
+	}
+
+	result := NormalizeAlert("rhobs-hcp-prod-critical-us-west-2", "[HCP] [RHOBS] (Critical) ClusterOperatorDown for HCP: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", alert)
+
+	assert.Equal(t, "ocm-production-aaaabbbbccccddddeeee-test-us-east-2", result.Namespace)
+	assert.Equal(t, "The ingress operator is unavailable for aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.", result.Description)
+}
+
+func TestOSDHive_ExtractsNamespaceAndMessage(t *testing.T) {
+	alert := pagerduty.IncidentAlert{
+		Service: pagerduty.APIObject{Summary: "osd-testcluster.p1.openshiftapps.com-hive-cluster"},
+		Body: map[string]interface{}{
+			"details": map[string]interface{}{
+				"alert_name": "PruningCronjobErrorSRE",
+				"cluster_id": "11111111-2222-3333-4444-555555555555",
+				"firing":     "Labels:\n - alertname = PruningCronjobErrorSRE\n - namespace = openshift-sre-pruning\n - severity = critical\nAnnotations:\n - message = SRE Pruning Job openshift-sre-pruning/builds-pruner is taking more than thirty minutes to complete.\n - summary = SRE pruning cronjob error\nSource: https://console.redhat.com/monitoring",
+				"link":       "https://github.com/openshift/ops-sop/blob/master/v4/alerts/PruningCronjobErrorSRE.md",
+			},
+		},
+	}
+
+	result := NormalizeAlert("osd-testcluster.p1.openshiftapps.com-hive-cluster", "PruningCronjobErrorSRE CRITICAL (1)", alert)
+
+	assert.Equal(t, "openshift-sre-pruning", result.Namespace)
+	assert.Equal(t, "SRE Pruning Job openshift-sre-pruning/builds-pruner is taking more than thirty minutes to complete.", result.Description)
+}

--- a/pkg/alert/types.go
+++ b/pkg/alert/types.go
@@ -91,12 +91,17 @@ func parseOSDHive(n *NormalizedAlert, title string, alert pagerduty.IncidentAler
 		}
 	}
 
-	// Extract namespace from firing field if available
+	// Extract namespace and description from firing field if available
 	firingText := getDetail("firing", alert)
 	if firingText != "" {
 		firingFields := ParseFiring(firingText)
 		if ns, ok := firingFields["namespace"]; ok {
 			n.Namespace = ns
+		}
+		if desc, ok := firingFields["description"]; ok {
+			n.Description = desc
+		} else if msg, ok := firingFields["message"]; ok {
+			n.Description = msg
 		}
 	}
 }
@@ -204,12 +209,15 @@ func parseRHOBSHCP(n *NormalizedAlert, title string, alert pagerduty.IncidentAle
 	// Extract region from service name: rhobs-hcp-{env}-{severity?}-{region}
 	n.Region = extractRHOBSRegion(n.ServiceName)
 
-	// Extract namespace from firing if available
+	// Extract namespace and description from firing if available
 	firingText := getDetail("firing", alert)
 	if firingText != "" {
 		firingFields := ParseFiring(firingText)
 		if ns, ok := firingFields["namespace"]; ok {
 			n.Namespace = ns
+		}
+		if desc, ok := firingFields["description"]; ok {
+			n.Description = desc
 		}
 	}
 }

--- a/pkg/pd/dev.go
+++ b/pkg/pd/dev.go
@@ -606,6 +606,24 @@ func (d *DevPagerDutyClient) ManageIncidentsWithContext(_ context.Context, _ str
 	}, nil
 }
 
+func (d *DevPagerDutyClient) MergeIncidentsWithContext(_ context.Context, _ string, targetID string, sources []pagerduty.MergeIncidentsOptions) (*pagerduty.Incident, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	target, ok := d.incidents[targetID]
+	if !ok {
+		return nil, fmt.Errorf("DevPagerDutyClient: target incident %q not found", targetID)
+	}
+
+	for _, src := range sources {
+		delete(d.incidents, src.ID)
+		log.Debug("DevPagerDutyClient.MergeIncidents", "merged", src.ID, "into", targetID)
+	}
+
+	copy := *target
+	return &copy, nil
+}
+
 // NewDevConfig creates a pd.Config using the DevPagerDutyClient, bypassing live PD API calls.
 // This is used when --dev mode is active.
 func NewDevConfig(fixturesDir string) (*Config, error) {

--- a/pkg/pd/mock.go
+++ b/pkg/pd/mock.go
@@ -239,3 +239,13 @@ func (m *MockPagerDutyClient) ListOnCallsWithContext(ctx context.Context, opts p
 		OnCalls: []pagerduty.OnCall{},
 	}, nil
 }
+
+func (m *MockPagerDutyClient) MergeIncidentsWithContext(ctx context.Context, from string, id string, o []pagerduty.MergeIncidentsOptions) (*pagerduty.Incident, error) {
+	m.recordCall("MergeIncidentsWithContext")
+	if id == "err" {
+		return nil, ErrMockError
+	}
+	return &pagerduty.Incident{
+		APIObject: pagerduty.APIObject{ID: id},
+	}, nil
+}

--- a/pkg/pd/pd.go
+++ b/pkg/pd/pd.go
@@ -38,6 +38,7 @@ type PagerDutyClientInterface interface {
 	ListIncidentNotesWithContext(ctx context.Context, id string) ([]pagerduty.IncidentNote, error)
 	ListOnCallsWithContext(ctx context.Context, opts pagerduty.ListOnCallOptions) (*pagerduty.ListOnCallsResponse, error)
 	ManageIncidentsWithContext(ctx context.Context, email string, opts []pagerduty.ManageIncidentsOptions) (*pagerduty.ListIncidentsResponse, error)
+	MergeIncidentsWithContext(ctx context.Context, from string, id string, o []pagerduty.MergeIncidentsOptions) (*pagerduty.Incident, error)
 }
 
 // PagerDutyClient implements PagerDutyClientInterface and is used by the pd package to make calls to PagerDuty

--- a/pkg/pd/ratelimit.go
+++ b/pkg/pd/ratelimit.go
@@ -251,3 +251,13 @@ func (c *RateLimitedClient) ManageIncidentsWithContext(ctx context.Context, emai
 	})
 	return result, err
 }
+
+func (c *RateLimitedClient) MergeIncidentsWithContext(ctx context.Context, from string, id string, o []pagerduty.MergeIncidentsOptions) (*pagerduty.Incident, error) {
+	var result *pagerduty.Incident
+	err := c.withRetry(ctx, func() error {
+		var innerErr error
+		result, innerErr = c.inner.MergeIncidentsWithContext(ctx, from, id, o)
+		return innerErr
+	})
+	return result, err
+}

--- a/pkg/tui/keymap.go
+++ b/pkg/tui/keymap.go
@@ -17,7 +17,7 @@ func (k keymap) FullHelp() [][]key.Binding {
 		// Column 1: Help at top, navigation
 		{k.Help, k.Up, k.Down, k.Top, k.Bottom, k.Enter, k.Back},
 		// Column 2: Primary incident actions
-		{k.Ack, k.Note, k.Login, k.Open, k.SOP, k.UnAck, k.Silence},
+		{k.Ack, k.Note, k.Login, k.Open, k.SOP, k.UnAck, k.Silence, k.Merge},
 		// Column 3: Settings & toggles, Quit at bottom
 		{k.Team, k.Refresh, k.AutoRefresh, k.AutoAck, k.Urgency, k.ViewLog, k.Quit},
 		// Column 4: Tab navigation (incident viewer)
@@ -56,6 +56,7 @@ type keymap struct {
 	Open        key.Binding
 	SOP         key.Binding
 	ViewLog     key.Binding
+	Merge       key.Binding
 	TabNext     key.Binding
 	TabPrev     key.Binding
 }
@@ -181,6 +182,10 @@ var defaultKeyMap = keymap{
 	ViewLog: key.NewBinding(
 		key.WithKeys("ctrl+l"),
 		key.WithHelp("ctrl+l", "view debug log"),
+	),
+	Merge: key.NewBinding(
+		key.WithKeys("m"),
+		key.WithHelp("m", "merge incident"),
 	),
 	TabNext: key.NewBinding(
 		key.WithKeys("tab"),

--- a/pkg/tui/merge.go
+++ b/pkg/tui/merge.go
@@ -78,7 +78,7 @@ func switchMergeFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case key.Matches(msg, defaultKeyMap.Enter):
 			selectedRow := m.mergeTable.SelectedRow()
-			if selectedRow == nil || len(selectedRow) < 2 {
+			if len(selectedRow) < 2 {
 				m.setStatus("no incident selected")
 				return m, nil
 			}

--- a/pkg/tui/merge.go
+++ b/pkg/tui/merge.go
@@ -1,0 +1,103 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/PagerDuty/go-pagerduty"
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/table"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/clcollins/srepd/pkg/pd"
+)
+
+type mergeIncidentMsg struct{}
+
+type mergedIncidentMsg struct {
+	sourceID string
+	targetID string
+	err      error
+}
+
+func mergeIncidents(p *pd.Config, sourceID, targetID string) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_, err := p.Client.MergeIncidentsWithContext(ctx,
+			p.CurrentUser.Email, targetID,
+			[]pagerduty.MergeIncidentsOptions{{ID: sourceID, Type: "incident_reference"}})
+		return mergedIncidentMsg{sourceID, targetID, err}
+	}
+}
+
+func filterMergeCandidates(incidents []pagerduty.Incident, excludeID string) []pagerduty.Incident {
+	var result []pagerduty.Incident
+	for _, inc := range incidents {
+		if inc.ID != excludeID {
+			result = append(result, inc)
+		}
+	}
+	return result
+}
+
+func (m *model) rebuildMergeTable() {
+	candidates := filterMergeCandidates(m.incidentList, m.mergeSourceIncident.ID)
+
+	var rows []table.Row
+	for _, i := range candidates {
+		state := stateShorthand(i, m.config.CurrentUser.ID)
+		if m.mergeTeamMode || AssignedToUser(i, m.config.CurrentUser.ID) {
+			rows = append(rows, table.Row{state, i.ID, i.Title, i.Service.Summary})
+		}
+	}
+
+	m.mergeTable.SetRows(rows)
+	m.mergeTable.SetColumns(m.table.Columns())
+	m.mergeTable.SetHeight(m.table.Height())
+	m.mergeTable.Focus()
+}
+
+func switchMergeFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch {
+		case key.Matches(msg, defaultKeyMap.Quit):
+			return m, tea.Quit
+
+		case key.Matches(msg, defaultKeyMap.Back):
+			m.mergeMode = false
+			m.mergeSourceIncident = nil
+			m.table.Focus()
+			return m, nil
+
+		case key.Matches(msg, defaultKeyMap.Team):
+			m.mergeTeamMode = !m.mergeTeamMode
+			m.rebuildMergeTable()
+			return m, nil
+
+		case key.Matches(msg, defaultKeyMap.Enter):
+			selectedRow := m.mergeTable.SelectedRow()
+			if selectedRow == nil || len(selectedRow) < 2 {
+				m.setStatus("no incident selected")
+				return m, nil
+			}
+			targetID := selectedRow[1]
+			sourceID := m.mergeSourceIncident.ID
+			m.pendingConfirmation = &confirmActionState{
+				prompt: fmt.Sprintf("Merge %s into %s? [y/n]", sourceID, targetID),
+				action: func() tea.Msg {
+					return mergeIncidentMsg{}
+				},
+			}
+			m.mergeTargetID = targetID
+			return m, nil
+
+		default:
+			var cmd tea.Cmd
+			m.mergeTable, cmd = m.mergeTable.Update(msg)
+			return m, cmd
+		}
+	}
+	return m, nil
+}

--- a/pkg/tui/merge_test.go
+++ b/pkg/tui/merge_test.go
@@ -1,0 +1,142 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/PagerDuty/go-pagerduty"
+	"github.com/charmbracelet/bubbles/table"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/clcollins/srepd/pkg/pd"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMergeIncidents_Success(t *testing.T) {
+	t.Run("mergeIncidents returns mergedIncidentMsg on success", func(t *testing.T) {
+		mockClient := &pd.MockPagerDutyClient{}
+		config := &pd.Config{
+			Client:      mockClient,
+			CurrentUser: &pagerduty.User{Email: "test@example.com"},
+		}
+
+		cmd := mergeIncidents(config, "SOURCE_001", "TARGET_001")
+		msg := cmd()
+
+		merged, ok := msg.(mergedIncidentMsg)
+		assert.True(t, ok, "should return mergedIncidentMsg")
+		assert.Equal(t, "SOURCE_001", merged.sourceID)
+		assert.Equal(t, "TARGET_001", merged.targetID)
+		assert.NoError(t, merged.err)
+	})
+}
+
+func TestMergeIncidents_Error(t *testing.T) {
+	t.Run("mergeIncidents returns error for invalid target", func(t *testing.T) {
+		mockClient := &pd.MockPagerDutyClient{}
+		config := &pd.Config{
+			Client:      mockClient,
+			CurrentUser: &pagerduty.User{Email: "test@example.com"},
+		}
+
+		cmd := mergeIncidents(config, "SOURCE_001", "err")
+		msg := cmd()
+
+		merged, ok := msg.(mergedIncidentMsg)
+		assert.True(t, ok, "should return mergedIncidentMsg")
+		assert.Error(t, merged.err)
+	})
+}
+
+func TestMergeMode_EnterFromMainView(t *testing.T) {
+	t.Run("ctrl+m enters merge mode with source incident", func(t *testing.T) {
+		m := createTestModel()
+		m.selectedIncident = &pagerduty.Incident{
+			APIObject: pagerduty.APIObject{ID: "Q123"},
+			Title:     "Source Incident",
+		}
+		m.incidentList = []pagerduty.Incident{
+			{APIObject: pagerduty.APIObject{ID: "Q123"}, Title: "Source"},
+			{APIObject: pagerduty.APIObject{ID: "Q456"}, Title: "Target"},
+		}
+		m.config = &pd.Config{
+			Client: &pd.MockPagerDutyClient{},
+			CurrentUser: &pagerduty.User{
+				APIObject: pagerduty.APIObject{ID: "USER1"},
+				Email:     "test@example.com",
+			},
+		}
+		cols := []table.Column{
+			{Title: "", Width: 1},
+			{Title: "ID", Width: 16},
+			{Title: "Title", Width: 40},
+			{Title: "Service", Width: 30},
+		}
+		rows := []table.Row{
+			{"•", "Q123", "Source", "svc"},
+			{"•", "Q456", "Target", "svc"},
+		}
+		m.table = table.New(table.WithColumns(cols), table.WithRows(rows), table.WithFocused(true))
+
+		keyMsg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'m'}}
+		result, _ := m.Update(keyMsg)
+		updated := result.(model)
+
+		assert.True(t, updated.mergeMode, "should enter merge mode")
+		assert.Equal(t, "Q123", updated.mergeSourceIncident.ID, "source incident should be set")
+	})
+}
+
+func TestMergeMode_EscapeCancels(t *testing.T) {
+	t.Run("escape exits merge mode", func(t *testing.T) {
+		m := createTestModel()
+		m.mergeMode = true
+		m.mergeSourceIncident = &pagerduty.Incident{
+			APIObject: pagerduty.APIObject{ID: "Q123"},
+		}
+
+		keyMsg := tea.KeyMsg{Type: tea.KeyEscape}
+		result, _ := m.Update(keyMsg)
+		updated := result.(model)
+
+		assert.False(t, updated.mergeMode, "should exit merge mode")
+		assert.Nil(t, updated.mergeSourceIncident, "source should be cleared")
+	})
+}
+
+func TestMergeMode_ExcludesSourceFromList(t *testing.T) {
+	t.Run("merge target list excludes source incident", func(t *testing.T) {
+		incidents := []pagerduty.Incident{
+			{APIObject: pagerduty.APIObject{ID: "Q123"}, Title: "Source"},
+			{APIObject: pagerduty.APIObject{ID: "Q456"}, Title: "Target 1"},
+			{APIObject: pagerduty.APIObject{ID: "Q789"}, Title: "Target 2"},
+		}
+
+		filtered := filterMergeCandidates(incidents, "Q123")
+
+		assert.Len(t, filtered, 2)
+		for _, inc := range filtered {
+			assert.NotEqual(t, "Q123", inc.ID, "source should be excluded")
+		}
+	})
+}
+
+func TestMergedIncidentMsg_HandledInModel(t *testing.T) {
+	t.Run("mergedIncidentMsg produces flash notification", func(t *testing.T) {
+		m := createTestModel()
+		m.config = &pd.Config{
+			Client:      &pd.MockPagerDutyClient{},
+			CurrentUser: &pagerduty.User{APIObject: pagerduty.APIObject{ID: "USER1"}},
+		}
+
+		msg := mergedIncidentMsg{
+			sourceID: "Q123",
+			targetID: "Q456",
+			err:      nil,
+		}
+
+		result, cmd := m.Update(msg)
+		updated := result.(model)
+
+		assert.Contains(t, updated.status, "Merged Q123 into Q456")
+		assert.NotNil(t, cmd, "should return commands for flash and refresh")
+	})
+}

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -117,6 +117,13 @@ type model struct {
 	// Incident viewer tab state
 	activeTab int // 0=details, 1=alerts, 2=notes
 
+	// Merge mode state
+	mergeMode           bool
+	mergeSourceIncident *pagerduty.Incident
+	mergeTargetID       string
+	mergeTable          table.Model
+	mergeTeamMode       bool
+
 	// Auto-update state
 	devMode          bool
 	updateAvailable  bool

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -208,6 +208,9 @@ func (m model) keyMsgHandler(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case m.err != nil:
 		return switchErrorFocusMode(m, msg)
 
+	case m.mergeMode:
+		return switchMergeFocusMode(m, msg)
+
 	case m.viewingLog:
 		return switchLogFocusMode(m, msg)
 
@@ -463,6 +466,23 @@ func switchTableFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			return m, parseTemplateForNote(m.selectedIncident)
+
+		case key.Matches(msg, defaultKeyMap.Merge):
+			if m.table.SelectedRow() == nil {
+				m.setStatus("no incident highlighted")
+				return m, nil
+			}
+			m.syncSelectedIncidentToHighlightedRow()
+			if m.selectedIncident == nil {
+				m.setStatus("no incident selected")
+				return m, nil
+			}
+			m.mergeMode = true
+			m.mergeSourceIncident = m.selectedIncident
+			m.mergeTeamMode = m.teamMode
+			m.mergeTable = newTableWithStyles()
+			m.rebuildMergeTable()
+			return m, nil
 
 		case key.Matches(msg, defaultKeyMap.Login):
 			// Login uses doIfIncidentSelected() instead of the standard sync pattern

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -923,6 +923,34 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case claudeResponseMsg:
 		return m.handleClaudeResponse(msg)
 
+	case mergeIncidentMsg:
+		if m.mergeSourceIncident == nil || m.mergeTargetID == "" {
+			m.setStatus("merge failed - missing source or target")
+			return m, nil
+		}
+		sourceID := m.mergeSourceIncident.ID
+		targetID := m.mergeTargetID
+		m.mergeMode = false
+		m.mergeSourceIncident = nil
+		m.mergeTargetID = ""
+		m.table.Focus()
+		m.apiInProgress = true
+		return m, tea.Batch(m.spinner.Tick, mergeIncidents(m.config, sourceID, targetID))
+
+	case mergedIncidentMsg:
+		m.apiInProgress = false
+		if msg.err != nil {
+			return m, func() tea.Msg { return errMsg{msg.err} }
+		}
+		log.Info("merged incident",
+			"user_id", m.config.CurrentUser.ID,
+			"source", msg.sourceID,
+			"target", msg.targetID)
+		return m, tea.Batch(
+			m.flashNotification(fmt.Sprintf("Merged %s into %s", msg.sourceID, msg.targetID)),
+			func() tea.Msg { return updateIncidentListMsg("sender: mergedIncidentMsg") },
+		)
+
 	case updateAvailableMsg:
 		m.updateAvailable = true
 		m.updateVersion = msg.latest

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -146,7 +146,7 @@ func (m model) View() string {
 		s.WriteString(tableContainerStyle.Render(m.logViewer.View()))
 
 	case m.mergeMode:
-		s.WriteString(fmt.Sprintf("  Select incident to merge %s into (Enter=select, Esc=cancel, t=toggle team):\n", m.mergeSourceIncident.ID))
+		fmt.Fprintf(&s, "  Select incident to merge %s into (Enter=select, Esc=cancel, t=toggle team):\n", m.mergeSourceIncident.ID)
 		s.WriteString(tableContainerStyle.Render(m.mergeTable.View()))
 
 	case m.viewingIncident:

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -501,18 +501,20 @@ func summarizeNotes(n []pagerduty.IncidentNote) []noteSummary {
 }
 
 type alertSummary struct {
-	ID        string
-	Name      string
-	Link      string
-	HTMLURL   string
-	Service   string
-	Created   string
-	Status    string
-	Incident  string
-	Cluster   string
-	Severity  string
-	Tags      []string
-	AlertType string
+	ID          string
+	Name        string
+	Link        string
+	HTMLURL     string
+	Service     string
+	Created     string
+	Status      string
+	Incident    string
+	Cluster     string
+	Severity    string
+	Tags        []string
+	AlertType   string
+	Namespace   string
+	Description string
 }
 
 func summarizeAlerts(a []pagerduty.IncidentAlert) []alertSummary {
@@ -543,18 +545,20 @@ func summarizeAlerts(a []pagerduty.IncidentAlert) []alertSummary {
 		}
 
 		s = append(s, alertSummary{
-			ID:        alt.ID,
-			Name:      name,
-			Link:      link,
-			Cluster:   cluster,
-			HTMLURL:   alt.HTMLURL,
-			Service:   alt.Service.Summary,
-			Created:   alt.CreatedAt,
-			Status:    alt.Status,
-			Incident:  alt.Incident.ID,
-			Severity:  normalized.Severity,
-			Tags:      normalized.Tags,
-			AlertType: normalized.AlertType,
+			ID:          alt.ID,
+			Name:        name,
+			Link:        link,
+			Cluster:     cluster,
+			HTMLURL:     alt.HTMLURL,
+			Service:     alt.Service.Summary,
+			Created:     alt.CreatedAt,
+			Status:      alt.Status,
+			Incident:    alt.Incident.ID,
+			Severity:    normalized.Severity,
+			Tags:        normalized.Tags,
+			AlertType:   normalized.AlertType,
+			Namespace:   normalized.Namespace,
+			Description: normalized.Description,
 		})
 
 	}
@@ -755,9 +759,14 @@ const alertTabTemplate = `
 {{ if .Alert.HTMLURL }}{{ if .Alert.Name }}{{ ToLink .Alert.Name .Alert.HTMLURL }}{{ else }}{{ ToLink .Alert.ID .Alert.HTMLURL }}{{ end }}{{ else }}{{ if .Alert.Name }}{{ .Alert.Name }}{{ else }}{{ .Alert.ID }}{{ end }}{{ end }}
 
 * Cluster: {{ .Alert.Cluster }}
+{{ if .Alert.Namespace }}* Namespace: {{ .Alert.Namespace }}
+{{ end -}}
 * SOP: {{ if .Alert.Link }}{{ ToLink (SOPName .Alert.Link) .Alert.Link }}{{ else }}_none_{{ end }}
 * Service: {{ .Alert.Service }}
 * Created: {{ .Alert.Created }}
+{{ if .Alert.Description }}
+> {{ .Alert.Description }}
+{{ end -}}
 `
 
 // noteTabTemplate renders a single note with navigation header (kept for backward compatibility)

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -145,6 +145,10 @@ func (m model) View() string {
 	case m.viewingLog:
 		s.WriteString(tableContainerStyle.Render(m.logViewer.View()))
 
+	case m.mergeMode:
+		s.WriteString(fmt.Sprintf("  Select incident to merge %s into (Enter=select, Esc=cancel, t=toggle team):\n", m.mergeSourceIncident.ID))
+		s.WriteString(tableContainerStyle.Render(m.mergeTable.View()))
+
 	case m.viewingIncident:
 		tabBar := renderTabBar(m.activeTab,
 			len(m.selectedIncidentAlerts), len(m.selectedIncidentNotes),


### PR DESCRIPTION
## Summary

### Incident Merge
- Press `m` to merge the selected incident into another incident
- Opens a scrollable table of other open incidents (same format as main view)
- `t` toggles team/individual view, `Enter` selects target, `Esc` cancels
- Confirmation prompt before dispatching merge
- Adds `MergeIncidentsWithContext` to PD interface, mock, ratelimit, and dev client
- INFO-level audit log with user_id, source, and target on merge completion

### Alert Tab: Namespace and Description
- Extract `namespace` and `description` from alert firing field for RHOBS HCP and OSD Hive types
- For OSD Hive, falls back to `message` annotation if `description` is not present
- Namespace shown as a bullet point, description as a blockquote in the alert tab
- Added `Description` field to `NormalizedAlert` struct

## Test plan
- [x] `make fmt-check` passes
- [x] `make vet` passes
- [x] `make lint` passes
- [x] `make test` passes
- [ ] Manual: `m` opens merge target list, excludes source incident
- [ ] Manual: Alert tab shows namespace and description for RHOBS/OSD Hive alerts
- [ ] Manual: Dev mode fixtures display namespace/description correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)