### PR TITLE
Add user notification when OCM browser auth is triggered

### DIFF
--- a/docs/plans/078-ocm-auth-notification.md
+++ b/docs/plans/078-ocm-auth-notification.md
@@ -1,0 +1,10 @@
+# OCM Auth Browser Notification
+
+## Problem
+When srepd starts with expired OCM tokens, InitiateAuthCode() opens a
+browser for OAuth login with no user-visible message. The app appears
+to hang.
+
+## Solution
+Add stderr messages before and after InitiateAuthCode() in NewClient().
+This runs only on startup before the TUI starts.

--- a/pkg/ocm/client.go
+++ b/pkg/ocm/client.go
@@ -3,6 +3,7 @@ package ocm
 import (
 	"context"
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 
@@ -63,11 +64,13 @@ func NewClient(agentVersion string) (*Client, error) {
 
 	if !armed {
 		log.Debug("ocm.NewClient", "msg", "not logged into OCM, initiating browser auth", "reason", reason)
+		fmt.Fprintln(os.Stderr, "OCM tokens expired — opening browser for authentication...")
 		token, authErr := auth.InitiateAuthCode(clientID)
 		if authErr != nil {
 			log.Debug("ocm.NewClient", "msg", "browser auth failed or cancelled", "error", authErr)
 			return nil, nil
 		}
+		fmt.Fprintln(os.Stderr, "OCM authentication successful.")
 
 		if ocmconfig.IsEncryptedToken(token) {
 			cfg.AccessToken = ""


### PR DESCRIPTION
## Summary
- Print stderr messages before and after `InitiateAuthCode()` in `pkg/ocm/client.go` so users know why the browser opened and when auth succeeds
- Before: app appears to hang silently when OCM tokens are expired
- After: user sees "OCM tokens expired — opening browser for authentication..." and "OCM authentication successful."

Fixes #265

## Test plan
- [ ] Run `make test-all` (unit tests, vet, lint, fmt-check)
- [ ] Start srepd with expired OCM tokens and verify stderr messages appear
- [ ] Start srepd with valid OCM tokens and verify no extra messages appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)