### PR TITLE
add logic to prompt for PD teams

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -4,11 +4,18 @@ Copyright © 2025 NAME HERE <EMAIL ADDRESS>
 package cmd
 
 import (
+	"bufio"
+	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
+	"time"
 
+	"github.com/PagerDuty/go-pagerduty"
 	"github.com/charmbracelet/log"
 	"github.com/clcollins/srepd/pkg/deprecation"
 	"github.com/spf13/cobra"
@@ -111,7 +118,10 @@ var configCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		switch {
 		case cmd.Flag("create").Value.String() == "true":
-			fmt.Println(exampleConfig)
+			err := createConfig()
+			if err != nil {
+				return err
+			}
 			return nil
 		case cmd.Flag("validate").Value.String() == "true":
 			err := validateConfig()
@@ -120,8 +130,12 @@ var configCmd = &cobra.Command{
 			}
 			fmt.Printf("Config file is valid\n")
 			return nil
-		case cmd.Flag("create").Value.String() == "true" && cmd.Flag("validate").Value.String() == "true":
-			return errors.New("cannot use both --create and --validate flags together")
+		case cmd.Flag("list-teams").Value.String() == "true":
+			err := listPagerDutyTeams()
+			if err != nil {
+				return err
+			}
+			return nil
 		default:
 			err := cmd.Usage()
 			return err
@@ -142,9 +156,303 @@ func init() {
 	// is called directly, e.g.:
 	// configCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 
-	configCmd.Flags().BoolP("create", "c", false, "print a sample config file")
+	configCmd.Flags().BoolP("create", "c", false, "create a sample config file at ~/.config/srepd/srepd.yaml")
 	configCmd.Flags().BoolP("validate", "v", false, "validate the config file")
-	configCmd.MarkFlagsMutuallyExclusive("create", "validate")
+	configCmd.Flags().BoolP("list-teams", "l", false, "list your PagerDuty teams (requires valid token in config or SREPD_TOKEN env var)")
+	configCmd.MarkFlagsMutuallyExclusive("create", "validate", "list-teams")
+}
+
+// createConfig creates the config directory and writes an example config file
+func createConfig() error {
+	const (
+		cfgFile     = "srepd.yaml"
+		cfgFilePath = ".config/srepd"
+	)
+
+	// Find home directory
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to get user home directory: %w", err)
+	}
+
+	// Construct full config directory path
+	configDir := filepath.Join(home, cfgFilePath)
+
+	// Create config directory if it doesn't exist
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+
+	// Construct full config file path
+	configFile := filepath.Join(configDir, cfgFile)
+
+	// Check if config file already exists
+	if _, err := os.Stat(configFile); err == nil {
+		return fmt.Errorf("config file already exists at %s", configFile)
+	}
+
+	// Write example config to file
+	if err := os.WriteFile(configFile, []byte(exampleConfig), 0644); err != nil {
+		return fmt.Errorf("failed to write config file: %w", err)
+	}
+
+	fmt.Printf("Config file created at %s\n", configFile)
+	fmt.Println("Please edit the file to add your PagerDuty credentials and team information.")
+	fmt.Println("\nTip: After adding your token, run 'srepd config --list-teams' to see available teams.")
+	return nil
+}
+
+// listPagerDutyTeams fetches and displays all available PagerDuty teams
+func listPagerDutyTeams() error {
+	// Get token from config or environment variable
+	token := viper.GetString("token")
+	if token == "" || token == "<PagerDuty API token>" {
+		return fmt.Errorf("no valid PagerDuty API token found. Please set 'token' in %s/.config/srepd/srepd.yaml or set SREPD_TOKEN environment variable", os.Getenv("HOME"))
+	}
+
+	fmt.Println("Fetching teams from PagerDuty...")
+
+	teams, err := fetchPagerDutyTeams(token)
+	if err != nil {
+		return err
+	}
+
+	if len(teams) == 0 {
+		fmt.Println("No teams found in your PagerDuty account.")
+		return nil
+	}
+
+	// Display teams
+	fmt.Printf("\nFound %d team(s):\n\n", len(teams))
+	for _, team := range teams {
+		fmt.Printf("  ID: %s\n  Name: %s\n\n", team.ID, team.Name)
+	}
+
+	// Show example config snippet
+	fmt.Println("To add teams to your config, edit ~/.config/srepd/srepd.yaml and update the teams section:")
+	fmt.Println("\nteams:")
+	for i, team := range teams {
+		if i < 3 { // Show first 3 as examples
+			fmt.Printf("  - %s  # %s\n", team.ID, team.Name)
+		}
+	}
+	if len(teams) > 3 {
+		fmt.Println("  # ...")
+	}
+
+	return nil
+}
+
+// fetchPagerDutyTeams retrieves the current user's teams from PagerDuty API
+func fetchPagerDutyTeams(token string) ([]pagerduty.Team, error) {
+	// Create PagerDuty client
+	client := pagerduty.NewClient(token)
+
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Get current user with their teams
+	opts := pagerduty.GetCurrentUserOptions{
+		Includes: []string{"teams"},
+	}
+
+	user, err := client.GetCurrentUserWithContext(ctx, opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch current user from PagerDuty: %w", err)
+	}
+
+	if len(user.Teams) == 0 {
+		return []pagerduty.Team{}, nil
+	}
+
+	return user.Teams, nil
+}
+
+// hasPlaceholderTeams checks if the teams list contains only placeholder values
+func hasPlaceholderTeams() bool {
+	teams := viper.GetStringSlice("teams")
+	if len(teams) == 0 {
+		return true
+	}
+
+	// Check if all teams are placeholder values
+	for _, team := range teams {
+		trimmed := strings.TrimSpace(team)
+		if trimmed != "" && !strings.HasPrefix(trimmed, "<PagerDuty Team ID") {
+			return false
+		}
+	}
+
+	return true
+}
+
+// promptInteractiveTeamSelection prompts the user to select teams interactively
+func promptInteractiveTeamSelection() error {
+	reader := bufio.NewReader(os.Stdin)
+
+	fmt.Println("\nNo teams found in config. This will result in zero tickets loaded in srepd.")
+	fmt.Print("Would you like to add your teams now? (y/n): ")
+
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("failed to read user input: %w", err)
+	}
+
+	response = strings.ToLower(strings.TrimSpace(response))
+	if response != "y" && response != "yes" {
+		fmt.Println("Skipping team configuration. You can add teams later by editing the config file or running 'srepd config --list-teams'")
+		return nil
+	}
+
+	// Get token
+	token := viper.GetString("token")
+	if token == "" || token == "<PagerDuty API token>" {
+		return fmt.Errorf("no valid PagerDuty API token found in config. Please add your token to the config file first")
+	}
+
+	fmt.Println("\nFetching teams from PagerDuty...")
+	teams, err := fetchPagerDutyTeams(token)
+	if err != nil {
+		return err
+	}
+
+	if len(teams) == 0 {
+		fmt.Println("No teams found in your PagerDuty account.")
+		return nil
+	}
+
+	// Display teams with numbers
+	fmt.Printf("\nFound %d team(s):\n\n", len(teams))
+	for i, team := range teams {
+		fmt.Printf("%2d. %s - %s\n", i+1, team.ID, team.Name)
+	}
+
+	fmt.Println("\nEnter the numbers of the teams you want to add (comma-separated, e.g., 1,3,5):")
+	fmt.Print("Teams: ")
+
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("failed to read team selection: %w", err)
+	}
+
+	input = strings.TrimSpace(input)
+	if input == "" {
+		fmt.Println("No teams selected. Skipping team configuration.")
+		return nil
+	}
+
+	// Parse selections
+	selections := strings.Split(input, ",")
+	var selectedTeams []string
+
+	for _, sel := range selections {
+		sel = strings.TrimSpace(sel)
+		num, err := strconv.Atoi(sel)
+		if err != nil || num < 1 || num > len(teams) {
+			fmt.Printf("Warning: Invalid selection '%s', skipping...\n", sel)
+			continue
+		}
+		selectedTeams = append(selectedTeams, teams[num-1].ID)
+	}
+
+	if len(selectedTeams) == 0 {
+		fmt.Println("No valid teams selected.")
+		return nil
+	}
+
+	// Update config file
+	err = updateConfigTeams(selectedTeams)
+	if err != nil {
+		return fmt.Errorf("failed to update config: %w", err)
+	}
+
+	fmt.Printf("\nSuccessfully added %d team(s) to config!\n", len(selectedTeams))
+	for i, teamID := range selectedTeams {
+		// Find the team name
+		for _, team := range teams {
+			if team.ID == teamID {
+				fmt.Printf("  %d. %s - %s\n", i+1, teamID, team.Name)
+				break
+			}
+		}
+	}
+
+	return nil
+}
+
+// updateConfigTeams updates only the teams list in the config file, preserving all other content
+func updateConfigTeams(teams []string) error {
+	const (
+		cfgFile     = "srepd.yaml"
+		cfgFilePath = ".config/srepd"
+	)
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to get user home directory: %w", err)
+	}
+
+	configFile := filepath.Join(home, cfgFilePath, cfgFile)
+
+	// Read existing config
+	data, err := os.ReadFile(configFile)
+	if err != nil {
+		return fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	lines := strings.Split(string(data), "\n")
+	var newLines []string
+	teamsIndentLevel := 0
+
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+
+		// Detect start of teams section
+		if strings.HasPrefix(strings.TrimSpace(line), "teams:") {
+			// Calculate indent level (number of leading spaces before "teams:")
+			teamsIndentLevel = len(line) - len(strings.TrimLeft(line, " \t"))
+			newLines = append(newLines, line)
+
+			// Add the new teams
+			for _, team := range teams {
+				newLines = append(newLines, fmt.Sprintf("%s  - %s", strings.Repeat(" ", teamsIndentLevel), team))
+			}
+
+			// Skip old team entries (lines that start with "  -" after teams:)
+			for i+1 < len(lines) {
+				nextLine := lines[i+1]
+				trimmed := strings.TrimSpace(nextLine)
+				// Check if it's a team entry (starts with -)
+				if trimmed != "" && strings.HasPrefix(trimmed, "-") {
+					// Check if indentation matches teams section (is a direct child)
+					indent := len(nextLine) - len(strings.TrimLeft(nextLine, " \t"))
+					if indent > teamsIndentLevel {
+						i++ // Skip this line
+						continue
+					}
+				}
+				// Not a team entry, stop skipping
+				break
+			}
+			continue
+		}
+
+		// Keep all other lines
+		newLines = append(newLines, line)
+	}
+
+	// Write back
+	updatedData := strings.Join(newLines, "\n")
+	err = os.WriteFile(configFile, []byte(updatedData), 0644)
+	if err != nil {
+		return fmt.Errorf("failed to write config file: %w", err)
+	}
+
+	// Reload viper config
+	viper.Set("teams", teams)
+
+	return nil
 }
 
 // validateConfig prints the viper info passed into the program
