### PR TITLE
Block login when no cluster_id found in alerts

### DIFF
--- a/docs/plans/080-block-login-no-cluster.md
+++ b/docs/plans/080-block-login-no-cluster.md
@@ -1,0 +1,8 @@
+# Block login when no cluster_id found
+
+## Problem
+Fleet-level alerts have no cluster_id. Pressing 'l' launched a
+terminal with an empty cluster ID argument.
+
+## Solution
+Show a flash notification instead of launching the terminal.

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -645,9 +645,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		var cluster string
 		switch len(clusters) {
 		case 0:
-			// Alerts exist but none carry a cluster_id
-			cluster = ""
-			m.setStatus("no cluster_id found in alerts - launching without cluster")
+			return m, m.flashNotification("No cluster_id found in alerts — cannot login")
 		case 1:
 			cluster = clusters[0]
 			m.setStatus(fmt.Sprintf("logging into cluster %s", cluster))


### PR DESCRIPTION
## Summary
- Fleet-level alerts (e.g., HCPProvisioningErrorBudgetBurn) have no cluster_id
- Previously pressing `l` would launch the terminal with an empty cluster ID
- Now shows a flash notification: "No cluster_id found in alerts — cannot login"

## Test plan
- [x] All tests pass
- [x] Press `l` on a fleet alert with no cluster_id → flash message, no terminal launched
- [x] Press `l` on a cluster-specific alert → normal login behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)