### PR TITLE
Fix issues #281, #282, #289, #290, #292

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,6 @@ Press `h` to toggle the help overlay inside srepd.
 | `ctrl+q`/`ctrl+c` | Quit | `1`-`9` | Select cluster |
 | `i`/`:` | Ask Claude | `m` | Merge incident |
 | `ctrl+x` + key | Chord commands | `ctrl+x ?` | Show chord help |
-| `ctrl+x s` | Bulk silence | | |
 | `Tab`/`Shift+Tab`/`←`/`→` | Switch tabs (incident view) | `↑`/`↓` | Scroll within tab |
 
 Chord commands use a configurable prefix (default `ctrl+x`) followed by a second key. Set `chord_prefix` in config to change.

--- a/README.md
+++ b/README.md
@@ -142,7 +142,8 @@ Press `h` to toggle the help overlay inside srepd.
 | `ctrl+q`/`ctrl+c` | Quit | `1`-`9` | Select cluster |
 | `i`/`:` | Ask Claude | `m` | Merge incident |
 | `ctrl+x` + key | Chord commands | `ctrl+x ?` | Show chord help |
-| `Tab`/`Shift+Tab` | Switch tabs (incident view) | `↑`/`↓` | Scroll within tab |
+| `ctrl+x s` | Bulk silence | | |
+| `Tab`/`Shift+Tab`/`←`/`→` | Switch tabs (incident view) | `↑`/`↓` | Scroll within tab |
 
 Chord commands use a configurable prefix (default `ctrl+x`) followed by a second key. Set `chord_prefix` in config to change.
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,7 @@ THE SOFTWARE.
 package cmd
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -84,6 +85,10 @@ but rather a simple tool to make on-call tasks easier.`,
 		if err != nil {
 			log.Fatal(err)
 		}
+
+		if _, err := autoCommentOldPolicies(configFile); err != nil {
+			log.Warn("Failed to auto-migrate old config format", "error", err)
+		}
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 
@@ -102,6 +107,33 @@ but rather a simple tool to make on-call tasks easier.`,
 
 		launchTUI()
 	},
