### PR TITLE
Auto-discover ignored users from silent escalation policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ SREPD reads `~/.config/srepd/srepd.yaml` and supports `SREPD_` environment varia
 | `editor` | `string` | `vim` | Editor for incident notes |
 | `terminal` | `string` | `gnome-terminal` | Terminal emulator for cluster login |
 | `cluster_login_command` | `string` | `ocm backplane login %%CLUSTER_ID%%` | Cluster login command |
-| `ignoredusers` | `[]string` | (none) | PagerDuty user IDs to exclude |
+| `ignoredusers` | `[]string` | (auto-discovered) | **Deprecated.** PagerDuty user IDs to exclude. Now auto-discovered from silent escalation policies. Remove from config to use auto-discovery. |
 | `toolbox_mode` | `string` | `auto` | Toolbox detection: `auto`, `true`, or `false` |
 | `chord_prefix` | `string` | `ctrl+x` | Prefix key for chord commands |
 | `colors` | `map[string]string` | (defaults) | Custom color scheme (hex values) |

--- a/docs/plans/083-replace-ignoredusers.md
+++ b/docs/plans/083-replace-ignoredusers.md
@@ -1,0 +1,61 @@
+# 083: Replace ignoredusers with auto-discovery from escalation policies
+
+Issue: #269
+Branch: `srepd/replace-ignoredusers`
+
+## Problem
+
+The `ignoredusers` config key requires manually looking up PagerDuty
+user IDs for bot/silent users. This information is already present in
+the escalation policies: silent policies target only `user_reference`
+bot users and never route to on-call schedules.
+
+## Solution
+
+Auto-discover ignored users by classifying escalation policies:
+
+- **REAL policies** have at least one `schedule_reference` target
+  (incidents reach on-call humans)
+- **SILENT policies** have only `user_reference` targets
+  (incidents go to bots only)
+
+Extract all `user_reference` target IDs from SILENT policies as the
+ignored user set.
+
+## Changes
+
+### New functions in `pkg/pd/pd.go`
+
+- `ClassifyEscalationPolicy(policy) string` — returns `"REAL"` or
+  `"SILENT"` based on whether any target is a `schedule_reference`
+- `ExtractSilentPolicyUsers(policies) []string` — collects deduplicated,
+  sorted user IDs from all SILENT policies
+
+### Modified `NewConfigWithClient`
+
+- If `ignoredUsers` is non-empty: use manual list + log deprecation
+- If empty/nil: auto-discover via `ExtractSilentPolicyUsers`
+- Auto-discovery fetch failures are warnings (bot accounts may be
+  deleted), manual fetch failures are errors
+
+### Mock enhancement
+
+- Added `EscalationPolicyResponses` map to `MockPagerDutyClient` for
+  returning policies with `EscalationRules` in tests
+
+### Deprecation
+
+- Added `ignoredusers` to `pkg/deprecation/deprecation.go`
+
+## Verification
+
+- `make test-all` passes
+- Remove `ignoredusers` from config → auto-discovery produces same list
+- Keep `ignoredusers` → deprecation warning, still works
+- No SILENT policies → `IgnoredUsers` is empty
+
+## Future work
+
+- Phase 3: Escalation level filtering (`ctrl+x e` chord)
+- Phase 4: Service discovery via `ListServicesWithContext`
+- Phase 5: Full `ignoredusers` removal after deprecation period

--- a/pkg/deprecation/deprecation.go
+++ b/pkg/deprecation/deprecation.go
@@ -2,8 +2,9 @@ package deprecation
 
 var (
 	deprecatedKeys = map[string]bool{
-		"shell":      true,
-		"silentuser": true,
+		"shell":        true,
+		"silentuser":   true,
+		"ignoredusers": true,
 	}
 )
 

--- a/pkg/deprecation/deprecation_test.go
+++ b/pkg/deprecation/deprecation_test.go
@@ -14,6 +14,10 @@ func TestDeprecated_KnownKey_Silentuser(t *testing.T) {
 	assert.True(t, Deprecated("silentuser"), "expected 'silentuser' to be deprecated")
 }
 
+func TestDeprecated_KnownKey_Ignoredusers(t *testing.T) {
+	assert.True(t, Deprecated("ignoredusers"), "expected 'ignoredusers' to be deprecated")
+}
+
 func TestDeprecated_UnknownKey(t *testing.T) {
 	assert.False(t, Deprecated("token"), "expected 'token' to not be deprecated")
 }

