### PR TITLE
Remove ignoredusers from config template and help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ SREPD reads `~/.config/srepd/srepd.yaml` and supports `SREPD_` environment varia
 | `editor` | `string` | `vim` | Editor for incident notes |
 | `terminal` | `string` | `gnome-terminal` | Terminal emulator for cluster login |
 | `cluster_login_command` | `string` | `ocm backplane login %%CLUSTER_ID%%` | Cluster login command |
-| `ignoredusers` | `[]string` | (auto-discovered) | **Deprecated.** PagerDuty user IDs to exclude. Now auto-discovered from silent escalation policies. Remove from config to use auto-discovery. |
 | `toolbox_mode` | `string` | `auto` | Toolbox detection: `auto`, `true`, or `false` |
 | `chord_prefix` | `string` | `ctrl+x` | Prefix key for chord commands |
 | `colors` | `map[string]string` | (defaults) | Custom color scheme (hex values) |

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -59,10 +59,6 @@ service_escalation_policies:
   <PagerDuty Service ID 1>: <PagerDuty Escalation Policy ID 3>
 
 # Optional configuration options
-# User to ignore - Alerts assigned to these users are ignored
-ignoredusers:
-  - <PagerDuty User ID 1>
-  - <PagerDuty User ID 2>
 
 # Editor to use for notes
 editor: vim
@@ -107,7 +103,6 @@ var (
 		"chord_prefix":          "ctrl+x",
 	}
 	optionalKeys = map[string]string{
-		"ignoredusers":          fmt.Sprintf("PagerDuty user IDs to ignore (default: %v)", "None"),
 		"editor":                fmt.Sprintf("Editor to use for notes (default: %v)", defaultOptionalKeys["editor"]),
 		"terminal":              fmt.Sprintf("Terminal to use for exec commands (default: %v)", defaultOptionalKeys["terminal"]),
 		"cluster_login_command": fmt.Sprintf("Cluster login command (default: %v)", defaultOptionalKeys["cluster-login-command"]),

--- a/docs/plans/084-remove-ignoredusers-config.md
+++ b/docs/plans/084-remove-ignoredusers-config.md
@@ -1,0 +1,17 @@
+# 084: Remove ignoredusers from config template and help
+
+Follow-up to #276 (083-replace-ignoredusers).
+
+## Problem
+
+After #276 added auto-discovery of ignored users from silent escalation
+policies, the `config --create` template, optional keys help text, and
+README config table still referenced `ignoredusers`.
+
+## Changes
+
+- Remove `ignoredusers` from example config in `cmd/config.go`
+- Remove `ignoredusers` from `optionalKeys` help map in `cmd/config.go`
+- Remove `ignoredusers` row from README config table
+
+The key is still accepted at runtime via the deprecation path in #276.


### PR DESCRIPTION
## Summary

Follow-up to #276. Now that ignored users are auto-discovered from silent escalation policies, remove `ignoredusers` from:

- The example config generated by `config --create`
- The `optionalKeys` help map used by `config --validate`

The `ignoredusers` key is still accepted at runtime (backward compatible via the deprecation path in #276), but new configs will no longer include it.

## Test plan

- [x] `go test ./...` passes
- [x] `config --create` no longer includes `ignoredusers` in generated config
- [x] `config --validate` no longer lists `ignoredusers` as an optional key

🤖 Generated with [Claude Code](https://claude.com/claude-code)