@@ -206,6 +514,19 @@ func validateConfig() error {
 		if !ok {
 			log.Debug("cmd.validateConfig()", "msg", "missing optional key", "key", k, "default_value", defaultOptionalKeys[k])
 			viper.Set(k, defaultOptionalKeys[k])
+		}
+	}
+
+	// If no errors so far and we have placeholder teams, prompt for interactive selection
+	if len(errs) == 0 && hasPlaceholderTeams() {
+		// Check if we have a valid token before prompting
+		token := viper.GetString("token")
+		if token != "" && token != "<PagerDuty API token>" {
+			err := promptInteractiveTeamSelection()
+			if err != nil {
+				log.Warn("Failed to configure teams interactively", "error", err)
+				// Don't add to errs - this is optional, user can configure later
+			}
 		}
 	}
 


### PR DESCRIPTION
## Improve config creation and add interactive team selection

  ### Changes

  **Fix `srepd config --create` to actually create the file**
  - Previously just printed example config to stdout
  - Now creates `~/.config/srepd/` directory if needed
  - Writes `srepd.yaml` with example configuration
  - Prevents overwriting existing config files

  **Add `srepd config --list-teams` command**
  - Fetches teams from PagerDuty API for current user
  - Shows only teams you're a member of (not all teams in org)
  - Displays team IDs and names ready for config

  **Interactive team selection on first startup**
  - Detects placeholder teams in config on first run
  - Prompts: "No teams found in config. This will result in zero tickets loaded in srepd. Would you like to add your teams now?"
  - Allows multi-select (comma-separated: `1,3,5`)
  - Surgically updates config file preserving all comments and formatting
  - Automatically updates teams section without touching other config

  **Before:**
  ```bash
  $ srepd config --create
  # Example srepd configuration file
  ...

  After:
  $ srepd config --create
  Config file created at /Users/user/.config/srepd/srepd.yaml
  Please edit the file to add your PagerDuty credentials and team information.

  Tip: After adding your token, run 'srepd config --list-teams' to see available teams.

  Workflow

  1. Run srepd config --create to create initial config
  2. Add PagerDuty API token to config file
  3. Run srepd - automatically prompts for team selection
  4. Or manually run srepd config --list-teams to see teams first

