### PR TITLE
Refactor cluster selection to scrollable table view (#259)

### DIFF
--- a/docs/plans/073-cluster-select-view.md
+++ b/docs/plans/073-cluster-select-view.md
@@ -1,0 +1,22 @@
+# Refactor cluster selection to scrollable table view
+
+## Context
+
+When logging into a multi-cluster incident, the cluster selection
+prompt in the status bar gets overwritten by async API responses,
+leaving the keyboard locked with no visible instructions.
+
+## Changes
+
+- Replace status bar prompt with scrollable table view (same
+  pattern as merge mode)
+- Add clusterSelectTable and clusterSelectPrompt to model
+- Enter selects, Escape cancels, Up/Down navigates
+- Remove digit-key (1-9) handling and handleClusterSelectInput
+- Remove cluster select rendering from renderHeader()
+
+## Verification
+
+- make test-all passes
+- Multi-cluster incident login shows scrollable cluster list
+- Async status updates don't interfere with cluster selection

--- a/pkg/tui/cluster_select_test.go
+++ b/pkg/tui/cluster_select_test.go
@@ -1,0 +1,178 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/PagerDuty/go-pagerduty"
+	"github.com/charmbracelet/bubbles/table"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapClusterServices(t *testing.T) {
+	tests := []struct {
+		name     string
+		alerts   []pagerduty.IncidentAlert
+		expected map[string]string
+	}{
+		{
+			name: "maps cluster IDs to service names",
+			alerts: []pagerduty.IncidentAlert{
+				{
+					Service: pagerduty.APIObject{Summary: "osd-cluster1-hive-cluster"},
+					Body: map[string]interface{}{
+						"details": map[string]interface{}{
+							"cluster_id": "aaaa-1111",
+						},
+					},
+				},
+				{
+					Service: pagerduty.APIObject{Summary: "prod-deadmanssnitch"},
+					Body: map[string]interface{}{
+						"details": map[string]interface{}{
+							"cluster_id": "bbbb-2222",
+						},
+					},
+				},
+			},
+			expected: map[string]string{
+				"aaaa-1111": "osd-cluster1-hive-cluster",
+				"bbbb-2222": "prod-deadmanssnitch",
+			},
+		},
+		{
+			name: "first service wins for duplicate cluster IDs",
+			alerts: []pagerduty.IncidentAlert{
+				{
+					Service: pagerduty.APIObject{Summary: "first-service"},
+					Body: map[string]interface{}{
+						"details": map[string]interface{}{
+							"cluster_id": "aaaa-1111",
+						},
+					},
+				},
+				{
+					Service: pagerduty.APIObject{Summary: "second-service"},
+					Body: map[string]interface{}{
+						"details": map[string]interface{}{
+							"cluster_id": "aaaa-1111",
+						},
+					},
+				},
+			},
+			expected: map[string]string{
+				"aaaa-1111": "first-service",
+			},
+		},
+		{
+			name:     "empty alerts returns empty map",
+			alerts:   []pagerduty.IncidentAlert{},
+			expected: map[string]string{},
+		},
+		{
+			name: "skips alerts without cluster_id",
+			alerts: []pagerduty.IncidentAlert{
+				{
+					Service: pagerduty.APIObject{Summary: "some-service"},
+					Body:    map[string]interface{}{},
+				},
+			},
+			expected: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := mapClusterServices(tt.alerts)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSwitchClusterSelectFocusMode_Enter(t *testing.T) {
+	t.Run("Enter selects highlighted cluster", func(t *testing.T) {
+		m := createTestModel()
+		m.clusterSelectMode = true
+		m.clusterSelectOptions = []string{"aaaa-1111", "bbbb-2222"}
+		cols := []table.Column{
+			{Title: "Cluster ID", Width: 40},
+			{Title: "Service", Width: 50},
+		}
+		rows := []table.Row{
+			{"aaaa-1111", "osd-cluster1"},
+			{"bbbb-2222", "prod-dms"},
+		}
+		m.clusterSelectTable = table.New(table.WithColumns(cols), table.WithRows(rows), table.WithFocused(true))
+
+		result, cmd := switchClusterSelectFocusMode(m, tea.KeyMsg{Type: tea.KeyEnter})
+		updated := result.(model)
+
+		assert.False(t, updated.clusterSelectMode)
+		assert.Nil(t, updated.clusterSelectOptions)
+		assert.NotNil(t, cmd)
+		msg := cmd()
+		assert.Equal(t, clusterSelectedMsg("aaaa-1111"), msg)
+	})
+}
+
+func TestSwitchClusterSelectFocusMode_Escape(t *testing.T) {
+	t.Run("Escape cancels cluster selection", func(t *testing.T) {
+		m := createTestModel()
+		m.clusterSelectMode = true
+		m.clusterSelectOptions = []string{"aaaa-1111"}
+		cols := []table.Column{{Title: "Cluster ID", Width: 40}}
+		rows := []table.Row{{"aaaa-1111"}}
+		m.clusterSelectTable = table.New(table.WithColumns(cols), table.WithRows(rows), table.WithFocused(true))
+
+		result, cmd := switchClusterSelectFocusMode(m, tea.KeyMsg{Type: tea.KeyEsc})
+		updated := result.(model)
+
+		assert.False(t, updated.clusterSelectMode)
+		assert.Nil(t, updated.clusterSelectOptions)
+		assert.Contains(t, updated.status, "cancelled")
+		assert.Nil(t, cmd)
+	})
+}
+
+func TestSwitchClusterSelectFocusMode_Quit(t *testing.T) {
+	t.Run("Quit key exits app from cluster select", func(t *testing.T) {
+		m := createTestModel()
+		m.clusterSelectMode = true
+		cols := []table.Column{{Title: "Cluster ID", Width: 40}}
+		m.clusterSelectTable = table.New(table.WithColumns(cols), table.WithFocused(true))
+
+		_, cmd := switchClusterSelectFocusMode(m, tea.KeyMsg{Type: tea.KeyCtrlC})
+
+		assert.NotNil(t, cmd)
+	})
+}
+
+func TestSwitchClusterSelectFocusMode_Navigation(t *testing.T) {
+	t.Run("other keys pass through to table", func(t *testing.T) {
+		m := createTestModel()
+		m.clusterSelectMode = true
+		cols := []table.Column{{Title: "Cluster ID", Width: 40}}
+		rows := []table.Row{{"aaaa-1111"}, {"bbbb-2222"}}
+		m.clusterSelectTable = table.New(table.WithColumns(cols), table.WithRows(rows), table.WithFocused(true))
+
+		result, _ := switchClusterSelectFocusMode(m, tea.KeyMsg{Type: tea.KeyDown})
+		updated := result.(model)
+
+		assert.True(t, updated.clusterSelectMode, "should stay in cluster select mode")
+	})
+}
+
+func TestSwitchClusterSelectFocusMode_EmptyTable(t *testing.T) {
+	t.Run("Enter with empty table shows no cluster selected", func(t *testing.T) {
+		m := createTestModel()
+		m.clusterSelectMode = true
+		cols := []table.Column{{Title: "Cluster ID", Width: 40}}
+		m.clusterSelectTable = table.New(table.WithColumns(cols), table.WithFocused(true))
+
+		result, cmd := switchClusterSelectFocusMode(m, tea.KeyMsg{Type: tea.KeyEnter})
+		updated := result.(model)
+
+		assert.Contains(t, updated.status, "no cluster selected")
+		assert.Nil(t, cmd)
+	})
+}

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -884,6 +884,19 @@ func getUniqueClusters(alerts []pagerduty.IncidentAlert) []string {
 	return clusters
 }
 
+func mapClusterServices(alerts []pagerduty.IncidentAlert) map[string]string {
+	result := make(map[string]string)
+	for _, a := range alerts {
+		cluster := getDetailFieldFromAlert("cluster_id", a)
+		if cluster != "" {
+			if _, exists := result[cluster]; !exists {
+				result[cluster] = a.Service.Summary
+			}
+		}
+	}
+	return result
+}
+
 // getEscalationPolicyKey is a helper function to determine the escalation policy key
 func getEscalationPolicyKey(serviceID string, policies map[string]*pagerduty.EscalationPolicy) string {
 	if _, ok := policies[serviceID]; ok {

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -101,6 +101,8 @@ type model struct {
 	// because the incident has alerts referencing multiple distinct cluster_ids.
 	clusterSelectMode    bool
 	clusterSelectOptions []string
+	clusterSelectTable   table.Model
+	clusterSelectPrompt  string
 
 	// chordPending is true when the chord prefix key has been pressed and
 	// the system is waiting for the second key to complete the chord.

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -130,10 +130,7 @@ func (m model) windowSizeMsgHandler(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m model) keyMsgHandler(msg tea.Msg) (tea.Model, tea.Cmd) {
-	// If cluster selection mode is active, only accept digit keys and Escape/quit
-	if m.clusterSelectMode {
-		return m.handleClusterSelectInput(msg.(tea.KeyMsg))
-	}
+	// Cluster selection mode is handled as a view in the switch below
 
 	// If a confirmation prompt is active, only accept y/n/Escape/quit
 	if m.pendingConfirmation != nil {
@@ -150,7 +147,7 @@ func (m model) keyMsgHandler(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// Chord state machine: runs before focus-mode dispatch so chords work
 	// in both table and incident-view modes. Disabled during input and error modes
 	// (those are handled below in the focus-mode switch).
-	if !m.input.Focused() && m.err == nil {
+	if !m.input.Focused() && m.err == nil && !m.clusterSelectMode {
 		// 1. If chord pending and Escape: cancel chord
 		if m.chordPending && keyStr == "esc" {
 			m.chordPending = false
@@ -208,6 +205,9 @@ func (m model) keyMsgHandler(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case m.err != nil:
 		return switchErrorFocusMode(m, msg)
 
+	case m.clusterSelectMode:
+		return switchClusterSelectFocusMode(m, msg)
+
 	case m.mergeMode:
 		return switchMergeFocusMode(m, msg)
 
@@ -227,34 +227,39 @@ func (m model) keyMsgHandler(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// handleClusterSelectInput processes keypresses while cluster selection mode is active.
-// Accepts digit keys 1-9 to select a cluster, Escape to cancel, and quit keys to exit.
-func (m model) handleClusterSelectInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if key.Matches(msg, defaultKeyMap.Quit) {
-		return m, tea.Quit
-	}
+func switchClusterSelectFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch {
+		case key.Matches(msg, defaultKeyMap.Quit):
+			return m, tea.Quit
 
-	keyStr := msg.String()
-	switch keyStr {
-	case "esc":
-		m.clusterSelectMode = false
-		m.clusterSelectOptions = nil
-		m.setStatus("cluster selection cancelled")
-		return m, nil
-	case "1", "2", "3", "4", "5", "6", "7", "8", "9":
-		idx := int(keyStr[0]-'0') - 1
-		if idx < len(m.clusterSelectOptions) {
-			selected := m.clusterSelectOptions[idx]
+		case key.Matches(msg, defaultKeyMap.Back):
 			m.clusterSelectMode = false
 			m.clusterSelectOptions = nil
+			m.setStatus("cluster selection cancelled")
+			m.table.Focus()
+			return m, nil
+
+		case key.Matches(msg, defaultKeyMap.Enter):
+			selectedRow := m.clusterSelectTable.SelectedRow()
+			if len(selectedRow) < 1 {
+				m.setStatus("no cluster selected")
+				return m, nil
+			}
+			selected := selectedRow[0]
+			m.clusterSelectMode = false
+			m.clusterSelectOptions = nil
+			m.table.Focus()
 			return m, func() tea.Msg { return clusterSelectedMsg(selected) }
+
+		default:
+			var cmd tea.Cmd
+			m.clusterSelectTable, cmd = m.clusterSelectTable.Update(msg)
+			return m, cmd
 		}
-		// Index out of range - ignore
-		return m, nil
-	default:
-		// Ignore all other keys while cluster selection is active
-		return m, nil
 	}
+	return m, nil
 }
 
 // handleConfirmationInput processes keypresses while a confirmation prompt is active.

--- a/pkg/tui/msgHandlers_test.go
+++ b/pkg/tui/msgHandlers_test.go
@@ -479,13 +479,15 @@ func TestIncidentViewMode_RefreshWithNilSelectedIncident(t *testing.T) {
 		"No command should be returned when selectedIncident is nil")
 }
 
-func TestClusterSelect_DigitSelectsCluster(t *testing.T) {
+func TestClusterSelect_EnterSelectsCluster(t *testing.T) {
 	m := createTestModel()
 	m.clusterSelectMode = true
 	m.clusterSelectOptions = []string{"cluster-abc", "cluster-def", "cluster-ghi"}
+	cols := []table.Column{{Title: "Cluster ID", Width: 40}}
+	rows := []table.Row{{"cluster-abc"}, {"cluster-def"}, {"cluster-ghi"}}
+	m.clusterSelectTable = table.New(table.WithColumns(cols), table.WithRows(rows), table.WithFocused(true))
 
-	// Press '2' to select the second cluster
-	keyMsg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}}
+	keyMsg := tea.KeyMsg{Type: tea.KeyEnter}
 	result, cmd := m.Update(keyMsg)
 	updatedModel := result.(model)
 
@@ -493,18 +495,19 @@ func TestClusterSelect_DigitSelectsCluster(t *testing.T) {
 		"Cluster select mode should be cleared after selection")
 	assert.Nil(t, updatedModel.clusterSelectOptions,
 		"Cluster select options should be cleared after selection")
-
-	// The command should produce a clusterSelectedMsg with the chosen cluster
 	assert.NotNil(t, cmd, "A command should be returned after selection")
 	msg := cmd()
-	assert.Equal(t, clusterSelectedMsg("cluster-def"), msg,
-		"Should select the second cluster")
+	assert.Equal(t, clusterSelectedMsg("cluster-abc"), msg,
+		"Should select the highlighted cluster")
 }
 
 func TestClusterSelect_EscCancels(t *testing.T) {
 	m := createTestModel()
 	m.clusterSelectMode = true
 	m.clusterSelectOptions = []string{"cluster-abc", "cluster-def"}
+	cols := []table.Column{{Title: "Cluster ID", Width: 40}}
+	rows := []table.Row{{"cluster-abc"}, {"cluster-def"}}
+	m.clusterSelectTable = table.New(table.WithColumns(cols), table.WithRows(rows), table.WithFocused(true))
 
 	keyMsg := tea.KeyMsg{Type: tea.KeyEsc}
 	result, cmd := m.Update(keyMsg)
@@ -517,38 +520,6 @@ func TestClusterSelect_EscCancels(t *testing.T) {
 	assert.Contains(t, updatedModel.status, "cancelled",
 		"Status should indicate cancellation")
 	assert.Nil(t, cmd, "No command should be returned on cancel")
-}
-
-func TestClusterSelect_OutOfRangeIgnored(t *testing.T) {
-	m := createTestModel()
-	m.clusterSelectMode = true
-	m.clusterSelectOptions = []string{"cluster-abc"}
-
-	// Press '5' which is out of range (only 1 option)
-	keyMsg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}}
-	result, cmd := m.Update(keyMsg)
-	updatedModel := result.(model)
-
-	assert.True(t, updatedModel.clusterSelectMode,
-		"Cluster select mode should remain active for out-of-range digit")
-	assert.NotNil(t, updatedModel.clusterSelectOptions,
-		"Cluster select options should remain for out-of-range digit")
-	assert.Nil(t, cmd, "No command for out-of-range digit")
-}
-
-func TestClusterSelect_OtherKeysIgnored(t *testing.T) {
-	m := createTestModel()
-	m.clusterSelectMode = true
-	m.clusterSelectOptions = []string{"cluster-abc", "cluster-def"}
-
-	// Press 'a' which is not a valid key in cluster selection mode
-	keyMsg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}}
-	result, cmd := m.Update(keyMsg)
-	updatedModel := result.(model)
-
-	assert.True(t, updatedModel.clusterSelectMode,
-		"Cluster select mode should remain active for non-digit keys")
-	assert.Nil(t, cmd, "No command for non-digit keys")
 }
 
 func TestClusterSelect_ClearedOnViewTransition(t *testing.T) {

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -574,10 +574,14 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.clusterSelectMode = true
 			m.clusterSelectOptions = clusters
 			m.clusterSelectPrompt = "Select cluster to log into (Enter=select, Esc=cancel):"
-			cols := []table.Column{{Title: "Cluster ID", Width: 60}}
+			clusterServices := mapClusterServices(m.selectedIncidentAlerts)
+			cols := []table.Column{
+				{Title: "Cluster ID", Width: 40},
+				{Title: "Service", Width: 50},
+			}
 			var rows []table.Row
 			for _, c := range clusters {
-				rows = append(rows, table.Row{c})
+				rows = append(rows, table.Row{c, clusterServices[c]})
 			}
 			m.clusterSelectTable = table.New(table.WithColumns(cols), table.WithRows(rows), table.WithFocused(true))
 			m.clusterSelectTable.SetStyles(tableStyle)

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -570,18 +570,17 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cluster = clusters[0]
 			m.setStatus(fmt.Sprintf("logging into cluster %s", cluster))
 		default:
-			// Multiple distinct clusters - ask the user to choose
+			// Multiple distinct clusters - open scrollable selection view
 			m.clusterSelectMode = true
 			m.clusterSelectOptions = clusters
-			var prompt strings.Builder
-			prompt.WriteString("Select cluster: ")
-			for i, c := range clusters {
-				if i > 0 {
-					prompt.WriteString(", ")
-				}
-				fmt.Fprintf(&prompt, "[%d] %s", i+1, c)
+			m.clusterSelectPrompt = "Select cluster to log into (Enter=select, Esc=cancel):"
+			cols := []table.Column{{Title: "Cluster ID", Width: 60}}
+			var rows []table.Row
+			for _, c := range clusters {
+				rows = append(rows, table.Row{c})
 			}
-			m.setStatus(prompt.String())
+			m.clusterSelectTable = table.New(table.WithColumns(cols), table.WithRows(rows), table.WithFocused(true))
+			m.clusterSelectTable.SetStyles(tableStyle)
 			return m, nil
 		}
 

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -145,6 +145,10 @@ func (m model) View() string {
 	case m.viewingLog:
 		s.WriteString(tableContainerStyle.Render(m.logViewer.View()))
 
+	case m.clusterSelectMode:
+		s.WriteString("  " + m.clusterSelectPrompt + "\n")
+		s.WriteString(tableContainerStyle.Render(m.clusterSelectTable.View()))
+
 	case m.mergeMode:
 		fmt.Fprintf(&s, "  Select incident to merge %s into (Enter=select, Esc=cancel, t=toggle team):\n", m.mergeSourceIncident.ID)
 		s.WriteString(tableContainerStyle.Render(m.mergeTable.View()))
@@ -233,13 +237,8 @@ func (m model) renderHeader() string {
 		assignedTo = "Team"
 	}
 
-	// When a cluster selection or confirmation prompt is active, show it in the
-	// status area instead of the normal status text, using the warning style to
-	// draw attention
 	var statusContent string
-	if m.clusterSelectMode {
-		statusContent = warningStyle.Render(m.status)
-	} else if m.pendingConfirmation != nil {
+	if m.pendingConfirmation != nil {
 		statusContent = warningStyle.Render(m.pendingConfirmation.prompt)
 	} else {
 		statusContent = statusArea(m.status, m.apiInProgress, m.spinner.View())


### PR DESCRIPTION
## Summary
- Replaced status bar numbered prompt with a dedicated scrollable table view for cluster selection
- Table shows Cluster ID and Service Name columns for easy identification
- Same pattern as merge mode: Enter selects, Escape cancels, Up/Down navigates
- Fixes async API responses overwriting the cluster selection prompt, which left the keyboard locked with no visible instructions
- Removed digit-key (1-9) handling, removed `handleClusterSelectInput`
- Disabled chord keys during cluster selection mode

## Test plan
- [x] `make fmt-check` passes
- [x] `make vet` passes
- [x] `make lint` passes
- [x] `make test` passes
- [x] Manual: Multi-cluster incident login shows scrollable cluster list with service names
- [x] Manual: Enter selects cluster, Esc cancels, Up/Down navigates

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)