### PR TITLE
Async OCM authentication to prevent blocking TUI startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ When running inside a Fedora Toolbox, terminal commands are automatically prefix
 
 ## OCM Integration
 
-SREPD enriches PagerDuty incident data with cluster details from the OpenShift Cluster Manager (OCM) API. On startup, it connects to the production OCM API using tokens from `~/.config/ocm/ocm.json`. If tokens are expired, a browser window opens for auth code login.
+SREPD enriches PagerDuty incident data with cluster details from the OpenShift Cluster Manager (OCM) API. On startup, it connects to the production OCM API using tokens from `~/.config/ocm/ocm.json`. If tokens are expired, a browser window opens for auth code login in the background — the TUI starts immediately with PagerDuty incidents visible, and OCM enrichment populates once authentication completes.
 
 Enriched data includes:
 * **Cluster display names** replace PD service names in the incident table (e.g., `mycluster.abc1.p1.example.org` instead of `osd-mycluster.abc1.p1.example.org-hive-cluster`)

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -69,14 +70,25 @@ func launchTUIWithConfig() {
 		log.Fatal(err)
 	}
 
-	ocmClient, ocmErr := ocm.NewClient(tui.Version)
-	if ocmErr != nil {
-		log.Warn("OCM connection failed", "error", ocmErr)
-	} else if ocmClient != nil {
-		defer ocmClient.Close()
-		log.Info("OCM connected")
+	var ocmClient ocm.OCMClient
+	var ocmAuthPending bool
+	var asyncOCMClient *ocm.Client
+
+	cfg, armed, checkErr := ocm.CheckTokens()
+	if checkErr != nil {
+		log.Warn("OCM config check failed", "error", checkErr)
+	} else if armed {
+		client, connErr := ocm.NewClientFromConfig(cfg, tui.Version)
+		if connErr != nil {
+			log.Warn("OCM connection failed", "error", connErr)
+		} else {
+			ocmClient = client
+			asyncOCMClient = client
+			log.Info("OCM connected")
+		}
 	} else {
-		log.Warn("OCM not configured")
+		ocmAuthPending = true
+		log.Info("OCM tokens not valid — will authenticate async")
 	}
 
 	m, _ := tui.InitialModel(
@@ -92,9 +104,31 @@ func launchTUIWithConfig() {
 		viper.GetString("default_silent_escalation_policy"),
 		viper.GetStringMapString("custom_service_escalation_policies"),
 		true, // configMode
+		ocmAuthPending,
 	)
 
 	p := tea.NewProgram(m, tea.WithAltScreen())
+
+	if ocmAuthPending {
+		go func() {
+			fmt.Fprintln(os.Stderr, "OCM tokens expired — opening browser for authentication...")
+			token, authErr := ocm.AuthenticateAsync(cfg)
+			if authErr != nil {
+				log.Debug("OCM browser auth failed", "error", authErr)
+				p.Send(tui.OCMClientReadyMsg{Err: authErr})
+				return
+			}
+			fmt.Fprintln(os.Stderr, "OCM authentication successful.")
+			ocm.ApplyAuthToken(cfg, token)
+			client, connErr := ocm.NewClientFromConfig(cfg, tui.Version)
+			if connErr != nil {
+				p.Send(tui.OCMClientReadyMsg{Err: connErr})
+				return
+			}
+			asyncOCMClient = client
+			p.Send(tui.OCMClientReadyMsg{Client: client})
+		}()
+	}
 
 	go func() {
 		for {
@@ -104,6 +138,11 @@ func launchTUIWithConfig() {
 	}()
 
 	_, err = p.Run()
+
+	if asyncOCMClient != nil {
+		asyncOCMClient.Close()
+	}
+
 	if err != nil {
 		fmt.Println(err)
 		log.Fatal(err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -111,14 +111,25 @@ func launchTUI() {
 		log.Fatal(err)
 	}
 
-	ocmClient, ocmErr := ocm.NewClient(tui.Version)
-	if ocmErr != nil {
-		log.Warn("OCM connection failed", "error", ocmErr)
-	} else if ocmClient != nil {
-		defer ocmClient.Close()
-		log.Info("OCM connected")
+	var ocmClient ocm.OCMClient
+	var ocmAuthPending bool
+	var asyncOCMClient *ocm.Client
+
+	cfg, armed, checkErr := ocm.CheckTokens()
+	if checkErr != nil {
+		log.Warn("OCM config check failed", "error", checkErr)
+	} else if armed {
+		client, connErr := ocm.NewClientFromConfig(cfg, tui.Version)
+		if connErr != nil {
+			log.Warn("OCM connection failed", "error", connErr)
+		} else {
+			ocmClient = client
+			asyncOCMClient = client
+			log.Info("OCM connected")
+		}
 	} else {
-		log.Warn("OCM not configured")
+		ocmAuthPending = true
+		log.Info("OCM tokens not valid — will authenticate async")
 	}
 
 	m, _ := tui.InitialModel(
@@ -134,9 +145,31 @@ func launchTUI() {
 		viper.GetString("default_silent_escalation_policy"),
 		viper.GetStringMapString("custom_service_escalation_policies"),
 		false,
+		ocmAuthPending,
 	)
 
 	p := tea.NewProgram(m, tea.WithAltScreen())
+
+	if ocmAuthPending {
+		go func() {
+			fmt.Fprintln(os.Stderr, "OCM tokens expired — opening browser for authentication...")
+			token, authErr := ocm.AuthenticateAsync(cfg)
+			if authErr != nil {
+				log.Debug("OCM browser auth failed", "error", authErr)
+				p.Send(tui.OCMClientReadyMsg{Err: authErr})
+				return
+			}
+			fmt.Fprintln(os.Stderr, "OCM authentication successful.")
+			ocm.ApplyAuthToken(cfg, token)
+			client, connErr := ocm.NewClientFromConfig(cfg, tui.Version)
+			if connErr != nil {
+				p.Send(tui.OCMClientReadyMsg{Err: connErr})
+				return
+			}
+			asyncOCMClient = client
+			p.Send(tui.OCMClientReadyMsg{Client: client})
+		}()
+	}
 
 	go func() {
 		for {
@@ -146,6 +179,11 @@ func launchTUI() {
 	}()
 
 	_, err = p.Run()
+
+	if asyncOCMClient != nil {
+		asyncOCMClient.Close()
+	}
+
 	if err != nil {
 		fmt.Println(err)
 		log.Fatal(err)

--- a/docs/plans/090-async-ocm-authentication.md
+++ b/docs/plans/090-async-ocm-authentication.md
@@ -1,0 +1,39 @@
+# Plan 090: Async OCM authentication (#279)
+
+## Problem
+
+When OCM tokens are expired, `ocm.NewClient()` calls `auth.InitiateAuthCode()`
+which opens a browser and blocks indefinitely until the user completes auth.
+This happens before the TUI starts — srepd appears hung while the user
+authenticates. PagerDuty incidents are invisible until auth completes.
+
+## Solution
+
+Split `ocm.NewClient()` into composable functions so token validity can be
+checked without blocking. If tokens are valid, connect synchronously (no UX
+change). If expired, launch the TUI immediately and run browser auth in a
+background goroutine that delivers the client via `p.Send()`.
+
+This follows the existing `pdClientInitializedMsg` pattern where a client is
+set on the model at runtime and follow-up commands are dispatched.
+
+## Changes
+
+| File | Change |
+|------|--------|
+| `pkg/ocm/client.go` | Split into `CheckTokens()`, `AuthenticateAsync()`, `ApplyAuthToken()`, `NewClientFromConfig()`, `applyConfigDefaults()`. Keep `NewClient()` as convenience wrapper |
+| `pkg/ocm/client_test.go` | New tests for CheckTokens, ApplyAuthToken, NewClientFromConfig |
+| `pkg/tui/commands.go` | Add exported `OCMClientReadyMsg` type |
+| `pkg/tui/model.go` | Add `ocmAuthPending` field + `InitialModel()` parameter |
+| `pkg/tui/tui.go` | Add `OCMClientReadyMsg` handler with retroactive enrichment |
+| `pkg/tui/views.go` | Differentiate "authenticating" vs "not connected" in 3 tab renderers |
+| `pkg/tui/ocm_enrichment_test.go` | 10 new tests for message handler and auth-pending views |
+| `cmd/root.go` | Split `launchTUI()` to use fast-path / async-auth |
+| `cmd/config.go` | Same split in `launchTUIWithConfig()` |
+
+## Verification
+
+- `make test-all` passes (fmt, vet, lint, unit tests, race detector)
+- Fast path: valid tokens connect synchronously, journal shows `ocm.NewClientFromConfig`
+- Async path: blanked tokens → TUI starts immediately, browser opens, auth completes → `OCM connected (async)` and enrichment fires
+- Both paths manually verified against live PagerDuty + OCM

--- a/pkg/ocm/client.go
+++ b/pkg/ocm/client.go
@@ -34,61 +34,72 @@ func sanitizeSearchValue(s string) string {
 	return strings.ReplaceAll(s, "'", "''")
 }
 
-// NewClient creates a real OCM client using the standard config file.
-// Always connects to production OCM. If no valid tokens exist, initiates
-// browser-based auth code login (same flow as ocm-container).
-func NewClient(agentVersion string) (*Client, error) {
+// CheckTokens loads the OCM config and checks if valid tokens exist.
+// Returns the config (with defaults applied), whether tokens are valid, and any error.
+// This is a fast, non-blocking operation.
+func CheckTokens() (*ocmconfig.Config, bool, error) {
 	cfg, err := ocmconfig.Load()
 	if err != nil {
-		log.Debug("ocm.NewClient", "msg", "OCM config not found, creating new", "error", err)
+		log.Debug("ocm.CheckTokens", "msg", "OCM config not found, creating new", "error", err)
 	}
 	if cfg == nil {
 		cfg = new(ocmconfig.Config)
 	}
 
-	cfg.URL = productionURL
-	if cfg.ClientID == "" {
-		cfg.ClientID = clientID
-	}
-	if cfg.TokenURL == "" {
-		cfg.TokenURL = sdk.DefaultTokenURL
-	}
-	if len(cfg.Scopes) == 0 {
-		cfg.Scopes = []string{"openid"}
-	}
+	applyConfigDefaults(cfg)
 
 	armed, reason, err := cfg.Armed()
 	if err != nil {
-		return nil, fmt.Errorf("ocm config check failed: %w", err)
+		return cfg, false, fmt.Errorf("ocm config check failed: %w", err)
 	}
 
 	if !armed {
-		log.Debug("ocm.NewClient", "msg", "not logged into OCM, initiating browser auth", "reason", reason)
-		fmt.Fprintln(os.Stderr, "OCM tokens expired — opening browser for authentication...")
-		token, authErr := auth.InitiateAuthCode(clientID)
-		if authErr != nil {
-			log.Debug("ocm.NewClient", "msg", "browser auth failed or cancelled", "error", authErr)
-			return nil, nil
-		}
-		fmt.Fprintln(os.Stderr, "OCM authentication successful.")
+		log.Debug("ocm.CheckTokens", "msg", "tokens not valid", "reason", reason)
+	}
 
-		if ocmconfig.IsEncryptedToken(token) {
-			cfg.AccessToken = ""
+	return cfg, armed, nil
+}
+
+// AuthenticateAsync performs browser-based auth code login.
+// This call blocks until the user completes authentication in the browser.
+// Returns the raw auth token string on success.
+func AuthenticateAsync(cfg *ocmconfig.Config) (string, error) {
+	cid := cfg.ClientID
+	if cid == "" {
+		cid = clientID
+	}
+	token, err := auth.InitiateAuthCode(cid)
+	if err != nil {
+		return "", err
+	}
+	return token, nil
+}
+
+// ApplyAuthToken classifies a raw auth token and sets the appropriate
+// field on the OCM config (RefreshToken or AccessToken).
+func ApplyAuthToken(cfg *ocmconfig.Config, token string) {
+	if ocmconfig.IsEncryptedToken(token) {
+		cfg.AccessToken = ""
+		cfg.RefreshToken = token
+		return
+	}
+	parsedToken, parseErr := ocmconfig.ParseToken(token)
+	if parseErr == nil {
+		typ, typErr := ocmconfig.TokenType(parsedToken)
+		if typErr == nil && (typ == "Refresh" || typ == "Offline") {
 			cfg.RefreshToken = token
-		} else {
-			parsedToken, parseErr := ocmconfig.ParseToken(token)
-			if parseErr == nil {
-				typ, typErr := ocmconfig.TokenType(parsedToken)
-				if typErr == nil && (typ == "Refresh" || typ == "Offline") {
-					cfg.RefreshToken = token
-					cfg.AccessToken = ""
-				} else {
-					cfg.AccessToken = token
-				}
-			} else {
-				cfg.AccessToken = token
-			}
+			cfg.AccessToken = ""
+			return
 		}
+	}
+	cfg.AccessToken = token
+}
+
+// NewClientFromConfig builds an OCM client from a pre-loaded config.
+// The config must already have valid tokens set.
+func NewClientFromConfig(cfg *ocmconfig.Config, agentVersion string) (*Client, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("ocm config is nil")
 	}
 
 	conn, err := ocmconn.NewConnection().
@@ -105,12 +116,49 @@ func NewClient(agentVersion string) (*Client, error) {
 		cfg.AccessToken = accessToken
 		cfg.RefreshToken = refreshToken
 		if saveErr := ocmconfig.Save(cfg); saveErr != nil {
-			log.Debug("ocm.NewClient", "msg", "failed to save OCM tokens", "error", saveErr)
+			log.Debug("ocm.NewClientFromConfig", "msg", "failed to save OCM tokens", "error", saveErr)
 		}
 	}
 
-	log.Debug("ocm.NewClient", "msg", "connected to OCM", "url", productionURL)
+	log.Debug("ocm.NewClientFromConfig", "msg", "connected to OCM", "url", productionURL)
 	return &Client{conn: conn}, nil
+}
+
+func applyConfigDefaults(cfg *ocmconfig.Config) {
+	cfg.URL = productionURL
+	if cfg.ClientID == "" {
+		cfg.ClientID = clientID
+	}
+	if cfg.TokenURL == "" {
+		cfg.TokenURL = sdk.DefaultTokenURL
+	}
+	if len(cfg.Scopes) == 0 {
+		cfg.Scopes = []string{"openid"}
+	}
+}
+
+// NewClient creates a real OCM client using the standard config file.
+// Always connects to production OCM. If no valid tokens exist, initiates
+// browser-based auth code login (same flow as ocm-container).
+func NewClient(agentVersion string) (*Client, error) {
+	cfg, armed, err := CheckTokens()
+	if err != nil {
+		return nil, err
+	}
+
+	if !armed {
+		log.Debug("ocm.NewClient", "msg", "not logged into OCM, initiating browser auth")
+		fmt.Fprintln(os.Stderr, "OCM tokens expired — opening browser for authentication...")
+		token, authErr := AuthenticateAsync(cfg)
+		if authErr != nil {
+			log.Debug("ocm.NewClient", "msg", "browser auth failed or cancelled", "error", authErr)
+			return nil, nil
+		}
+		fmt.Fprintln(os.Stderr, "OCM authentication successful.")
+		ApplyAuthToken(cfg, token)
+	}
+
+	return NewClientFromConfig(cfg, agentVersion)
 }
 
 func (c *Client) GetCluster(ctx context.Context, key string) (*ClusterInfo, error) {

--- a/pkg/ocm/client_test.go
+++ b/pkg/ocm/client_test.go
@@ -1,0 +1,124 @@
+package ocm
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ocmconfig "github.com/openshift-online/ocm-common/pkg/ocm/config"
+)
+
+func TestCheckTokens_NoConfigFile(t *testing.T) {
+	t.Run("returns not armed when no config exists", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Setenv("OCM_CONFIG", filepath.Join(dir, "nonexistent.json"))
+
+		cfg, armed, err := CheckTokens()
+
+		assert.NoError(t, err)
+		assert.False(t, armed)
+		assert.NotNil(t, cfg, "should return a config even when unarmed")
+	})
+}
+
+func TestCheckTokens_EmptyConfig(t *testing.T) {
+	t.Run("returns not armed when config has no tokens", func(t *testing.T) {
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, "ocm.json")
+		require.NoError(t, os.WriteFile(cfgPath, []byte("{}"), 0600))
+		t.Setenv("OCM_CONFIG", cfgPath)
+
+		cfg, armed, err := CheckTokens()
+
+		assert.NoError(t, err)
+		assert.False(t, armed)
+		assert.NotNil(t, cfg)
+		assert.Equal(t, productionURL, cfg.URL, "should set production URL")
+		assert.Equal(t, clientID, cfg.ClientID, "should set default client ID")
+	})
+}
+
+func TestCheckTokens_SetsDefaults(t *testing.T) {
+	t.Run("sets URL, ClientID, TokenURL, and Scopes when empty", func(t *testing.T) {
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, "ocm.json")
+		require.NoError(t, os.WriteFile(cfgPath, []byte("{}"), 0600))
+		t.Setenv("OCM_CONFIG", cfgPath)
+
+		cfg, _, err := CheckTokens()
+
+		assert.NoError(t, err)
+		assert.Equal(t, productionURL, cfg.URL)
+		assert.Equal(t, clientID, cfg.ClientID)
+		assert.NotEmpty(t, cfg.TokenURL)
+		assert.Contains(t, cfg.Scopes, "openid")
+	})
+}
+
+func TestCheckTokens_PreservesExistingClientID(t *testing.T) {
+	t.Run("preserves non-empty ClientID from config", func(t *testing.T) {
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, "ocm.json")
+		data, _ := json.Marshal(ocmconfig.Config{ClientID: "custom-client"})
+		require.NoError(t, os.WriteFile(cfgPath, data, 0600))
+		t.Setenv("OCM_CONFIG", cfgPath)
+
+		cfg, _, err := CheckTokens()
+
+		assert.NoError(t, err)
+		assert.Equal(t, "custom-client", cfg.ClientID)
+	})
+}
+
+func TestApplyAuthToken_RefreshToken(t *testing.T) {
+	t.Run("offline token is set as RefreshToken", func(t *testing.T) {
+		cfg := &ocmconfig.Config{}
+		// "Offline" typ claim token — craft a minimal unencrypted JWT
+		// Header: {"alg":"none","typ":"JWT"}
+		// Payload: {"typ":"Offline","exp":9999999999}
+		token := "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJ0eXAiOiJPZmZsaW5lIiwiZXhwIjo5OTk5OTk5OTk5fQ."
+
+		ApplyAuthToken(cfg, token)
+
+		assert.Equal(t, token, cfg.RefreshToken)
+		assert.Empty(t, cfg.AccessToken)
+	})
+}
+
+func TestApplyAuthToken_AccessToken(t *testing.T) {
+	t.Run("bearer token is set as AccessToken", func(t *testing.T) {
+		cfg := &ocmconfig.Config{}
+		// "Bearer" typ claim token
+		// Header: {"alg":"none","typ":"JWT"}
+		// Payload: {"typ":"Bearer","exp":9999999999}
+		token := "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJ0eXAiOiJCZWFyZXIiLCJleHAiOjk5OTk5OTk5OTl9."
+
+		ApplyAuthToken(cfg, token)
+
+		assert.Equal(t, token, cfg.AccessToken)
+		assert.Empty(t, cfg.RefreshToken)
+	})
+}
+
+func TestApplyAuthToken_UnparseableToken(t *testing.T) {
+	t.Run("unparseable token is set as AccessToken", func(t *testing.T) {
+		cfg := &ocmconfig.Config{}
+		token := "not-a-valid-jwt"
+
+		ApplyAuthToken(cfg, token)
+
+		assert.Equal(t, token, cfg.AccessToken)
+	})
+}
+
+func TestNewClientFromConfig_NilConfig(t *testing.T) {
+	t.Run("returns error for nil config", func(t *testing.T) {
+		_, err := NewClientFromConfig(nil, "test-version")
+
+		assert.Error(t, err)
+	})
+}

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -21,6 +21,7 @@ import (
 	"github.com/clcollins/srepd/pkg/alert"
 	pkgconfig "github.com/clcollins/srepd/pkg/config"
 	"github.com/clcollins/srepd/pkg/launcher"
+	"github.com/clcollins/srepd/pkg/ocm"
 	"github.com/clcollins/srepd/pkg/pd"
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
@@ -1239,6 +1240,13 @@ func writeConfigCmd(final pkgconfig.ResolvedValues, changes pkgconfig.ConfigChan
 		}
 		return configSavedMsg{err: nil}
 	}
+}
+
+// OCMClientReadyMsg is sent when async OCM authentication completes.
+// Exported because cmd/root.go sends it via p.Send().
+type OCMClientReadyMsg struct {
+	Client ocm.OCMClient
+	Err    error
 }
 
 type pdClientInitializedMsg struct {

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -148,6 +148,7 @@ type model struct {
 
 	// OCM enrichment state
 	ocmClient             ocm.OCMClient
+	ocmAuthPending        bool
 	incidentClusterMap    map[string][]string // incident ID → cluster IDs
 	clusterEnrichInFlight map[string]bool     // cluster IDs currently being enriched
 	clusterEnrichFailed   map[string]int      // failure count per cluster ID
@@ -186,6 +187,7 @@ func InitialModel(
 	defaultSilentPolicy string,
 	customSilentPolicies map[string]string,
 	configMode bool,
+	ocmAuthPending bool,
 ) (tea.Model, tea.Cmd) {
 	var err error
 
@@ -229,6 +231,7 @@ func InitialModel(
 		autoRefresh:           true,
 		showLowUrgency:        true,
 		ocmClient:             ocmClient,
+		ocmAuthPending:        ocmAuthPending,
 		incidentClusterMap:    make(map[string][]string),
 		clusterEnrichInFlight: make(map[string]bool),
 		clusterEnrichFailed:   make(map[string]int),

--- a/pkg/tui/ocm_enrichment_test.go
+++ b/pkg/tui/ocm_enrichment_test.go
@@ -508,6 +508,182 @@ func TestCacheCleanup_SharedClusterPreserved(t *testing.T) {
 	})
 }
 
+func TestOCMClientReadyMsg_SetsClient(t *testing.T) {
+	t.Run("successful auth sets ocmClient and clears pending", func(t *testing.T) {
+		m := createTestModel()
+		m.ocmClient = nil
+		m.ocmAuthPending = true
+
+		mock := createMockOCMClient()
+		result, _ := m.Update(OCMClientReadyMsg{Client: mock, Err: nil})
+		updated := result.(model)
+
+		assert.Equal(t, mock, updated.ocmClient, "ocmClient should be set")
+		assert.False(t, updated.ocmAuthPending, "ocmAuthPending should be false")
+	})
+}
+
+func TestOCMClientReadyMsg_ClearsAuthPending(t *testing.T) {
+	t.Run("clears ocmAuthPending on error", func(t *testing.T) {
+		m := createTestModel()
+		m.ocmClient = nil
+		m.ocmAuthPending = true
+
+		result, _ := m.Update(OCMClientReadyMsg{Err: fmt.Errorf("auth cancelled")})
+		updated := result.(model)
+
+		assert.Nil(t, updated.ocmClient, "ocmClient should remain nil on error")
+		assert.False(t, updated.ocmAuthPending, "ocmAuthPending should be cleared on error")
+	})
+}
+
+func TestOCMClientReadyMsg_NilClientGraceful(t *testing.T) {
+	t.Run("nil client without error is graceful degradation", func(t *testing.T) {
+		m := createTestModel()
+		m.ocmClient = nil
+		m.ocmAuthPending = true
+
+		result, _ := m.Update(OCMClientReadyMsg{Client: nil, Err: nil})
+		updated := result.(model)
+
+		assert.Nil(t, updated.ocmClient)
+		assert.False(t, updated.ocmAuthPending)
+	})
+}
+
+func TestOCMClientReadyMsg_TriggersRetroactiveEnrichment(t *testing.T) {
+	t.Run("enriches already-loaded clusters after auth", func(t *testing.T) {
+		m := createTestModel()
+		m.ocmClient = nil
+		m.ocmAuthPending = true
+		m.incidentClusterMap = map[string][]string{
+			"INC001": {"1q2w3e4rfakeidtest9o0p1a2s3d4f5g"},
+			"INC002": {"2a3b4c5dfakeidtest0i1j2k3l4m5n6o"},
+		}
+		m.clusterCache = make(map[string]*ocm.ClusterInfo)
+		m.clusterEnrichInFlight = make(map[string]bool)
+		m.clusterEnrichFailed = make(map[string]int)
+
+		mock := createMockOCMClient()
+		result, cmd := m.Update(OCMClientReadyMsg{Client: mock, Err: nil})
+		updated := result.(model)
+
+		assert.Equal(t, mock, updated.ocmClient)
+		assert.NotNil(t, cmd, "should return enrichment commands")
+		// Verify the in-flight tracking was set for uncached clusters
+		assert.True(t, updated.clusterEnrichInFlight["1q2w3e4rfakeidtest9o0p1a2s3d4f5g"])
+		assert.True(t, updated.clusterEnrichInFlight["2a3b4c5dfakeidtest0i1j2k3l4m5n6o"])
+	})
+}
+
+func TestOCMClientReadyMsg_SkipsCachedClusters(t *testing.T) {
+	t.Run("does not re-enrich already cached clusters", func(t *testing.T) {
+		m := createTestModel()
+		m.ocmClient = nil
+		m.ocmAuthPending = true
+		m.incidentClusterMap = map[string][]string{
+			"INC001": {"1q2w3e4rfakeidtest9o0p1a2s3d4f5g"},
+		}
+		m.clusterCache = map[string]*ocm.ClusterInfo{
+			"1q2w3e4rfakeidtest9o0p1a2s3d4f5g": {ID: "1q2w3e4rfakeidtest9o0p1a2s3d4f5g"},
+		}
+		m.clusterEnrichInFlight = make(map[string]bool)
+		m.clusterEnrichFailed = make(map[string]int)
+
+		mock := createMockOCMClient()
+		result, _ := m.Update(OCMClientReadyMsg{Client: mock, Err: nil})
+		updated := result.(model)
+
+		assert.False(t, updated.clusterEnrichInFlight["1q2w3e4rfakeidtest9o0p1a2s3d4f5g"],
+			"already cached cluster should not be in-flight")
+	})
+}
+
+func TestOCMClientReadyMsg_SkipsFailedClusters(t *testing.T) {
+	t.Run("does not re-enrich clusters that exceeded retry limit", func(t *testing.T) {
+		m := createTestModel()
+		m.ocmClient = nil
+		m.ocmAuthPending = true
+		m.incidentClusterMap = map[string][]string{
+			"INC001": {"1q2w3e4rfakeidtest9o0p1a2s3d4f5g"},
+		}
+		m.clusterCache = make(map[string]*ocm.ClusterInfo)
+		m.clusterEnrichInFlight = make(map[string]bool)
+		m.clusterEnrichFailed = map[string]int{
+			"1q2w3e4rfakeidtest9o0p1a2s3d4f5g": 3,
+		}
+
+		mock := createMockOCMClient()
+		result, _ := m.Update(OCMClientReadyMsg{Client: mock, Err: nil})
+		updated := result.(model)
+
+		assert.False(t, updated.clusterEnrichInFlight["1q2w3e4rfakeidtest9o0p1a2s3d4f5g"],
+			"failed cluster should not be retried")
+	})
+}
+
+func TestOCMClientReadyMsg_NoIncidents(t *testing.T) {
+	t.Run("no retroactive enrichment when no incidents loaded", func(t *testing.T) {
+		m := createTestModel()
+		m.ocmClient = nil
+		m.ocmAuthPending = true
+		m.incidentClusterMap = make(map[string][]string)
+		m.clusterEnrichInFlight = make(map[string]bool)
+		m.clusterEnrichFailed = make(map[string]int)
+
+		mock := createMockOCMClient()
+		result, cmd := m.Update(OCMClientReadyMsg{Client: mock, Err: nil})
+		updated := result.(model)
+
+		assert.Equal(t, mock, updated.ocmClient)
+		// cmd will still be non-nil (flash notification), but no enrichment in-flight
+		assert.Empty(t, updated.clusterEnrichInFlight)
+		_ = cmd
+	})
+}
+
+func TestRenderClusterTab_AuthPending(t *testing.T) {
+	t.Run("shows authenticating message when auth is pending", func(t *testing.T) {
+		m := createTestModel()
+		m.clusterCache = make(map[string]*ocm.ClusterInfo)
+		m.ocmClient = nil
+		m.ocmAuthPending = true
+
+		content, err := m.renderClusterTab()
+		assert.NoError(t, err)
+		assert.Contains(t, content, "authenticating")
+		assert.NotContains(t, content, "OCM not connected")
+	})
+}
+
+func TestRenderServiceLogsTab_AuthPending(t *testing.T) {
+	t.Run("shows authenticating message when auth is pending", func(t *testing.T) {
+		m := createTestModel()
+		m.serviceLogCache = make(map[string][]ocm.ServiceLog)
+		m.ocmClient = nil
+		m.ocmAuthPending = true
+
+		content, err := m.renderServiceLogsTab()
+		assert.NoError(t, err)
+		assert.Contains(t, content, "authenticating")
+		assert.NotContains(t, content, "OCM not connected")
+	})
+}
+
+func TestRenderLimitedSupportTab_AuthPending(t *testing.T) {
+	t.Run("shows authenticating message when auth is pending", func(t *testing.T) {
+		m := createTestModel()
+		m.limitedSupportCache = make(map[string][]ocm.LimitedSupportReason)
+		m.ocmClient = nil
+		m.ocmAuthPending = true
+
+		content, err := m.renderLimitedSupportTab()
+		assert.NoError(t, err)
+		assert.Contains(t, content, "authenticating")
+		assert.NotContains(t, content, "OCM not connected")
+	})
+}
+
 func TestCacheCleanup_RemovedFromList(t *testing.T) {
 	t.Run("OCM caches cleared when incident removed from list", func(t *testing.T) {
 		c1 := "1q2w3e4rfakeidtest9o0p1a2s3d4f5g"

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -342,6 +342,38 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			func() tea.Msg { return tea.WindowSizeMsg{Width: windowSize.Width, Height: windowSize.Height} },
 		)
 
+	case OCMClientReadyMsg:
+		m.ocmAuthPending = false
+		if msg.Err != nil {
+			log.Warn("OCM authentication failed", "error", msg.Err)
+			return m, m.flashNotification("OCM auth failed — cluster enrichment disabled")
+		}
+		if msg.Client == nil {
+			log.Warn("OCM authentication cancelled")
+			return m, m.flashNotification("OCM auth cancelled — cluster enrichment disabled")
+		}
+		m.ocmClient = msg.Client
+		log.Info("OCM connected (async)")
+
+		var enrichCmds []tea.Cmd
+		for _, clusterIDs := range m.incidentClusterMap {
+			var uncached []string
+			for _, id := range clusterIDs {
+				if _, cached := m.clusterCache[id]; cached {
+					continue
+				}
+				if m.clusterEnrichInFlight[id] || m.clusterEnrichFailed[id] >= 3 {
+					continue
+				}
+				uncached = append(uncached, id)
+				m.clusterEnrichInFlight[id] = true
+			}
+			enrichCmds = append(enrichCmds, enrichClusters(m.ocmClient, uncached, m.devMode)...)
+		}
+
+		enrichCmds = append(enrichCmds, m.flashNotification("OCM connected — enriching cluster data"))
+		return m, tea.Batch(enrichCmds...)
+
 	case spinner.TickMsg:
 		var cmd tea.Cmd
 		m.spinner, cmd = m.spinner.Update(msg)

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -406,6 +406,9 @@ func (m model) renderNotesTab(summary incidentSummary) (string, error) {
 func (m model) renderClusterTab() (string, error) {
 	if len(m.clusterCache) == 0 {
 		if m.ocmClient == nil {
+			if m.ocmAuthPending {
+				return "\n_OCM authenticating — complete login in browser..._\n", nil
+			}
 			return "\n_OCM not connected_\n", nil
 		}
 		return "\n_Loading cluster info..._\n", nil
@@ -437,6 +440,9 @@ func (m model) renderClusterTab() (string, error) {
 func (m model) renderServiceLogsTab() (string, error) {
 	if len(m.serviceLogCache) == 0 {
 		if m.ocmClient == nil {
+			if m.ocmAuthPending {
+				return "\n_OCM authenticating — complete login in browser..._\n", nil
+			}
 			return "\n_OCM not connected_\n", nil
 		}
 		return "\n_Loading service logs..._\n", nil
@@ -471,6 +477,9 @@ func (m model) renderServiceLogsTab() (string, error) {
 func (m model) renderLimitedSupportTab() (string, error) {
 	if len(m.limitedSupportCache) == 0 {
 		if m.ocmClient == nil {
+			if m.ocmAuthPending {
+				return "\n_OCM authenticating — complete login in browser..._\n", nil
+			}
 			return "\n_OCM not connected_\n", nil
 		}
 		return "\n_No limited support history_\n", nil


### PR DESCRIPTION
## Summary

- Split `ocm.NewClient()` into composable functions (`CheckTokens`, `AuthenticateAsync`, `ApplyAuthToken`, `NewClientFromConfig`) so token validity can be checked without blocking
- When tokens are valid: synchronous connect (no UX change)
- When tokens are expired: TUI starts immediately with PD incidents visible, browser auth runs in a background goroutine, OCM enrichment triggers retroactively via `OCMClientReadyMsg` once auth completes
- OCM tabs show "authenticating — complete login in browser..." while auth is pending

Fixes #279

## Test plan

- [x] `make test-all` passes (fmt, vet, lint, unit tests, race detector)
- [x] Fast path verified: valid tokens connect synchronously, journal shows `ocm.NewClientFromConfig connected to OCM`
- [x] Async path verified: blanked tokens → TUI starts immediately with incidents, browser opens, auth completes → `OCM connected (async)` and enrichment fires
- [x] 18 new tests covering OCM client split, message handler, retroactive enrichment, and auth-pending views

🤖 Generated with [Claude Code](https://claude.com/claude-code)