--- a/pkg/pd/mock.go
+++ b/pkg/pd/mock.go
@@ -44,6 +44,11 @@ type MockPagerDutyClient struct {
 	// ListMembersOffsets records the offset value from each call to ListMembersWithContext,
 	// in order. Useful for verifying pagination offset reset behavior.
 	ListMembersOffsets []uint
+
+	// EscalationPolicyResponses maps policy IDs to specific responses for
+	// GetEscalationPolicyWithContext. When non-nil and a matching key exists,
+	// that policy is returned. Otherwise falls back to the default response.
+	EscalationPolicyResponses map[string]*pagerduty.EscalationPolicy
 }
 
 // recordCall increments the call count for the named method, lazily
@@ -223,6 +228,11 @@ func (m *MockPagerDutyClient) GetEscalationPolicyWithContext(ctx context.Context
 	m.recordCall("GetEscalationPolicyWithContext")
 	if id == "err" {
 		return nil, ErrMockError
+	}
+	if m.EscalationPolicyResponses != nil {
+		if policy, ok := m.EscalationPolicyResponses[id]; ok {
+			return policy, nil
+		}
 	}
 	return &pagerduty.EscalationPolicy{
 		APIObject: pagerduty.APIObject{ID: id},

--- a/pkg/pd/pd.go
+++ b/pkg/pd/pd.go
@@ -3,6 +3,7 @@ package pd
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -14,6 +15,9 @@ const (
 	defaultPageLimit  = 100
 	defaultOffset     = 0
 	defaultAPITimeout = 30 * time.Second
+
+	PolicyClassReal   = "REAL"
+	PolicyClassSilent = "SILENT"
 )
 
 var defaultIncidentStatuses = []string{"triggered", "acknowledged"}
@@ -111,12 +115,32 @@ func NewConfigWithClient(client PagerDutyClient, teams []string, escalation_poli
 		}
 	}
 
-	for _, i := range ignoredUsers {
-		user, err := GetUser(c.Client, i, pagerduty.GetUserOptions{})
-		if err != nil {
-			return &c, fmt.Errorf("pd.NewConfig(): failed to get user for ignore list `%v`: %v", i, err)
+	if len(ignoredUsers) > 0 {
+		log.Info("pd.NewConfig(): using manual ignoredusers (deprecated — remove ignoredusers from config to use auto-discovery)")
+		for _, i := range ignoredUsers {
+			user, err := GetUser(c.Client, i, pagerduty.GetUserOptions{})
+			if err != nil {
+				return &c, fmt.Errorf("pd.NewConfig(): failed to get user for ignore list `%v`: %v", i, err)
+			}
+			c.IgnoredUsers = append(c.IgnoredUsers, user)
 		}
-		c.IgnoredUsers = append(c.IgnoredUsers, user)
+	} else {
+		silentUserIDs := ExtractSilentPolicyUsers(c.EscalationPolicies)
+		for _, id := range silentUserIDs {
+			user, err := GetUser(c.Client, id, pagerduty.GetUserOptions{})
+			if err != nil {
+				log.Warn("pd.NewConfig(): failed to get user from silent policy, skipping", "user_id", id, "error", err)
+				continue
+			}
+			c.IgnoredUsers = append(c.IgnoredUsers, user)
+		}
+		if len(c.IgnoredUsers) > 0 {
+			var ids []string
+			for _, u := range c.IgnoredUsers {
+				ids = append(ids, u.ID)
+			}
+			log.Info("pd.NewConfig(): auto-discovered ignored users from silent policies", "count", len(c.IgnoredUsers), "user_ids", ids)
+		}
 	}
 
 	return &c, nil
@@ -434,4 +458,50 @@ func PostNote(client PagerDutyClient, id string, user *pagerduty.User, content s
 	}
 
 	return n, nil
+}
+
+// ClassifyEscalationPolicy returns PolicyClassReal if any target in any
+// escalation rule is a schedule_reference (meaning incidents can reach
+// on-call humans). Returns PolicyClassSilent if all targets are
+// user_reference only, or if the policy has no rules.
+func ClassifyEscalationPolicy(policy *pagerduty.EscalationPolicy) string {
+	if policy == nil {
+		return PolicyClassSilent
+	}
+	for _, rule := range policy.EscalationRules {
+		for _, target := range rule.Targets {
+			if target.Type == "schedule_reference" {
+				return PolicyClassReal
+			}
+		}
+	}
+	return PolicyClassSilent
+}
+
+// ExtractSilentPolicyUsers collects the deduplicated, sorted user IDs
+// from all SILENT escalation policies. These are the bot/placeholder
+// users whose assigned incidents should be filtered from the view.
+func ExtractSilentPolicyUsers(policies map[string]*pagerduty.EscalationPolicy) []string {
+	seen := make(map[string]bool)
+	var userIDs []string
+
+	for _, policy := range policies {
+		if ClassifyEscalationPolicy(policy) != PolicyClassSilent {
+			continue
+		}
+		for _, rule := range policy.EscalationRules {
+			for _, target := range rule.Targets {
+				if target.Type == "user_reference" && !seen[target.ID] {
+					seen[target.ID] = true
+					userIDs = append(userIDs, target.ID)
+				}
+			}
+		}
+	}
+
+	if len(userIDs) == 0 {
+		return nil
+	}
+	sort.Strings(userIDs)
+	return userIDs
 }

--- a/pkg/pd/pd_test.go
+++ b/pkg/pd/pd_test.go
@@ -564,6 +564,117 @@ func TestNewConfig_PolicyKeysUppercased(t *testing.T) {
 	assert.NotNil(t, config.EscalationPolicies["CUSTOM_SERVICE"])
 }
 
+func TestNewConfig_AutoDiscoverIgnoredUsers(t *testing.T) {
+	mockClient := &MockPagerDutyClient{
+		EscalationPolicyResponses: map[string]*pagerduty.EscalationPolicy{
+			"POLICY_REAL": {
+				APIObject: pagerduty.APIObject{ID: "POLICY_REAL"},
+				Name:      "OpenShift Escalation Policy",
+				EscalationRules: []pagerduty.EscalationRule{
+					{Targets: []pagerduty.APIObject{
+						{ID: "NOBODY_SREP", Type: "user_reference"},
+					}},
+					{Targets: []pagerduty.APIObject{
+						{ID: "ONCALL_SCHED", Type: "schedule_reference"},
+					}},
+				},
+			},
+			"POLICY_SILENT": {
+				APIObject: pagerduty.APIObject{ID: "POLICY_SILENT"},
+				Name:      "Silent Test - Non-Actionable",
+				EscalationRules: []pagerduty.EscalationRule{
+					{Targets: []pagerduty.APIObject{
+						{ID: "BOT_USER_1", Type: "user_reference"},
+					}},
+					{Targets: []pagerduty.APIObject{
+						{ID: "BOT_USER_2", Type: "user_reference"},
+					}},
+				},
+			},
+		},
+	}
+	policies := map[string]string{
+		"default":        "POLICY_REAL",
+		"silent_default": "POLICY_SILENT",
+	}
+
+	config, err := NewConfigWithClient(mockClient, []string{"team1"}, policies, nil)
+
+	assert.NoError(t, err)
+	assert.Len(t, config.IgnoredUsers, 2)
+	assert.Equal(t, "BOT_USER_1", config.IgnoredUsers[0].ID)
+	assert.Equal(t, "BOT_USER_2", config.IgnoredUsers[1].ID)
+}
+
+func TestNewConfig_ManualIgnoredUsersTakePrecedence(t *testing.T) {
+	mockClient := &MockPagerDutyClient{
+		EscalationPolicyResponses: map[string]*pagerduty.EscalationPolicy{
+			"POLICY_REAL": {
+				APIObject: pagerduty.APIObject{ID: "POLICY_REAL"},
+				Name:      "OpenShift Escalation Policy",
+				EscalationRules: []pagerduty.EscalationRule{
+					{Targets: []pagerduty.APIObject{
+						{ID: "ONCALL_SCHED", Type: "schedule_reference"},
+					}},
+				},
+			},
+			"POLICY_SILENT": {
+				APIObject: pagerduty.APIObject{ID: "POLICY_SILENT"},
+				Name:      "Silent Test",
+				EscalationRules: []pagerduty.EscalationRule{
+					{Targets: []pagerduty.APIObject{
+						{ID: "BOT_USER_1", Type: "user_reference"},
+					}},
+				},
+			},
+		},
+	}
+	policies := map[string]string{
+		"default":        "POLICY_REAL",
+		"silent_default": "POLICY_SILENT",
+	}
+
+	config, err := NewConfigWithClient(mockClient, []string{"team1"}, policies, []string{"MANUAL_USER"})
+
+	assert.NoError(t, err)
+	assert.Len(t, config.IgnoredUsers, 1)
+	assert.Equal(t, "MANUAL_USER", config.IgnoredUsers[0].ID)
+}
+
+func TestNewConfig_AutoDiscoverNoSilentPolicies(t *testing.T) {
+	mockClient := &MockPagerDutyClient{
+		EscalationPolicyResponses: map[string]*pagerduty.EscalationPolicy{
+			"POLICY1": {
+				APIObject: pagerduty.APIObject{ID: "POLICY1"},
+				Name:      "Real Policy 1",
+				EscalationRules: []pagerduty.EscalationRule{
+					{Targets: []pagerduty.APIObject{
+						{ID: "SCHED1", Type: "schedule_reference"},
+					}},
+				},
+			},
+			"POLICY2": {
+				APIObject: pagerduty.APIObject{ID: "POLICY2"},
+				Name:      "Real Policy 2",
+				EscalationRules: []pagerduty.EscalationRule{
+					{Targets: []pagerduty.APIObject{
+						{ID: "SCHED2", Type: "schedule_reference"},
+					}},
+				},
+			},
+		},
+	}
+	policies := map[string]string{
+		"default":        "POLICY1",
+		"silent_default": "POLICY2",
+	}
+
+	config, err := NewConfigWithClient(mockClient, []string{"team1"}, policies, nil)
+
+	assert.NoError(t, err)
+	assert.Empty(t, config.IgnoredUsers)
+}
+
 func TestAcknowledgeIncident_Success(t *testing.T) {
 	mockClient := &MockPagerDutyClient{}
 	user := &pagerduty.User{
@@ -852,4 +963,183 @@ func TestGetUserOnCalls_MultiplePages(t *testing.T) {
 	assert.Equal(t, "USER3", onCalls[2].User.ID)
 	// Verify the mock was called 2 times
 	assert.Equal(t, 2, mockClient.CallCounts["ListOnCallsWithContext"])
+}
+
+func TestClassifyEscalationPolicy(t *testing.T) {
+	tests := []struct {
+		name     string
+		policy   *pagerduty.EscalationPolicy
+		expected string
+	}{
+		{
+			name: "policy with schedule_reference is REAL",
+			policy: &pagerduty.EscalationPolicy{
+				EscalationRules: []pagerduty.EscalationRule{
+					{Targets: []pagerduty.APIObject{
+						{ID: "SCHED1", Type: "schedule_reference"},
+					}},
+				},
+			},
+			expected: PolicyClassReal,
+		},
+		{
+			name: "policy with schedule_reference in later rule is REAL",
+			policy: &pagerduty.EscalationPolicy{
+				EscalationRules: []pagerduty.EscalationRule{
+					{Targets: []pagerduty.APIObject{
+						{ID: "BOT_USER", Type: "user_reference"},
+					}},
+					{Targets: []pagerduty.APIObject{
+						{ID: "ONCALL_SCHED", Type: "schedule_reference"},
+					}},
+				},
+			},
+			expected: PolicyClassReal,
+		},
+		{
+			name: "policy with mixed targets in one rule is REAL",
+			policy: &pagerduty.EscalationPolicy{
+				EscalationRules: []pagerduty.EscalationRule{
+					{Targets: []pagerduty.APIObject{
+						{ID: "BOT_USER", Type: "user_reference"},
+						{ID: "SCHED1", Type: "schedule_reference"},
+					}},
+				},
+			},
+			expected: PolicyClassReal,
+		},
+		{
+			name: "policy with only user_reference targets is SILENT",
+			policy: &pagerduty.EscalationPolicy{
+				EscalationRules: []pagerduty.EscalationRule{
+					{Targets: []pagerduty.APIObject{
+						{ID: "BOT_USER_1", Type: "user_reference"},
+					}},
+					{Targets: []pagerduty.APIObject{
+						{ID: "BOT_USER_2", Type: "user_reference"},
+					}},
+				},
+			},
+			expected: PolicyClassSilent,
+		},
+		{
+			name: "policy with empty escalation rules is SILENT",
+			policy: &pagerduty.EscalationPolicy{
+				EscalationRules: []pagerduty.EscalationRule{},
+			},
+			expected: PolicyClassSilent,
+		},
+		{
+			name:     "nil policy is SILENT",
+			policy:   nil,
+			expected: PolicyClassSilent,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ClassifyEscalationPolicy(tt.policy)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExtractSilentPolicyUsers(t *testing.T) {
+	silentPolicy := &pagerduty.EscalationPolicy{
+		EscalationRules: []pagerduty.EscalationRule{
+			{Targets: []pagerduty.APIObject{
+				{ID: "BOT_USER_1", Type: "user_reference"},
+			}},
+			{Targets: []pagerduty.APIObject{
+				{ID: "BOT_USER_2", Type: "user_reference"},
+			}},
+		},
+	}
+	realPolicy := &pagerduty.EscalationPolicy{
+		EscalationRules: []pagerduty.EscalationRule{
+			{Targets: []pagerduty.APIObject{
+				{ID: "NOBODY_SREP", Type: "user_reference"},
+			}},
+			{Targets: []pagerduty.APIObject{
+				{ID: "ONCALL_SCHED", Type: "schedule_reference"},
+			}},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		policies map[string]*pagerduty.EscalationPolicy
+		expected []string
+	}{
+		{
+			name: "extracts users from SILENT policy",
+			policies: map[string]*pagerduty.EscalationPolicy{
+				"SILENT_DEFAULT": silentPolicy,
+			},
+			expected: []string{"BOT_USER_1", "BOT_USER_2"},
+		},
+		{
+			name: "skips REAL policy users",
+			policies: map[string]*pagerduty.EscalationPolicy{
+				"DEFAULT":        realPolicy,
+				"SILENT_DEFAULT": silentPolicy,
+			},
+			expected: []string{"BOT_USER_1", "BOT_USER_2"},
+		},
+		{
+			name: "all REAL policies returns empty",
+			policies: map[string]*pagerduty.EscalationPolicy{
+				"DEFAULT": realPolicy,
+			},
+			expected: nil,
+		},
+		{
+			name: "deduplicates across rules",
+			policies: map[string]*pagerduty.EscalationPolicy{
+				"SILENT_DEFAULT": {
+					EscalationRules: []pagerduty.EscalationRule{
+						{Targets: []pagerduty.APIObject{
+							{ID: "BOT_USER_1", Type: "user_reference"},
+						}},
+						{Targets: []pagerduty.APIObject{
+							{ID: "BOT_USER_1", Type: "user_reference"},
+						}},
+					},
+				},
+			},
+			expected: []string{"BOT_USER_1"},
+		},
+		{
+			name: "union across multiple SILENT policies",
+			policies: map[string]*pagerduty.EscalationPolicy{
+				"SILENT_DEFAULT": silentPolicy,
+				"DMS_SILENT": {
+					EscalationRules: []pagerduty.EscalationRule{
+						{Targets: []pagerduty.APIObject{
+							{ID: "BOT_USER_2", Type: "user_reference"},
+							{ID: "BOT_USER_3", Type: "user_reference"},
+						}},
+					},
+				},
+			},
+			expected: []string{"BOT_USER_1", "BOT_USER_2", "BOT_USER_3"},
+		},
+		{
+			name:     "empty map returns nil",
+			policies: map[string]*pagerduty.EscalationPolicy{},
+			expected: nil,
+		},
+		{
+			name:     "nil map returns nil",
+			policies: nil,
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ExtractSilentPolicyUsers(tt.policies)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Closes #269

- Adds `ClassifyEscalationPolicy()` — classifies policies as REAL (has `schedule_reference` targets) or SILENT (only `user_reference` targets)
- Adds `ExtractSilentPolicyUsers()` — extracts deduplicated bot user IDs from all SILENT policies
- Wires auto-discovery into `NewConfigWithClient`: when `ignoredusers` is absent, auto-discovers from silent policies; when present, uses manual list with deprecation warning
- Adds `ignoredusers` to the deprecation registry
- Enhances mock with `EscalationPolicyResponses` for testing policies with escalation rules

## Test plan

- [x] 16 new unit tests (6 classify, 7 extract, 3 auto-discovery integration)
- [x] All existing tests pass unchanged
- [x] `make test-all` passes (fmt, vet, lint, test, race)
- [x] Manual test: removed `ignoredusers` from config → auto-discovery produces same incident list
- [x] Manual test: kept `ignoredusers` → deprecation warning logged, still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)