+}
+
+func autoCommentOldPolicies(configFile string) (bool, error) {
+	data, err := os.ReadFile(configFile)
+	if err != nil {
+		return false, fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	content := string(data)
+	hasOld := strings.Contains(content, "\nservice_escalation_policies:") || strings.HasPrefix(content, "service_escalation_policies:")
+	hasNew := strings.Contains(content, "default_silent_escalation_policy:")
+
+	if !hasOld || !hasNew {
+		return false, nil
+	}
+
+	migrated := pkgconfig.CommentOutOldPolicies(data)
+	if bytes.Equal(data, migrated) {
+		return false, nil
+	}
+
+	if err := os.WriteFile(configFile, migrated, 0644); err != nil {
+		return false, fmt.Errorf("failed to write migrated config: %w", err)
+	}
+
+	log.Info("Auto-commented deprecated service_escalation_policies block")
+	return true, nil
 }
 
 func launchTUI() {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -444,6 +444,78 @@ func TestJournalWriter_Write(t *testing.T) {
 	}
 }
 
+func TestAutoCommentOldPolicies_BothFormatsPresent(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "srepd.yaml")
+
+	content := `token: my-token
+teams:
+  - TEAM1
+service_escalation_policies:
+  SILENT_DEFAULT: PCGXUDY
+  DEFAULT: PA4586M
+default_silent_escalation_policy: PCGXUDY
+`
+	err := os.WriteFile(configFile, []byte(content), 0644)
+	require.NoError(t, err)
+
+	changed, err := autoCommentOldPolicies(configFile)
+	require.NoError(t, err)
+	assert.True(t, changed, "should report that changes were made")
+
+	result, err := os.ReadFile(configFile)
+	require.NoError(t, err)
+	output := string(result)
+
+	assert.NotContains(t, output, "\nservice_escalation_policies:", "old block should be commented out")
+	assert.Contains(t, output, "# service_escalation_policies:", "old block should be commented")
+	assert.Contains(t, output, "default_silent_escalation_policy: PCGXUDY", "new format should be preserved")
+}
+
+func TestAutoCommentOldPolicies_NoOldFormat(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "srepd.yaml")
+
+	content := `token: my-token
+teams:
+  - TEAM1
+default_silent_escalation_policy: PCGXUDY
+`
+	err := os.WriteFile(configFile, []byte(content), 0644)
+	require.NoError(t, err)
+
+	changed, err := autoCommentOldPolicies(configFile)
+	require.NoError(t, err)
+	assert.False(t, changed, "should report no changes when old format absent")
+
+	result, err := os.ReadFile(configFile)
+	require.NoError(t, err)
+	assert.Equal(t, content, string(result), "file should not be modified")
+}
+
+func TestAutoCommentOldPolicies_OnlyOldFormat(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "srepd.yaml")
+
+	content := `token: my-token
+teams:
+  - TEAM1
+service_escalation_policies:
+  SILENT_DEFAULT: PCGXUDY
+  DEFAULT: PA4586M
+`
+	err := os.WriteFile(configFile, []byte(content), 0644)
+	require.NoError(t, err)
+
+	changed, err := autoCommentOldPolicies(configFile)
+	require.NoError(t, err)
+	assert.False(t, changed, "should not migrate when new format is absent")
+
+	result, err := os.ReadFile(configFile)
+	require.NoError(t, err)
+	assert.Equal(t, content, string(result), "file should not be modified when only old format exists")
+}
+
 func TestJournalWriter_WriteReturnsCorrectLength(t *testing.T) {
 	if !journal.Enabled() {
 		t.Skip("systemd journal not available")

--- a/docs/plans/090-multi-issue-bugfixes.md
+++ b/docs/plans/090-multi-issue-bugfixes.md
@@ -1,0 +1,49 @@
+# Plan 090: Multi-issue Bug Fixes (#281, #282, #289, #290, #292)
+
+## Summary
+
+Five bug fixes in a single PR addressing crash, rendering, navigation, config migration, and bulk silence issues.
+
+## Issues Fixed
+
+### #289 — Panic in rebuildMergeTable
+- **Root cause**: `SetRows()` called before `SetColumns()` on a fresh mergeTable, causing index-out-of-range in renderRow
+- **Fix**: Swap call order in `pkg/tui/merge.go` so columns exist before rows are rendered
+
+### #290 — Multi-paragraph note blockquoting
+- **Root cause**: Template used `> {{ .Note.Content }}` which only blockquotes the first line
+- **Fix**: Add `blockquote` template function that prefixes every line with `> `, returning `template.HTML` to avoid html/template escaping
+
+### #281 — Arrow key tab navigation in incident view
+- **Root cause**: Left/right arrow keys not bound to TabPrev/TabNext
+- **Fix**: Add `"left"` and `"right"` keys to TabPrev/TabNext bindings in keymap
+
+### #292 — Auto-comment old config format on startup
+- **Root cause**: `CommentOutOldPolicies()` only ran during `srepd config`, not normal startup
+- **Fix**: Add `autoCommentOldPolicies()` in PreRun that detects both old and new format coexistence and comments out the old block
+
+### #282 — Bulk silence adjustments
+- **Root cause**: No UI trigger for bulk silence; hardcoded default policy ignoring per-service mappings
+- **Fix**: Add `ctrl+x s` chord, multi-select form (following teamSelectForm pattern), per-service policy lookup via `getEscalationPolicyKey()`, and confirmation prompt
+
+## Files Changed
+
+- `pkg/tui/merge.go` — swap SetColumns/SetRows order
+- `pkg/tui/views.go` — add blockquote function, bulk silence form view
+- `pkg/tui/keymap.go` — add left/right to tab bindings
+- `pkg/tui/chords.go` — add `s` chord for bulk silence
+- `pkg/tui/model.go` — add bulk silence state fields
+- `pkg/tui/msgHandlers.go` — add switchBulkSilenceFocusMode, dispatch case
+- `pkg/tui/tui.go` — add enterBulkSilenceMsg/bulkSilenceConfirmedMsg handlers, fix silenceIncidentsMsg per-service lookup
+- `pkg/tui/commands.go` — add message types
+- `cmd/root.go` — add autoCommentOldPolicies in PreRun
+
+## Test Plan
+
+- [x] TDD: all tests written before implementation
+- [x] `make test-all` passes (fmt-check, vet, lint, test, test-race)
+- [x] CI passes
+- [ ] Manual: press `m` on incident — no panic
+- [ ] Manual: view multi-paragraph note — all paragraphs blockquoted
+- [ ] Manual: left/right arrows switch tabs in incident view
+- [ ] Manual: `ctrl+x s` opens bulk silence multi-select

--- a/pkg/tui/chords.go
+++ b/pkg/tui/chords.go
@@ -20,10 +20,11 @@ type chordAction struct {
 var chordRegistry = []struct {
 	Key         string
 	Description string
+	Hidden      bool
 }{
 	{Key: "?", Description: "show chord help"},
 	{Key: "d", Description: "view debug log"},
-	{Key: "s", Description: "bulk silence"},
+	{Key: "s", Description: "bulk silence", Hidden: true},
 }
 
 // getChordActions returns the full chord action list with handlers attached.
@@ -85,6 +86,9 @@ func (k chordKeymap) ShortHelp() []key.Binding {
 func (k chordKeymap) FullHelp() [][]key.Binding {
 	var bindings []key.Binding
 	for _, entry := range chordRegistry {
+		if entry.Hidden {
+			continue
+		}
 		bindings = append(bindings, key.NewBinding(
 			key.WithKeys(k.prefix+" "+entry.Key),
 			key.WithHelp(k.prefix+" "+entry.Key, entry.Description),
@@ -102,10 +106,15 @@ func chordViewLog(m model) (tea.Model, tea.Cmd) {
 func chordHelpText(prefix string) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "Chords (%s + key): ", prefix)
-	for i, entry := range chordRegistry {
-		if i > 0 {
+	first := true
+	for _, entry := range chordRegistry {
+		if entry.Hidden {
+			continue
+		}
+		if !first {
 			b.WriteString(", ")
 		}
+		first = false
 		fmt.Fprintf(&b, "%s=%s", entry.Key, entry.Description)
 	}
 	return b.String()
@@ -129,6 +138,9 @@ func chordHelpBindings() []key.Binding {
 	prefix := "ctrl+x"
 	var bindings []key.Binding
 	for _, entry := range chordRegistry {
+		if entry.Hidden {
+			continue
+		}
 		bindings = append(bindings, key.NewBinding(
 			key.WithKeys(prefix+" "+entry.Key),
 			key.WithHelp(prefix+" "+entry.Key, entry.Description),

--- a/pkg/tui/chords.go
+++ b/pkg/tui/chords.go
@@ -23,6 +23,7 @@ var chordRegistry = []struct {
 }{
 	{Key: "?", Description: "show chord help"},
 	{Key: "d", Description: "view debug log"},
+	{Key: "s", Description: "bulk silence"},
 }
 
 // getChordActions returns the full chord action list with handlers attached.
@@ -32,6 +33,7 @@ func getChordActions() []chordAction {
 	handlers := map[string]func(m model) (tea.Model, tea.Cmd){
 		"?": chordShowHelp,
 		"d": chordViewLog,
+		"s": chordBulkSilence,
 	}
 
 	var actions []chordAction
@@ -107,6 +109,15 @@ func chordHelpText(prefix string) string {
 		fmt.Fprintf(&b, "%s=%s", entry.Key, entry.Description)
 	}
 	return b.String()
+}
+
+// chordBulkSilence enters the bulk-silence incident selection mode.
+func chordBulkSilence(m model) (tea.Model, tea.Cmd) {
+	if len(m.incidentList) == 0 {
+		m.setStatus("no incidents to silence")
+		return m, nil
+	}
+	return m, func() tea.Msg { return enterBulkSilenceMsg{} }
 }
 
 // chordHelpBindings generates key.Binding entries for the help display.

--- a/pkg/tui/chords_test.go
+++ b/pkg/tui/chords_test.go
@@ -322,13 +322,18 @@ func TestChordKeymap_ImplementsHelpKeyMap(t *testing.T) {
 		km := chordKeymap{prefix: "ctrl+x"}
 		full := km.FullHelp()
 		assert.NotEmpty(t, full, "FullHelp should return at least one column")
-		// Should have bindings for each chord registry entry
 		totalBindings := 0
 		for _, col := range full {
 			totalBindings += len(col)
 		}
-		assert.GreaterOrEqual(t, totalBindings, len(chordRegistry),
-			"FullHelp should have at least as many bindings as chord registry entries")
+		visibleCount := 0
+		for _, entry := range chordRegistry {
+			if !entry.Hidden {
+				visibleCount++
+			}
+		}
+		assert.GreaterOrEqual(t, totalBindings, visibleCount,
+			"FullHelp should have at least as many bindings as visible chord registry entries")
 	})
 }
 

--- a/pkg/tui/chords_test.go
+++ b/pkg/tui/chords_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"testing"
 
+	"github.com/PagerDuty/go-pagerduty"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
 )
@@ -356,6 +357,44 @@ func TestChord_WorksInIncidentViewMode(t *testing.T) {
 
 		assert.True(t, updatedModel.chordPending,
 			"chordPending should be set in incident view mode")
+	})
+}
+
+func TestChordBulkSilence_Registered(t *testing.T) {
+	t.Run("bulk silence chord is registered", func(t *testing.T) {
+		action := resolveChord("s")
+		assert.NotNil(t, action, "resolveChord should return an action for 's'")
+		assert.Equal(t, "s", action.Key)
+		assert.Equal(t, "bulk silence", action.Description)
+	})
+}
+
+func TestChordBulkSilence_NoIncidents(t *testing.T) {
+	t.Run("bulk silence with no incidents shows status", func(t *testing.T) {
+		m := createTestModel()
+		m.incidentList = nil
+
+		result, cmd := chordBulkSilence(m)
+		updated := result.(model)
+
+		assert.Contains(t, updated.status, "no incidents")
+		assert.Nil(t, cmd)
+	})
+}
+
+func TestChordBulkSilence_WithIncidents(t *testing.T) {
+	t.Run("bulk silence with incidents returns enterBulkSilenceMsg", func(t *testing.T) {
+		m := createTestModel()
+		m.incidentList = []pagerduty.Incident{
+			{APIObject: pagerduty.APIObject{ID: "Q123"}, Title: "Test"},
+		}
+
+		_, cmd := chordBulkSilence(m)
+		assert.NotNil(t, cmd, "should return a command")
+
+		msg := cmd()
+		_, ok := msg.(enterBulkSilenceMsg)
+		assert.True(t, ok, "command should produce enterBulkSilenceMsg, got %T", msg)
 	})
 }
 

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -730,6 +730,10 @@ type silenceSelectedIncidentMsg struct{}
 type silenceIncidentsMsg struct {
 	incidents []pagerduty.Incident
 }
+type enterBulkSilenceMsg struct{}
+type bulkSilenceConfirmedMsg struct {
+	incidents []pagerduty.Incident
+}
 
 var errSilenceIncidentInvalidArgs = errors.New("silenceIncidents: invalid arguments")
 

--- a/pkg/tui/commands_test.go
+++ b/pkg/tui/commands_test.go
@@ -2672,3 +2672,20 @@ func TestRenderIncident_NilRenderer(t *testing.T) {
 	assert.NotEmpty(t, msg.content, "content should not be empty (plain text fallback)")
 	assert.Contains(t, msg.content, "Q456", "plain text content should contain incident ID")
 }
+
+func TestGetEscalationPolicyKey_CustomPolicy(t *testing.T) {
+	policies := map[string]*pagerduty.EscalationPolicy{
+		"silent_default": {APIObject: pagerduty.APIObject{ID: "POL_DEFAULT"}},
+		"SVC_ABC":        {APIObject: pagerduty.APIObject{ID: "POL_CUSTOM"}},
+	}
+
+	t.Run("returns service-specific key when custom policy exists", func(t *testing.T) {
+		key := getEscalationPolicyKey("SVC_ABC", policies)
+		assert.Equal(t, "SVC_ABC", key)
+	})
+
+	t.Run("returns silent_default when no custom policy exists", func(t *testing.T) {
+		key := getEscalationPolicyKey("SVC_XYZ", policies)
+		assert.Equal(t, silentDefaultPolicyKey, key)
+	})
+}

--- a/pkg/tui/keymap.go
+++ b/pkg/tui/keymap.go
@@ -188,12 +188,12 @@ var defaultKeyMap = keymap{
 		key.WithHelp("m", "merge incident"),
 	),
 	TabNext: key.NewBinding(
-		key.WithKeys("tab"),
-		key.WithHelp("tab", "next tab"),
+		key.WithKeys("tab", "right"),
+		key.WithHelp("tab/→", "next tab"),
 	),
 	TabPrev: key.NewBinding(
-		key.WithKeys("shift+tab"),
-		key.WithHelp("shift+tab", "prev tab"),
+		key.WithKeys("shift+tab", "left"),
+		key.WithHelp("shift+tab/←", "prev tab"),
 	),
 }
 

--- a/pkg/tui/keymap_test.go
+++ b/pkg/tui/keymap_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -205,4 +206,30 @@ func getBindingFieldName(binding key.Binding) string {
 	}
 
 	return ""
+}
+
+func TestTabNavigation_ArrowKeys(t *testing.T) {
+	t.Run("left arrow matches TabPrev", func(t *testing.T) {
+		msg := tea.KeyMsg{Type: tea.KeyLeft}
+		assert.True(t, key.Matches(msg, defaultKeyMap.TabPrev),
+			"left arrow should match TabPrev binding")
+	})
+
+	t.Run("right arrow matches TabNext", func(t *testing.T) {
+		msg := tea.KeyMsg{Type: tea.KeyRight}
+		assert.True(t, key.Matches(msg, defaultKeyMap.TabNext),
+			"right arrow should match TabNext binding")
+	})
+
+	t.Run("tab still matches TabNext", func(t *testing.T) {
+		msg := tea.KeyMsg{Type: tea.KeyTab}
+		assert.True(t, key.Matches(msg, defaultKeyMap.TabNext),
+			"tab should still match TabNext binding")
+	})
+
+	t.Run("shift+tab still matches TabPrev", func(t *testing.T) {
+		msg := tea.KeyMsg{Type: tea.KeyShiftTab}
+		assert.True(t, key.Matches(msg, defaultKeyMap.TabPrev),
+			"shift+tab should still match TabPrev binding")
+	})
 }

--- a/pkg/tui/merge.go
+++ b/pkg/tui/merge.go
@@ -53,8 +53,8 @@ func (m *model) rebuildMergeTable() {
 	}
 
 	m.mergeTable.SetStyles(m.styles.Table)
-	m.mergeTable.SetRows(rows)
 	m.mergeTable.SetColumns(m.table.Columns())
+	m.mergeTable.SetRows(rows)
 	m.mergeTable.SetHeight(m.table.Height())
 	m.mergeTable.Focus()
 }

--- a/pkg/tui/merge_test.go
+++ b/pkg/tui/merge_test.go
@@ -119,6 +119,50 @@ func TestMergeMode_ExcludesSourceFromList(t *testing.T) {
 	})
 }
 
+func TestRebuildMergeTable_NoPanic(t *testing.T) {
+	t.Run("rebuildMergeTable does not panic when columns are unset on mergeTable", func(t *testing.T) {
+		m := createTestModel()
+		m.config = &pd.Config{
+			Client: &pd.MockPagerDutyClient{},
+			CurrentUser: &pagerduty.User{
+				APIObject: pagerduty.APIObject{ID: "USER1"},
+				Email:     "test@example.com",
+			},
+		}
+		m.mergeSourceIncident = &pagerduty.Incident{
+			APIObject: pagerduty.APIObject{ID: "Q123"},
+		}
+		m.incidentList = []pagerduty.Incident{
+			{APIObject: pagerduty.APIObject{ID: "Q123"}, Title: "Source"},
+			{
+				APIObject: pagerduty.APIObject{ID: "Q456"},
+				Title:     "Target",
+				Service:   pagerduty.APIObject{Summary: "svc"},
+			},
+		}
+
+		cols := []table.Column{
+			{Title: "", Width: 1},
+			{Title: "ID", Width: 16},
+			{Title: "Title", Width: 40},
+			{Title: "Service", Width: 30},
+		}
+		rows := []table.Row{
+			{".", "Q123", "Source", "svc"},
+			{".", "Q456", "Target", "svc"},
+		}
+		m.table = table.New(table.WithColumns(cols), table.WithRows(rows), table.WithFocused(true))
+		m.mergeTeamMode = true
+		m.mergeTable = newTableWithStyles()
+
+		assert.NotPanics(t, func() {
+			m.rebuildMergeTable()
+		}, "rebuildMergeTable should not panic")
+
+		assert.Equal(t, len(cols), len(m.mergeTable.Columns()), "mergeTable should have same columns as main table")
+	})
+}
+
 func TestMergedIncidentMsg_HandledInModel(t *testing.T) {
 	t.Run("mergedIncidentMsg produces flash notification", func(t *testing.T) {
 		m := createTestModel()

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -129,6 +129,11 @@ type model struct {
 	mergeTable          table.Model
 	mergeTeamMode       bool
 
+	// Bulk silence state — triggered via chord ctrl+x s
+	bulkSilenceMode bool
+	bulkSilenceForm *huh.Form
+	bulkSilenceIDs  []string
+
 	// Team selection state — shown on first run or via --pick-teams
 	teamSelectMode  bool
 	teamSelectForm  *huh.Form

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -160,6 +160,9 @@ func (m model) keyMsgHandler(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case m.configMode:
 		return switchConfigFocusMode(m, msg)
 
+	case m.bulkSilenceMode:
+		return switchBulkSilenceFocusMode(m, msg)
+
 	case m.teamSelectMode:
 		return switchTeamSelectFocusMode(m, msg)
 
@@ -186,6 +189,49 @@ func (m model) keyMsgHandler(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	return m, nil
+}
+
+func switchBulkSilenceFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
+	form, cmd := m.bulkSilenceForm.Update(msg)
+	if f, ok := form.(*huh.Form); ok {
+		m.bulkSilenceForm = f
+	}
+	if m.bulkSilenceForm.State == huh.StateCompleted {
+		m.bulkSilenceMode = false
+		m.table.Focus()
+
+		if len(m.bulkSilenceIDs) == 0 {
+			m.setStatus("no incidents selected for silence")
+			return m, nil
+		}
+
+		var selected []pagerduty.Incident
+		idSet := make(map[string]bool)
+		for _, id := range m.bulkSilenceIDs {
+			idSet[id] = true
+		}
+		for _, inc := range m.incidentList {
+			if idSet[inc.ID] {
+				selected = append(selected, inc)
+			}
+		}
+
+		incidentIDs := strings.Join(m.bulkSilenceIDs, ", ")
+		m.pendingConfirmation = &confirmActionState{
+			prompt: fmt.Sprintf("Silence %d incident(s): %s? [y/n]", len(selected), incidentIDs),
+			action: func() tea.Msg {
+				return bulkSilenceConfirmedMsg{incidents: selected}
+			},
+		}
+		return m, nil
+	}
+	if m.bulkSilenceForm.State == huh.StateAborted {
+		m.bulkSilenceMode = false
+		m.table.Focus()
+		m.setStatus("bulk silence cancelled")
+		return m, nil
+	}
+	return m, cmd
 }
 
 func switchTeamSelectFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {

--- a/pkg/tui/msgHandlers_test.go
+++ b/pkg/tui/msgHandlers_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 	"github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/huh"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -902,5 +903,69 @@ func TestErrorMode_NonEscapeKeysDoNotClearError(t *testing.T) {
 
 		assert.NotNil(t, updatedModel.err, "error should NOT be cleared by non-Escape key")
 		assert.Nil(t, cmd, "no command should be returned")
+	})
+}
+
+func TestBulkSilenceMode_AbortExitsMode(t *testing.T) {
+	t.Run("aborted form exits bulk silence mode", func(t *testing.T) {
+		m := createTestModel()
+		m.bulkSilenceMode = true
+
+		form := huh.NewForm(
+			huh.NewGroup(
+				huh.NewMultiSelect[string]().
+					Title("test").
+					Options(huh.NewOption("test", "Q123")).
+					Value(&m.bulkSilenceIDs),
+			),
+		)
+		m.bulkSilenceForm = form
+		m.bulkSilenceForm.Init()
+		m.bulkSilenceForm.State = huh.StateAborted
+
+		keyMsg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}}
+		result, _ := switchBulkSilenceFocusMode(m, keyMsg)
+		updated := result.(model)
+
+		assert.False(t, updated.bulkSilenceMode, "should exit bulk silence mode")
+		assert.Contains(t, updated.status, "cancelled")
+	})
+}
+
+func TestBulkSilenceMode_ConfirmationPrompt(t *testing.T) {
+	t.Run("completing form with selections shows confirmation prompt", func(t *testing.T) {
+		m := createTestModel()
+		m.bulkSilenceMode = true
+		m.incidentList = []pagerduty.Incident{
+			{APIObject: pagerduty.APIObject{ID: "Q123"}, Title: "Test 1"},
+			{APIObject: pagerduty.APIObject{ID: "Q456"}, Title: "Test 2"},
+		}
+		m.bulkSilenceIDs = []string{"Q123", "Q456"}
+
+		form := huh.NewForm(
+			huh.NewGroup(
+				huh.NewMultiSelect[string]().
+					Title("test").
+					Options(
+						huh.NewOption("test1", "Q123"),
+						huh.NewOption("test2", "Q456"),
+					).
+					Value(&m.bulkSilenceIDs),
+			),
+		)
+		m.bulkSilenceForm = form
+		m.bulkSilenceForm.Init()
+
+		// Simulate form completion by setting state
+		m.bulkSilenceForm.State = huh.StateCompleted
+
+		// Send any key to trigger the handler
+		keyMsg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}}
+		result, _ := switchBulkSilenceFocusMode(m, keyMsg)
+		updated := result.(model)
+
+		assert.False(t, updated.bulkSilenceMode, "should exit bulk silence mode")
+		assert.NotNil(t, updated.pendingConfirmation, "should show confirmation prompt")
+		assert.Contains(t, updated.pendingConfirmation.prompt, "2 incident(s)")
 	})
 }

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -1140,6 +1140,62 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			),
 		)
 
+	case enterBulkSilenceMsg:
+		var options []huh.Option[string]
+		for _, inc := range m.incidentList {
+			label := fmt.Sprintf("%s — %s — %s", inc.ID, inc.Service.Summary, inc.Title)
+			options = append(options, huh.NewOption(label, inc.ID))
+		}
+		if len(options) == 0 {
+			m.setStatus("no incidents to silence")
+			return m, nil
+		}
+		m.bulkSilenceIDs = nil
+
+		theme := huh.ThemeCharm()
+		theme.Focused.Title = theme.Focused.Title.Foreground(m.theme.Highlight)
+		theme.Focused.Description = theme.Focused.Description.Foreground(m.theme.Muted)
+		theme.Focused.SelectedOption = theme.Focused.SelectedOption.Foreground(m.theme.Highlight)
+		theme.Focused.UnselectedOption = theme.Focused.UnselectedOption.Foreground(m.theme.Text)
+		theme.Focused.MultiSelectSelector = theme.Focused.MultiSelectSelector.Foreground(m.theme.Text)
+		theme.Focused.SelectedPrefix = theme.Focused.SelectedPrefix.Foreground(m.theme.Highlight)
+		theme.Focused.UnselectedPrefix = theme.Focused.UnselectedPrefix.Foreground(m.theme.Muted)
+		theme.Focused.Base = theme.Focused.Base.BorderForeground(m.theme.Border)
+
+		m.bulkSilenceForm = huh.NewForm(
+			huh.NewGroup(
+				huh.NewMultiSelect[string]().
+					Title("Select incidents to silence").
+					Description("Space to toggle, a to select all, enter to confirm, esc to cancel").
+					Options(options...).
+					Filterable(true).
+					Value(&m.bulkSilenceIDs),
+			),
+		).WithTheme(theme).WithHeight(m.layout.TeamSelectFormHeight)
+		m.bulkSilenceMode = true
+		return m, m.bulkSilenceForm.Init()
+
+	case bulkSilenceConfirmedMsg:
+		if len(msg.incidents) == 0 {
+			m.setStatus("no incidents to silence")
+			return m, nil
+		}
+
+		var cmds []tea.Cmd
+		for _, inc := range msg.incidents {
+			policyKey := getEscalationPolicyKey(inc.Service.ID, m.config.EscalationPolicies)
+			policy := m.config.EscalationPolicies[policyKey]
+			cmds = append(cmds, silenceIncidents([]pagerduty.Incident{inc}, policy, silentDefaultPolicyLevel))
+		}
+
+		incidentIDs := strings.Join(getIDsFromIncidents(msg.incidents), " ")
+		cmds = append(cmds, func() tea.Msg { return clearSelectedIncidentsMsg("sender: bulkSilenceConfirmedMsg") })
+
+		return m, tea.Batch(
+			m.flashNotification(fmt.Sprintf("Silenced %s", incidentIDs)),
+			tea.Sequence(cmds...),
+		)
+
 	case silenceIncidentsMsg:
 		if msg.incidents == nil {
 			m.setStatus("failed silencing incidents - no incidents provided")
@@ -1151,14 +1207,19 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			incidents = append(msg.incidents, *m.selectedIncident)
 		}
 
+		var cmds []tea.Cmd
+		for _, inc := range incidents {
+			policyKey := getEscalationPolicyKey(inc.Service.ID, m.config.EscalationPolicies)
+			policy := m.config.EscalationPolicies[policyKey]
+			cmds = append(cmds, silenceIncidents([]pagerduty.Incident{inc}, policy, silentDefaultPolicyLevel))
+		}
+
 		incidentIDs := strings.Join(getIDsFromIncidents(incidents), " ")
+		cmds = append(cmds, func() tea.Msg { return clearSelectedIncidentsMsg("sender: silenceIncidentsMsg") })
 
 		return m, tea.Batch(
 			m.flashNotification(fmt.Sprintf("Silenced %s", incidentIDs)),
-			tea.Sequence(
-				silenceIncidents(incidents, m.config.EscalationPolicies["silent_default"], silentDefaultPolicyLevel),
-				func() tea.Msg { return clearSelectedIncidentsMsg("sender: silenceIncidentsMsg") },
-			),
+			tea.Sequence(cmds...),
 		)
 
 	case clearSelectedIncidentsMsg:

--- a/pkg/tui/update_test.go
+++ b/pkg/tui/update_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/PagerDuty/go-pagerduty"
 	"github.com/clcollins/srepd/pkg/launcher"
 	"github.com/clcollins/srepd/pkg/pd"
 	"github.com/stretchr/testify/assert"
@@ -337,5 +338,116 @@ func TestDevModeFieldSet(t *testing.T) {
 		m := teaModel.(model)
 
 		assert.True(t, m.devMode, "devMode should be true for InitialModelWithConfig")
+	})
+}
+
+func TestEnterBulkSilenceMsg_BuildsForm(t *testing.T) {
+	t.Run("enterBulkSilenceMsg creates multi-select form", func(t *testing.T) {
+		m := createTestModel()
+		m.config = &pd.Config{
+			Client:      &pd.MockPagerDutyClient{},
+			CurrentUser: &pagerduty.User{APIObject: pagerduty.APIObject{ID: "U1"}},
+		}
+		m.incidentList = []pagerduty.Incident{
+			{APIObject: pagerduty.APIObject{ID: "Q123"}, Title: "Alert 1", Service: pagerduty.APIObject{Summary: "SvcA"}},
+			{APIObject: pagerduty.APIObject{ID: "Q456"}, Title: "Alert 2", Service: pagerduty.APIObject{Summary: "SvcB"}},
+		}
+
+		result, cmd := m.Update(enterBulkSilenceMsg{})
+		updated := result.(model)
+
+		assert.True(t, updated.bulkSilenceMode, "should enter bulk silence mode")
+		assert.NotNil(t, updated.bulkSilenceForm, "form should be created")
+		assert.NotNil(t, cmd, "should return init command for form")
+	})
+
+	t.Run("enterBulkSilenceMsg with no incidents shows status", func(t *testing.T) {
+		m := createTestModel()
+		m.config = &pd.Config{
+			Client:      &pd.MockPagerDutyClient{},
+			CurrentUser: &pagerduty.User{APIObject: pagerduty.APIObject{ID: "U1"}},
+		}
+		m.incidentList = nil
+
+		result, _ := m.Update(enterBulkSilenceMsg{})
+		updated := result.(model)
+
+		assert.False(t, updated.bulkSilenceMode, "should not enter bulk silence mode")
+		assert.Contains(t, updated.status, "no incidents")
+	})
+}
+
+func TestBulkSilenceConfirmedMsg_PerServicePolicy(t *testing.T) {
+	t.Run("bulkSilenceConfirmedMsg uses per-service policy lookup", func(t *testing.T) {
+		m := createTestModel()
+		m.config = &pd.Config{
+			Client:      &pd.MockPagerDutyClient{},
+			CurrentUser: &pagerduty.User{APIObject: pagerduty.APIObject{ID: "U1"}},
+			EscalationPolicies: map[string]*pagerduty.EscalationPolicy{
+				"SILENT_DEFAULT": {APIObject: pagerduty.APIObject{ID: "POL_DEFAULT"}, Name: "Default Silent"},
+				"SVC_CUSTOM":     {APIObject: pagerduty.APIObject{ID: "POL_CUSTOM"}, Name: "Custom Silent"},
+			},
+		}
+
+		incidents := []pagerduty.Incident{
+			{APIObject: pagerduty.APIObject{ID: "Q123"}, Service: pagerduty.APIObject{ID: "SVC_CUSTOM", Summary: "Custom Svc"}},
+			{APIObject: pagerduty.APIObject{ID: "Q456"}, Service: pagerduty.APIObject{ID: "SVC_OTHER", Summary: "Other Svc"}},
+		}
+
+		result, cmd := m.Update(bulkSilenceConfirmedMsg{incidents: incidents})
+		updated := result.(model)
+
+		assert.NotNil(t, cmd, "should return batch command")
+		assert.Contains(t, updated.status, "Silenced")
+	})
+
+	t.Run("bulkSilenceConfirmedMsg with empty incidents shows status", func(t *testing.T) {
+		m := createTestModel()
+		m.config = &pd.Config{
+			Client:      &pd.MockPagerDutyClient{},
+			CurrentUser: &pagerduty.User{APIObject: pagerduty.APIObject{ID: "U1"}},
+		}
+
+		result, _ := m.Update(bulkSilenceConfirmedMsg{incidents: nil})
+		updated := result.(model)
+
+		assert.Contains(t, updated.status, "no incidents")
+	})
+}
+
+func TestSilenceIncidentsMsg_PerServicePolicy(t *testing.T) {
+	t.Run("silenceIncidentsMsg uses per-service policy lookup", func(t *testing.T) {
+		m := createTestModel()
+		m.config = &pd.Config{
+			Client:      &pd.MockPagerDutyClient{},
+			CurrentUser: &pagerduty.User{APIObject: pagerduty.APIObject{ID: "U1"}},
+			EscalationPolicies: map[string]*pagerduty.EscalationPolicy{
+				"SILENT_DEFAULT": {APIObject: pagerduty.APIObject{ID: "POL_DEFAULT"}, Name: "Default Silent"},
+				"SVC_CUSTOM":     {APIObject: pagerduty.APIObject{ID: "POL_CUSTOM"}, Name: "Custom Silent"},
+			},
+		}
+
+		incidents := []pagerduty.Incident{
+			{APIObject: pagerduty.APIObject{ID: "Q123"}, Service: pagerduty.APIObject{ID: "SVC_CUSTOM"}},
+		}
+
+		result, cmd := m.Update(silenceIncidentsMsg{incidents: incidents})
+		updated := result.(model)
+
+		assert.NotNil(t, cmd, "should return batch command")
+		assert.Contains(t, updated.status, "Silenced")
+	})
+
+	t.Run("silenceIncidentsMsg with nil incidents shows error", func(t *testing.T) {
+		m := createTestModel()
+		m.config = &pd.Config{
+			Client:      &pd.MockPagerDutyClient{},
+			CurrentUser: &pagerduty.User{APIObject: pagerduty.APIObject{ID: "U1"}},
+		}
+
+		result, _ := m.Update(silenceIncidentsMsg{incidents: nil})
+		updated := result.(model)
+
+		assert.Contains(t, updated.status, "failed silencing")
 	})
 }

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -726,6 +726,13 @@ var funcMap = template.FuncMap{
 		}
 		return url
 	},
+	"blockquote": func(s string) template.HTML {
+		lines := strings.Split(s, "\n")
+		for i, line := range lines {
+			lines[i] = "> " + template.HTMLEscapeString(line)
+		}
+		return template.HTML(strings.Join(lines, "\n"))
+	},
 }
 
 func renderIncidentMarkdown(m *model, content string) (string, error) {
@@ -895,7 +902,7 @@ const alertTabTemplate = `
 const noteTabTemplate = `
 ### Note {{ add1 .Index }}/{{ .Total }}
 
-> {{ .Note.Content }}
+{{ blockquote .Note.Content }}
 
 -- {{ .Note.User }} @ {{ .Note.Created }}
 `

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -61,6 +61,9 @@ func (m model) View() string {
 	case m.configModeRequested:
 		s.WriteString("  Loading configuration...")
 
+	case m.bulkSilenceMode:
+		s.WriteString(m.bulkSilenceForm.View())
+
 	case m.teamSelectMode:
 		s.WriteString(m.teamSelectForm.View())
 

--- a/pkg/tui/views_test.go
+++ b/pkg/tui/views_test.go
@@ -1316,3 +1316,70 @@ func TestRenderBottomStatus_Layout(t *testing.T) {
 		assert.NotContains(t, result, "An update is available", "should not show update notice")
 	})
 }
+
+func TestBlockquote(t *testing.T) {
+	bq := funcMap["blockquote"].(func(string) template.HTML)
+
+	tests := []struct {
+		name     string
+		input    string
+		expected template.HTML
+	}{
+		{
+			name:     "single line",
+			input:    "Hello world",
+			expected: "> Hello world",
+		},
+		{
+			name:     "multi-paragraph with blank line",
+			input:    "First paragraph.\n\nSecond paragraph.",
+			expected: "> First paragraph.\n> \n> Second paragraph.",
+		},
+		{
+			name:     "three lines no blank",
+			input:    "Line one\nLine two\nLine three",
+			expected: "> Line one\n> Line two\n> Line three",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "> ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := bq(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNoteTabTemplate_MultiParagraph(t *testing.T) {
+	tmpl, err := template.New("note").Funcs(funcMap).Parse(noteTabTemplate)
+	require.NoError(t, err)
+
+	data := struct {
+		Note  noteSummary
+		Index int
+		Total int
+	}{
+		Note: noteSummary{
+			Content: "First paragraph.\n\nSecond paragraph.",
+			User:    "testuser",
+			Created: "2025-01-01",
+		},
+		Index: 0,
+		Total: 1,
+	}
+
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, data)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "> First paragraph.")
+	assert.Contains(t, output, "> Second paragraph.")
+	assert.Contains(t, output, "-- testuser @ 2025-01-01", "attribution should be present")
+	assert.NotContains(t, output, "> -- testuser", "attribution should not be blockquoted")
+}


### PR DESCRIPTION
## Summary

Five bug fixes addressing crash, rendering, navigation, config migration, and bulk silence:

- **#289**: Fix panic in `rebuildMergeTable` — swap `SetColumns`/`SetRows` call order to prevent index-out-of-range crash when pressing merge key
- **#290**: Fix multi-paragraph note blockquoting — add `blockquote` template function so all note lines get `>` prefix
- **#281**: Add left/right arrow keys for tab switching in incident view
- **#292**: Auto-comment deprecated `service_escalation_policies` block on startup when new format config keys exist
- **#282**: Bulk silence improvements — per-service policy lookup, confirmation prompt, hidden chord trigger

## Test plan

- [x] All tests written before implementation (TDD)
- [x] `make test-all` passes (fmt-check, vet, lint, test, test-race)
- [ ] Press `m` on incident — no panic
- [ ] View multi-paragraph note — all paragraphs blockquoted
- [ ] Left/right arrows switch tabs in incident view
- [ ] Config with both old and new policy formats — old block auto-commented on startup

Closes #281, closes #282, closes #289, closes #290, closes #292

Created with assistance from Claude 🤖 <claude@anthropic.com>