### PR TITLE
Add flag conditions to highlight matching incidents

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A PagerDuty terminal user interface focused on common SRE tasks.
 * Log into clusters via ocm-container or ocm backplane with multi-cluster selection
 * Add notes, auto-refresh with selection preservation, auto-acknowledge when on-call
 * PagerDuty environment variables passed automatically to terminal sessions
+* [Flag conditions](docs/flag-conditions.md): mark incidents matching cluster ID or organization name patterns
 * OCM integration: cluster enrichment with display names, service logs, limited support history
 * 6-tab incident viewer: Details, Alerts, Notes, Cluster, SLs, LS History
 * Auto-update notification and `srepd update` self-update command
@@ -68,6 +69,7 @@ If no config file exists, running `srepd` automatically enters the configuration
 | `cluster_login_command` | `string` | `ocm backplane login %%CLUSTER_ID%%` | Cluster login command |
 | `toolbox_mode` | `string` | `auto` | Toolbox detection: `auto`, `true`, or `false` |
 | `chord_prefix` | `string` | `ctrl+x` | Prefix key for chord commands |
+| `flag_marker` | `string` | `🚩 ` | Prefix marker for flagged incidents (alt: `\|►`) |
 | `colors` | `map[string]string` | (defaults) | Custom color scheme (hex values) |
 
 ### Colors
@@ -141,6 +143,7 @@ Press `h` to toggle the help overlay inside srepd.
 | `ctrl+a` | Toggle auto-acknowledge | `ctrl+l` | View debug log |
 | `ctrl+q`/`ctrl+c` | Quit | `1`-`9` | Select cluster |
 | `i`/`:` | Ask Claude | `m` | Merge incident |
+| `f` | Flag condition | | |
 | `ctrl+x` + key | Chord commands | `ctrl+x ?` | Show chord help |
 | `Tab`/`Shift+Tab`/`←`/`→` | Switch tabs (incident view) | `↑`/`↓` | Scroll within tab |
 

--- a/docs/flag-conditions.md
+++ b/docs/flag-conditions.md
@@ -1,0 +1,168 @@
+# Flag Conditions
+
+Flag conditions let you visually mark incidents that match specific criteria.
+Flagged incidents show a configurable marker prefix on their Summary in the
+incident table, and a "Flag Conditions" section in the Details tab explaining
+which flags matched.
+
+## Quick Start
+
+Press `f` to open the flag input prompt (pre-filled with `/flag `), or enter
+input mode with `:` and type the command manually.
+
+```
+/flag cluster 1q2w3e4rfakeidtest9o0p1a2s3d4f5g
+/flag org ^Acme*
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/flag cluster <id>` | Flag incidents involving a specific cluster (matches OCM internal ID, external ID, or raw alert cluster ID) |
+| `/flag org <pattern>` | Flag incidents involving clusters owned by an organization matching the pattern |
+| `/flags` | List all active flag conditions |
+| `/unflag <id>` | Remove a flag condition by its session ID |
+| `/unflag all` | Clear all flag conditions |
+| `/flags save [path]` | Save flag conditions to a JSON file |
+| `/flags load [path]` | Load flag conditions from a JSON file |
+
+## Condition Types
+
+### Cluster ID (`/flag cluster <id>`)
+
+Matches any incident whose alerts reference the given cluster. The ID is
+compared against:
+
+1. The raw `cluster_id` field from alert details
+2. The OCM internal cluster ID (from `ClusterInfo.ID`)
+3. The OCM external cluster ID/UUID (from `ClusterInfo.ExternalID`)
+
+Matching is case-insensitive. If OCM enrichment has not yet completed for a
+cluster, only the raw alert cluster ID is checked.
+
+### Organization Name (`/flag org <pattern>`)
+
+Matches incidents involving clusters whose `Organization` field (from OCM)
+matches the pattern. Requires OCM enrichment to be active.
+
+**Supported glob patterns:**
+
+| Pattern | Meaning | Example |
+|---------|---------|---------|
+| `STRING` | Contains (case-insensitive) | `Acme` matches "Acme Corp" and "Big Acme Ltd" |
+| `^STRING` | Starts with | `^Acme` matches "Acme Corp" but not "Big Acme" |
+| `STRING$` | Ends with | `Corp$` matches "Acme Corp" but not "Corp Inc" |
+| `STRING*` | Starts with (trailing wildcard) | `Acme*` same as `^Acme` |
+| `^STRING*` | Starts with (both markers) | `^Acme*` same as `^Acme` |
+| `*STRING$` | Ends with (leading wildcard) | `*Corp$` same as `Corp$` |
+
+## Display
+
+### Table View
+
+Flagged incidents have the flag marker prepended to their Summary column:
+
+```
+  • | P1234567 | 🚩 ClusterMonitoringError...  | mycluster.example.org
+  A | P7654321 | KubePersistentVolumeFilling... | other-cluster.example.org
+```
+
+### Details Tab
+
+When viewing a flagged incident, the Details tab includes a "Flag Conditions"
+section at the bottom:
+
+```
+## Flag Conditions
+
+* 🚩 #1: cluster ID matches "1q2w3e4rfakeidtest9o0p1a2s3d4f5g"
+* 🚩 #2: org name matches "^Acme*"
+```
+
+## Configuration
+
+### `flag_marker` (optional)
+
+The prefix marker shown on flagged incidents. Default: `🚩 ` (flag emoji +
+space).
+
+For terminals that don't render emoji well, set to `|►` (no trailing space
+needed):
+
+```yaml
+flag_marker: "|►"
+```
+
+Add this to your `~/.config/srepd/srepd.yaml`.
+
+## Persistence
+
+Flag conditions are **session-only by default** — they are lost when srepd
+exits. To persist them:
+
+```
+/flags save              # saves to ~/.config/srepd/flags.json
+/flags save /tmp/my.json # saves to a custom path
+/flags load              # loads from ~/.config/srepd/flags.json
+/flags load /tmp/my.json # loads from a custom path
+```
+
+### Save File Format (`flags.json`)
+
+The save file is a JSON array of flag condition objects:
+
+```json
+[
+  {
+    "id": 1,
+    "type": 0,
+    "pattern": "1q2w3e4rfakeidtest9o0p1a2s3d4f5g",
+    "label": "cluster ID matches \"1q2w3e4rfakeidtest9o0p1a2s3d4f5g\"",
+    "created_at": "2026-06-08T16:30:00Z"
+  },
+  {
+    "id": 2,
+    "type": 1,
+    "pattern": "^Acme*",
+    "label": "org name matches \"^Acme*\"",
+    "created_at": "2026-06-08T16:31:00Z"
+  }
+]
+```
+
+**Field descriptions:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | integer | Session-assigned unique ID. When loaded, IDs are preserved and the next auto-increment starts after the highest loaded ID. |
+| `type` | integer | Condition type enum: `0` = FlagClusterID, `1` = FlagOrgName. Future types (SUPPORTEX, OHSS) will use higher values. |
+| `pattern` | string | The match pattern. For cluster IDs, this is the literal ID. For org names, this is the glob pattern including any `^`, `$`, `*` markers. |
+| `label` | string | Human-readable description shown in the UI. |
+| `created_at` | string | ISO 8601 timestamp of when the condition was created. |
+
+**Default path:** `~/.config/srepd/flags.json`
+
+The directory is created automatically if it doesn't exist. The file is
+overwritten on each save (not appended).
+
+## Behavior with OCM
+
+Flag matching depends on cluster enrichment data from OCM:
+
+- **Cluster ID flags** work partially without OCM — the raw `cluster_id` from
+  alert details is always checked. OCM internal/external ID matching requires
+  enrichment.
+- **Organization flags** require OCM enrichment — they silently produce no
+  matches when OCM is disconnected or cluster data hasn't arrived yet.
+- When OCM connects or enrichment data arrives, the flag match cache is
+  automatically rebuilt, and previously-unflagged incidents may become flagged.
+
+## Future Extensions
+
+The following condition types are planned but not yet implemented:
+
+- **SUPPORTEX** — flag clusters with open support exceptions
+- **OHSS** — flag clusters with open OHSS Jira cards
+
+These will require OCM API integration for the corresponding endpoints.

--- a/docs/plans/091-flag-conditions.md
+++ b/docs/plans/091-flag-conditions.md
@@ -1,0 +1,39 @@
+# Plan 091: Flag conditions for incidents (#280)
+
+## Problem
+
+SREs need to visually mark incidents matching specific criteria (cluster ID,
+customer org) to track incidents of interest during an on-call shift. No
+mechanism exists for this.
+
+## Solution
+
+Add session-only flag conditions that prepend a configurable marker to matching
+incident summaries in the table view, with a "Flag Conditions" section in the
+Details tab. Conditions match against cluster ID (internal, external, or raw
+alert ID) and organization name (with glob patterns). Conditions can optionally
+be saved/loaded to JSON for persistence.
+
+## Changes
+
+| File | Change |
+|------|--------|
+| `pkg/tui/flags.go` | New: FlagCondition types, matchGlob, evaluateFlags, matchClusterID, matchOrgName, renderFlagConditionsSection, formatFlagsList, rebuildFlagMatchCache |
+| `pkg/tui/flags_test.go` | New: 50+ tests for glob matching, flag evaluation, message handlers, display |
+| `pkg/tui/flag_commands.go` | New: Slash command parsing (/flag, /flags, /unflag), save/load, dispatch |
+| `pkg/tui/flag_commands_test.go` | New: 23 tests for command parsing and isFlagCommand |
+| `pkg/tui/model.go` | Add flagConditions, flagNextID, flagMarker, flagMatchCache fields |
+| `pkg/tui/tui.go` | Add message handlers, row annotation with flag marker, cache rebuild triggers |
+| `pkg/tui/msgHandlers.go` | Add f key handler, slash command routing in input mode |
+| `pkg/tui/keymap.go` | Add Flag key binding on f |
+| `pkg/tui/views.go` | Add flag conditions section to renderDetailsTab |
+| `pkg/config/config.go` | Add flag_marker optional config key |
+| `README.md` | Document flag feature, f key, flag_marker config |
+| `docs/flag-conditions.md` | Full feature documentation with save file spec |
+
+## Verification
+
+- `make test-all` passes
+- Core logic (matchGlob, evaluateFlags) at 100% coverage
+- Command parsing at 77-100% coverage
+- SUPPORTEX/OHSS deferred to #303

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,6 +30,7 @@ var (
 		"cluster_login_command": "ocm backplane login %%CLUSTER_ID%%",
 		"toolbox_mode":          "auto",
 		"chord_prefix":          "ctrl+x",
+		"flag_marker":           "🚩 ",
 	}
 	OptionalKeys = map[string]string{
 		"editor":                             fmt.Sprintf("Editor to use for notes (default: %v)", DefaultOptionalKeys["editor"]),
@@ -37,6 +38,7 @@ var (
 		"cluster_login_command":              fmt.Sprintf("Cluster login command (default: %v)", DefaultOptionalKeys["cluster_login_command"]),
 		"toolbox_mode":                       fmt.Sprintf("Toolbox detection mode: auto, true, false (default: %v)", DefaultOptionalKeys["toolbox_mode"]),
 		"chord_prefix":                       fmt.Sprintf("Chord prefix key for multi-key commands (default: %v)", DefaultOptionalKeys["chord_prefix"]),
+		"flag_marker":                        fmt.Sprintf("Prefix marker for flagged incidents (default: %v, alt: |►)", DefaultOptionalKeys["flag_marker"]),
 		"colors":                             "Custom color scheme (map of color name to hex value)",
 		"default_silent_escalation_policy":   "Default silent escalation policy ID (auto-discovered via srepd config)",
 		"custom_service_escalation_policies": "Per-service silent policy overrides (service ID → policy ID)",

--- a/pkg/tui/flag_commands.go
+++ b/pkg/tui/flag_commands.go
@@ -1,0 +1,224 @@
+package tui
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/log"
+)
+
+type flagCmdAction int
+
+const (
+	flagCmdAdd flagCmdAction = iota
+	flagCmdRemove
+	flagCmdClearAll
+	flagCmdList
+	flagCmdSave
+	flagCmdLoad
+)
+
+type parsedFlagCommand struct {
+	action    flagCmdAction
+	condition FlagCondition
+	targetID  int
+	path      string
+}
+
+type addFlagConditionMsg struct{ condition FlagCondition }
+type removeFlagConditionMsg struct{ id int }
+type clearFlagConditionsMsg struct{}
+type listFlagConditionsMsg struct{}
+type flagsSavedMsg struct{ err error }
+type flagsLoadedMsg struct {
+	conditions []FlagCondition
+	err        error
+}
+
+func isFlagCommand(input string) bool {
+	trimmed := strings.TrimSpace(input)
+	return trimmed == "/flags" ||
+		strings.HasPrefix(trimmed, "/flags ") ||
+		strings.HasPrefix(trimmed, "/flag ") ||
+		trimmed == "/flag" ||
+		strings.HasPrefix(trimmed, "/unflag ") ||
+		trimmed == "/unflag"
+}
+
+func parseFlagCommand(input string) (*parsedFlagCommand, error) {
+	trimmed := strings.TrimSpace(input)
+	parts := strings.Fields(trimmed)
+
+	if len(parts) == 0 {
+		return nil, fmt.Errorf("empty command")
+	}
+
+	switch parts[0] {
+	case "/flags":
+		return parseFlagsSubcommand(parts[1:])
+	case "/flag":
+		return parseFlagAdd(parts[1:])
+	case "/unflag":
+		return parseUnflag(parts[1:])
+	default:
+		return nil, fmt.Errorf("unknown command: %s", parts[0])
+	}
+}
+
+func parseFlagsSubcommand(args []string) (*parsedFlagCommand, error) {
+	if len(args) == 0 {
+		return &parsedFlagCommand{action: flagCmdList}, nil
+	}
+
+	switch args[0] {
+	case "save":
+		cmd := &parsedFlagCommand{action: flagCmdSave}
+		if len(args) > 1 {
+			cmd.path = strings.Join(args[1:], " ")
+		}
+		return cmd, nil
+	case "load":
+		cmd := &parsedFlagCommand{action: flagCmdLoad}
+		if len(args) > 1 {
+			cmd.path = strings.Join(args[1:], " ")
+		}
+		return cmd, nil
+	default:
+		return nil, fmt.Errorf("unknown /flags subcommand: %s (use: save, load)", args[0])
+	}
+}
+
+func parseFlagAdd(args []string) (*parsedFlagCommand, error) {
+	if len(args) == 0 {
+		return nil, fmt.Errorf("usage: /flag <cluster|org> <value>")
+	}
+
+	flagType := args[0]
+	value := strings.Join(args[1:], " ")
+
+	switch flagType {
+	case "cluster":
+		if value == "" {
+			return nil, fmt.Errorf("usage: /flag cluster <cluster-id>")
+		}
+		return &parsedFlagCommand{
+			action: flagCmdAdd,
+			condition: FlagCondition{
+				Type:    FlagClusterID,
+				Pattern: value,
+				Label:   fmt.Sprintf("cluster ID matches %q", value),
+			},
+		}, nil
+	case "org":
+		if value == "" {
+			return nil, fmt.Errorf("usage: /flag org <pattern>")
+		}
+		return &parsedFlagCommand{
+			action: flagCmdAdd,
+			condition: FlagCondition{
+				Type:    FlagOrgName,
+				Pattern: value,
+				Label:   fmt.Sprintf("org name matches %q", value),
+			},
+		}, nil
+	default:
+		return nil, fmt.Errorf("unknown flag type %q (use: cluster, org)", flagType)
+	}
+}
+
+func parseUnflag(args []string) (*parsedFlagCommand, error) {
+	if len(args) == 0 {
+		return nil, fmt.Errorf("usage: /unflag <id|all>")
+	}
+
+	if args[0] == "all" {
+		return &parsedFlagCommand{action: flagCmdClearAll}, nil
+	}
+
+	id, err := strconv.Atoi(args[0])
+	if err != nil {
+		return nil, fmt.Errorf("invalid flag ID %q: must be a number or 'all'", args[0])
+	}
+
+	return &parsedFlagCommand{action: flagCmdRemove, targetID: id}, nil
+}
+
+func defaultFlagsPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "flags.json"
+	}
+	return filepath.Join(home, ".config", "srepd", "flags.json")
+}
+
+func saveFlagsCmd(conditions []FlagCondition, path string) tea.Cmd {
+	return func() tea.Msg {
+		if path == "" {
+			path = defaultFlagsPath()
+		}
+		dir := filepath.Dir(path)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return flagsSavedMsg{err: fmt.Errorf("create directory: %w", err)}
+		}
+		data, err := json.MarshalIndent(conditions, "", "  ")
+		if err != nil {
+			return flagsSavedMsg{err: fmt.Errorf("marshal flags: %w", err)}
+		}
+		if err := os.WriteFile(path, data, 0644); err != nil {
+			return flagsSavedMsg{err: fmt.Errorf("write flags: %w", err)}
+		}
+		log.Info("flags saved", "path", path, "count", len(conditions))
+		return flagsSavedMsg{}
+	}
+}
+
+func loadFlagsCmd(path string) tea.Cmd {
+	return func() tea.Msg {
+		if path == "" {
+			path = defaultFlagsPath()
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return flagsLoadedMsg{err: fmt.Errorf("read flags: %w", err)}
+		}
+		var conditions []FlagCondition
+		if err := json.Unmarshal(data, &conditions); err != nil {
+			return flagsLoadedMsg{err: fmt.Errorf("parse flags: %w", err)}
+		}
+		log.Info("flags loaded", "path", path, "count", len(conditions))
+		return flagsLoadedMsg{conditions: conditions}
+	}
+}
+
+func (m model) dispatchFlagCommand(input string) tea.Cmd {
+	parsed, err := parseFlagCommand(input)
+	if err != nil {
+		return m.flashNotification(err.Error())
+	}
+
+	switch parsed.action {
+	case flagCmdAdd:
+		cond := parsed.condition
+		cond.CreatedAt = time.Now()
+		return func() tea.Msg { return addFlagConditionMsg{condition: cond} }
+	case flagCmdRemove:
+		id := parsed.targetID
+		return func() tea.Msg { return removeFlagConditionMsg{id: id} }
+	case flagCmdClearAll:
+		return func() tea.Msg { return clearFlagConditionsMsg{} }
+	case flagCmdList:
+		return func() tea.Msg { return listFlagConditionsMsg{} }
+	case flagCmdSave:
+		return saveFlagsCmd(m.flagConditions, parsed.path)
+	case flagCmdLoad:
+		return loadFlagsCmd(parsed.path)
+	default:
+		return nil
+	}
+}

--- a/pkg/tui/flag_commands_test.go
+++ b/pkg/tui/flag_commands_test.go
@@ -1,0 +1,365 @@
+package tui
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseFlagCommand_ClusterID(t *testing.T) {
+	t.Run("parses /flag cluster <id>", func(t *testing.T) {
+		cmd, err := parseFlagCommand("/flag cluster 1q2w3e4rfakeidtest9o0p1a2s3d4f5g")
+
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+		assert.Equal(t, flagCmdAdd, cmd.action)
+		assert.Equal(t, FlagClusterID, cmd.condition.Type)
+		assert.Equal(t, "1q2w3e4rfakeidtest9o0p1a2s3d4f5g", cmd.condition.Pattern)
+		assert.Contains(t, cmd.condition.Label, "cluster")
+	})
+}
+
+func TestParseFlagCommand_OrgName(t *testing.T) {
+	t.Run("parses /flag org <pattern>", func(t *testing.T) {
+		cmd, err := parseFlagCommand("/flag org ^Acme*")
+
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+		assert.Equal(t, flagCmdAdd, cmd.action)
+		assert.Equal(t, FlagOrgName, cmd.condition.Type)
+		assert.Equal(t, "^Acme*", cmd.condition.Pattern)
+		assert.Contains(t, cmd.condition.Label, "org")
+	})
+}
+
+func TestParseFlagCommand_OrgNameMultiWord(t *testing.T) {
+	t.Run("parses org pattern with spaces", func(t *testing.T) {
+		cmd, err := parseFlagCommand("/flag org Red Hat Inc")
+
+		require.NoError(t, err)
+		assert.Equal(t, FlagOrgName, cmd.condition.Type)
+		assert.Equal(t, "Red Hat Inc", cmd.condition.Pattern)
+	})
+}
+
+func TestParseFlagCommand_List(t *testing.T) {
+	t.Run("parses /flags as list command", func(t *testing.T) {
+		cmd, err := parseFlagCommand("/flags")
+
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+		assert.Equal(t, flagCmdList, cmd.action)
+	})
+}
+
+func TestParseFlagCommand_Unflag(t *testing.T) {
+	t.Run("parses /unflag <id>", func(t *testing.T) {
+		cmd, err := parseFlagCommand("/unflag 3")
+
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+		assert.Equal(t, flagCmdRemove, cmd.action)
+		assert.Equal(t, 3, cmd.targetID)
+	})
+}
+
+func TestParseFlagCommand_UnflagAll(t *testing.T) {
+	t.Run("parses /unflag all", func(t *testing.T) {
+		cmd, err := parseFlagCommand("/unflag all")
+
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+		assert.Equal(t, flagCmdClearAll, cmd.action)
+	})
+}
+
+func TestParseFlagCommand_FlagsSave(t *testing.T) {
+	t.Run("parses /flags save", func(t *testing.T) {
+		cmd, err := parseFlagCommand("/flags save")
+
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+		assert.Equal(t, flagCmdSave, cmd.action)
+		assert.Empty(t, cmd.path)
+	})
+}
+
+func TestParseFlagCommand_FlagsSavePath(t *testing.T) {
+	t.Run("parses /flags save <path>", func(t *testing.T) {
+		cmd, err := parseFlagCommand("/flags save /tmp/myflags.json")
+
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+		assert.Equal(t, flagCmdSave, cmd.action)
+		assert.Equal(t, "/tmp/myflags.json", cmd.path)
+	})
+}
+
+func TestParseFlagCommand_FlagsLoad(t *testing.T) {
+	t.Run("parses /flags load", func(t *testing.T) {
+		cmd, err := parseFlagCommand("/flags load")
+
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+		assert.Equal(t, flagCmdLoad, cmd.action)
+	})
+}
+
+func TestParseFlagCommand_FlagsLoadPath(t *testing.T) {
+	t.Run("parses /flags load <path>", func(t *testing.T) {
+		cmd, err := parseFlagCommand("/flags load /tmp/myflags.json")
+
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+		assert.Equal(t, flagCmdLoad, cmd.action)
+		assert.Equal(t, "/tmp/myflags.json", cmd.path)
+	})
+}
+
+func TestParseFlagCommand_InvalidType(t *testing.T) {
+	t.Run("returns error for unknown flag type", func(t *testing.T) {
+		_, err := parseFlagCommand("/flag badtype value")
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown flag type")
+	})
+}
+
+func TestParseFlagCommand_MissingValue(t *testing.T) {
+	t.Run("returns error for /flag cluster with no value", func(t *testing.T) {
+		_, err := parseFlagCommand("/flag cluster")
+
+		assert.Error(t, err)
+	})
+}
+
+func TestParseFlagCommand_MissingOrgValue(t *testing.T) {
+	t.Run("returns error for /flag org with no value", func(t *testing.T) {
+		_, err := parseFlagCommand("/flag org")
+
+		assert.Error(t, err)
+	})
+}
+
+func TestParseFlagCommand_FlagNoArgs(t *testing.T) {
+	t.Run("returns error for bare /flag", func(t *testing.T) {
+		_, err := parseFlagCommand("/flag")
+
+		assert.Error(t, err)
+	})
+}
+
+func TestParseFlagCommand_UnflagInvalidID(t *testing.T) {
+	t.Run("returns error for /unflag with non-numeric id", func(t *testing.T) {
+		_, err := parseFlagCommand("/unflag abc")
+
+		assert.Error(t, err)
+	})
+}
+
+func TestParseFlagCommand_UnflagNoArgs(t *testing.T) {
+	t.Run("returns error for bare /unflag", func(t *testing.T) {
+		_, err := parseFlagCommand("/unflag")
+
+		assert.Error(t, err)
+	})
+}
+
+func TestSaveFlagsCmd_WritesJSON(t *testing.T) {
+	t.Run("saves conditions to JSON file", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "flags.json")
+		conditions := []FlagCondition{
+			{ID: 1, Type: FlagClusterID, Pattern: "cluster1", Label: "test flag", CreatedAt: time.Now()},
+			{ID: 2, Type: FlagOrgName, Pattern: "^Acme*", Label: "org flag", CreatedAt: time.Now()},
+		}
+
+		cmd := saveFlagsCmd(conditions, path)
+		msg := cmd()
+
+		saved, ok := msg.(flagsSavedMsg)
+		require.True(t, ok)
+		assert.NoError(t, saved.err)
+
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+
+		var loaded []FlagCondition
+		require.NoError(t, json.Unmarshal(data, &loaded))
+		assert.Len(t, loaded, 2)
+		assert.Equal(t, "cluster1", loaded[0].Pattern)
+		assert.Equal(t, "^Acme*", loaded[1].Pattern)
+	})
+}
+
+func TestSaveFlagsCmd_CreatesDirectory(t *testing.T) {
+	t.Run("creates parent directory if needed", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "subdir", "nested", "flags.json")
+
+		cmd := saveFlagsCmd([]FlagCondition{{ID: 1}}, path)
+		msg := cmd()
+
+		saved := msg.(flagsSavedMsg)
+		assert.NoError(t, saved.err)
+		assert.FileExists(t, path)
+	})
+}
+
+func TestSaveFlagsCmd_InvalidPath(t *testing.T) {
+	t.Run("returns error for invalid path", func(t *testing.T) {
+		cmd := saveFlagsCmd([]FlagCondition{{ID: 1}}, "/dev/null/impossible/flags.json")
+		msg := cmd()
+
+		saved := msg.(flagsSavedMsg)
+		assert.Error(t, saved.err)
+	})
+}
+
+func TestLoadFlagsCmd_ReadsJSON(t *testing.T) {
+	t.Run("loads conditions from JSON file", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "flags.json")
+		conditions := []FlagCondition{
+			{ID: 1, Type: FlagClusterID, Pattern: "cluster1", Label: "test"},
+			{ID: 2, Type: FlagOrgName, Pattern: "Acme", Label: "org"},
+		}
+		data, _ := json.MarshalIndent(conditions, "", "  ")
+		require.NoError(t, os.WriteFile(path, data, 0644))
+
+		cmd := loadFlagsCmd(path)
+		msg := cmd()
+
+		loaded, ok := msg.(flagsLoadedMsg)
+		require.True(t, ok)
+		assert.NoError(t, loaded.err)
+		assert.Len(t, loaded.conditions, 2)
+		assert.Equal(t, "cluster1", loaded.conditions[0].Pattern)
+	})
+}
+
+func TestLoadFlagsCmd_FileNotFound(t *testing.T) {
+	t.Run("returns error for missing file", func(t *testing.T) {
+		cmd := loadFlagsCmd("/nonexistent/flags.json")
+		msg := cmd()
+
+		loaded := msg.(flagsLoadedMsg)
+		assert.Error(t, loaded.err)
+	})
+}
+
+func TestLoadFlagsCmd_InvalidJSON(t *testing.T) {
+	t.Run("returns error for malformed JSON", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "flags.json")
+		require.NoError(t, os.WriteFile(path, []byte("{not valid json}"), 0644))
+
+		cmd := loadFlagsCmd(path)
+		msg := cmd()
+
+		loaded := msg.(flagsLoadedMsg)
+		assert.Error(t, loaded.err)
+	})
+}
+
+func TestSaveLoadRoundTrip(t *testing.T) {
+	t.Run("save and load preserves all fields", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "flags.json")
+		now := time.Now().Truncate(time.Second)
+		original := []FlagCondition{
+			{ID: 5, Type: FlagClusterID, Pattern: "abc123", Label: "cluster flag", CreatedAt: now},
+			{ID: 8, Type: FlagOrgName, Pattern: "^Red Hat*", Label: "org flag", CreatedAt: now},
+		}
+
+		saveMsg := saveFlagsCmd(original, path)().(flagsSavedMsg)
+		require.NoError(t, saveMsg.err)
+
+		loadMsg := loadFlagsCmd(path)().(flagsLoadedMsg)
+		require.NoError(t, loadMsg.err)
+		require.Len(t, loadMsg.conditions, 2)
+
+		assert.Equal(t, 5, loadMsg.conditions[0].ID)
+		assert.Equal(t, FlagClusterID, loadMsg.conditions[0].Type)
+		assert.Equal(t, "abc123", loadMsg.conditions[0].Pattern)
+		assert.Equal(t, "cluster flag", loadMsg.conditions[0].Label)
+
+		assert.Equal(t, 8, loadMsg.conditions[1].ID)
+		assert.Equal(t, FlagOrgName, loadMsg.conditions[1].Type)
+		assert.Equal(t, "^Red Hat*", loadMsg.conditions[1].Pattern)
+	})
+}
+
+func TestDispatchFlagCommand_Add(t *testing.T) {
+	t.Run("dispatches addFlagConditionMsg for /flag cluster", func(t *testing.T) {
+		m := createTestModel()
+		m.flagMarker = defaultFlagMarker
+
+		cmd := m.dispatchFlagCommand("/flag cluster abc123")
+		require.NotNil(t, cmd)
+
+		msg := cmd()
+		addMsg, ok := msg.(addFlagConditionMsg)
+		assert.True(t, ok)
+		assert.Equal(t, FlagClusterID, addMsg.condition.Type)
+		assert.Equal(t, "abc123", addMsg.condition.Pattern)
+	})
+}
+
+func TestDispatchFlagCommand_List(t *testing.T) {
+	t.Run("dispatches listFlagConditionsMsg for /flags", func(t *testing.T) {
+		m := createTestModel()
+		m.flagMarker = defaultFlagMarker
+
+		cmd := m.dispatchFlagCommand("/flags")
+		require.NotNil(t, cmd)
+
+		msg := cmd()
+		_, ok := msg.(listFlagConditionsMsg)
+		assert.True(t, ok)
+	})
+}
+
+func TestDispatchFlagCommand_Invalid(t *testing.T) {
+	t.Run("returns flash notification for invalid command", func(t *testing.T) {
+		m := createTestModel()
+		m.flagMarker = defaultFlagMarker
+
+		cmd := m.dispatchFlagCommand("/flag badtype value")
+		require.NotNil(t, cmd)
+
+		// The flash notification returns a tea.Cmd that produces setStatusMsg
+		// We can't easily inspect the exact message but we can verify it's not nil
+		_ = cmd
+	})
+}
+
+// Suppress unused import warnings
+var _ = tea.Cmd(nil)
+
+func TestIsFlagCommand(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"flag command", "/flag cluster abc", true},
+		{"flags command", "/flags", true},
+		{"unflag command", "/unflag 3", true},
+		{"not a flag command", "hello world", false},
+		{"claude prompt", "explain this code", false},
+		{"partial match", "/flagged", false},
+		{"flags save", "/flags save", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isFlagCommand(tt.input))
+		})
+	}
+}

--- a/pkg/tui/flags.go
+++ b/pkg/tui/flags.go
@@ -1,0 +1,193 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/clcollins/srepd/pkg/ocm"
+)
+
+// FlagConditionType identifies the kind of flag condition.
+type FlagConditionType int
+
+const (
+	FlagClusterID FlagConditionType = iota
+	FlagOrgName
+)
+
+const defaultFlagMarker = "🚩 "
+
+// FlagCondition is a user-defined rule that marks matching incidents.
+type FlagCondition struct {
+	ID        int               `json:"id"`
+	Type      FlagConditionType `json:"type"`
+	Pattern   string            `json:"pattern"`
+	Label     string            `json:"label"`
+	CreatedAt time.Time         `json:"created_at"`
+}
+
+// matchGlob matches a value against a simple glob pattern.
+// Supported forms: ^STRING (prefix), STRING$ (suffix), STRING* (prefix),
+// ^STRING* (prefix), *STRING$ (suffix), plain STRING (contains).
+// All matching is case-insensitive.
+func matchGlob(pattern, value string) bool {
+	if pattern == "" {
+		return true
+	}
+
+	lowerValue := strings.ToLower(value)
+
+	hasPrefix := strings.HasPrefix(pattern, "^")
+	hasSuffix := strings.HasSuffix(pattern, "$")
+	hasLeadingStar := strings.HasPrefix(pattern, "*")
+	hasTrailingStar := strings.HasSuffix(pattern, "*")
+
+	core := pattern
+	if hasPrefix {
+		core = core[1:]
+	}
+	if hasLeadingStar && !hasPrefix {
+		core = core[1:]
+	}
+	if hasSuffix {
+		core = core[:len(core)-1]
+	}
+	if hasTrailingStar && !hasSuffix {
+		core = core[:len(core)-1]
+	}
+
+	lowerCore := strings.ToLower(core)
+
+	if hasPrefix || hasTrailingStar {
+		return strings.HasPrefix(lowerValue, lowerCore)
+	}
+	if hasSuffix || hasLeadingStar {
+		return strings.HasSuffix(lowerValue, lowerCore)
+	}
+
+	return strings.Contains(lowerValue, lowerCore)
+}
+
+// evaluateFlags checks all incidents against all flag conditions and returns
+// a map of incident ID to the IDs of matching conditions.
+func evaluateFlags(
+	incidents []string,
+	conditions []FlagCondition,
+	incidentClusterMap map[string][]string,
+	clusterCache map[string]*ocm.ClusterInfo,
+) map[string][]int {
+	if len(conditions) == 0 {
+		return nil
+	}
+
+	result := make(map[string][]int)
+
+	for _, incidentID := range incidents {
+		clusterIDs := incidentClusterMap[incidentID]
+		for _, cond := range conditions {
+			if matchCondition(cond, clusterIDs, clusterCache) {
+				result[incidentID] = append(result[incidentID], cond.ID)
+			}
+		}
+	}
+
+	return result
+}
+
+func matchCondition(cond FlagCondition, clusterIDs []string, clusterCache map[string]*ocm.ClusterInfo) bool {
+	switch cond.Type {
+	case FlagClusterID:
+		return matchClusterID(cond.Pattern, clusterIDs, clusterCache)
+	case FlagOrgName:
+		return matchOrgName(cond.Pattern, clusterIDs, clusterCache)
+	default:
+		return false
+	}
+}
+
+func matchClusterID(pattern string, clusterIDs []string, clusterCache map[string]*ocm.ClusterInfo) bool {
+	lowerPattern := strings.ToLower(pattern)
+	for _, cid := range clusterIDs {
+		if strings.ToLower(cid) == lowerPattern {
+			return true
+		}
+		if info, ok := clusterCache[cid]; ok {
+			if strings.ToLower(info.ID) == lowerPattern || strings.ToLower(info.ExternalID) == lowerPattern {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func matchOrgName(pattern string, clusterIDs []string, clusterCache map[string]*ocm.ClusterInfo) bool {
+	for _, cid := range clusterIDs {
+		if info, ok := clusterCache[cid]; ok && info.Organization != "" {
+			if matchGlob(pattern, info.Organization) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (m model) renderFlagConditionsSection() string {
+	if m.selectedIncident == nil {
+		return ""
+	}
+	matched, ok := m.flagMatchCache[m.selectedIncident.ID]
+	if !ok || len(matched) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("\n## Flag Conditions\n\n")
+	for _, flagID := range matched {
+		for _, cond := range m.flagConditions {
+			if cond.ID == flagID {
+				fmt.Fprintf(&b, "* %s#%d: %s\n", m.flagMarker, cond.ID, cond.Label)
+				break
+			}
+		}
+	}
+	return b.String()
+}
+
+func formatFlagsList(conditions []FlagCondition) string {
+	if len(conditions) == 0 {
+		return "No active flag conditions.\n\nUse `/flag cluster <id>` or `/flag org <pattern>` to add one."
+	}
+
+	var b strings.Builder
+	b.WriteString("# Active Flag Conditions\n\n")
+	for _, c := range conditions {
+		typeName := "unknown"
+		switch c.Type {
+		case FlagClusterID:
+			typeName = "cluster"
+		case FlagOrgName:
+			typeName = "org"
+		}
+		fmt.Fprintf(&b, "* **#%d** [%s] %s\n", c.ID, typeName, c.Label)
+	}
+	b.WriteString("\nUse `/unflag <id>` to remove, `/unflag all` to clear.")
+	return b.String()
+}
+
+func (m *model) rebuildFlagMatchCache() {
+	if len(m.flagConditions) == 0 {
+		m.flagMatchCache = nil
+		return
+	}
+	var incidentIDs []string
+	for _, inc := range m.incidentList {
+		incidentIDs = append(incidentIDs, inc.ID)
+	}
+	m.flagMatchCache = evaluateFlags(
+		incidentIDs,
+		m.flagConditions,
+		m.incidentClusterMap,
+		m.clusterCache,
+	)
+}

--- a/pkg/tui/flags_test.go
+++ b/pkg/tui/flags_test.go
@@ -1,0 +1,467 @@
+package tui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/PagerDuty/go-pagerduty"
+	"github.com/clcollins/srepd/pkg/ocm"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatchGlob(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		value   string
+		want    bool
+	}{
+		// Plain string (contains)
+		{"contains match", "Widget", "Acme Widget Corp", true},
+		{"contains no match", "Gadget", "Acme Widget Corp", false},
+		{"contains case insensitive", "widget", "Acme Widget Corp", true},
+		{"contains empty pattern", "", "Acme Widget Corp", true},
+		{"contains empty value", "Widget", "", false},
+
+		// ^STRING (hasPrefix)
+		{"prefix match", "^Acme", "Acme Widget Corp", true},
+		{"prefix no match", "^Widget", "Acme Widget Corp", false},
+		{"prefix case insensitive", "^acme", "Acme Widget Corp", true},
+
+		// STRING$ (hasSuffix)
+		{"suffix match", "Corp$", "Acme Widget Corp", true},
+		{"suffix no match", "Widget$", "Acme Widget Corp", false},
+		{"suffix case insensitive", "corp$", "Acme Widget Corp", true},
+
+		// STRING* (hasPrefix, trailing wildcard)
+		{"prefix wildcard match", "Acme*", "Acme Widget Corp", true},
+		{"prefix wildcard no match", "Widget*", "Acme Widget Corp", false},
+		{"prefix wildcard case insensitive", "acme*", "Acme Widget Corp", true},
+
+		// ^STRING* (hasPrefix, both markers)
+		{"caret prefix wildcard match", "^Acme*", "Acme Widget Corp", true},
+		{"caret prefix wildcard no match", "^Widget*", "Acme Widget Corp", false},
+
+		// *STRING$ (hasSuffix, leading wildcard)
+		{"star suffix match", "*Corp$", "Acme Widget Corp", true},
+		{"star suffix no match", "*Widget$", "Acme Widget Corp", false},
+		{"star suffix case insensitive", "*corp$", "Acme Widget Corp", true},
+
+		// Edge cases
+		{"exact match plain", "Acme Widget Corp", "Acme Widget Corp", true},
+		{"pattern equals value with prefix", "^Acme Widget Corp", "Acme Widget Corp", true},
+		{"pattern equals value with suffix", "Acme Widget Corp$", "Acme Widget Corp", true},
+		{"single char pattern", "A", "Acme", true},
+		{"single char no match", "Z", "Acme", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchGlob(tt.pattern, tt.value)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestEvaluateFlags_NoConditions(t *testing.T) {
+	t.Run("returns nil when no conditions", func(t *testing.T) {
+		result := evaluateFlags(
+			[]string{"INC001"},
+			nil,
+			map[string][]string{"INC001": {"cluster1"}},
+			map[string]*ocm.ClusterInfo{},
+		)
+		assert.Nil(t, result)
+	})
+}
+
+func TestEvaluateFlags_ClusterIDDirect(t *testing.T) {
+	t.Run("matches by raw cluster ID from alerts", func(t *testing.T) {
+		conditions := []FlagCondition{
+			{ID: 1, Type: FlagClusterID, Pattern: "1q2w3e4rfakeidtest9o0p1a2s3d4f5g", CreatedAt: time.Now()},
+		}
+		result := evaluateFlags(
+			[]string{"INC001"},
+			conditions,
+			map[string][]string{"INC001": {"1q2w3e4rfakeidtest9o0p1a2s3d4f5g"}},
+			map[string]*ocm.ClusterInfo{},
+		)
+		assert.Equal(t, []int{1}, result["INC001"])
+	})
+}
+
+func TestEvaluateFlags_ClusterIDExternal(t *testing.T) {
+	t.Run("matches by external ID via clusterCache", func(t *testing.T) {
+		conditions := []FlagCondition{
+			{ID: 1, Type: FlagClusterID, Pattern: "00000000-fake-uuid-test-999999999999", CreatedAt: time.Now()},
+		}
+		result := evaluateFlags(
+			[]string{"INC001"},
+			conditions,
+			map[string][]string{"INC001": {"1q2w3e4rfakeidtest9o0p1a2s3d4f5g"}},
+			map[string]*ocm.ClusterInfo{
+				"1q2w3e4rfakeidtest9o0p1a2s3d4f5g": {
+					ID:         "internal-id-fake",
+					ExternalID: "00000000-fake-uuid-test-999999999999",
+				},
+			},
+		)
+		assert.Equal(t, []int{1}, result["INC001"])
+	})
+}
+
+func TestEvaluateFlags_ClusterIDInternalViaCache(t *testing.T) {
+	t.Run("matches by internal OCM ID via clusterCache", func(t *testing.T) {
+		conditions := []FlagCondition{
+			{ID: 1, Type: FlagClusterID, Pattern: "internal-id-fake", CreatedAt: time.Now()},
+		}
+		result := evaluateFlags(
+			[]string{"INC001"},
+			conditions,
+			map[string][]string{"INC001": {"1q2w3e4rfakeidtest9o0p1a2s3d4f5g"}},
+			map[string]*ocm.ClusterInfo{
+				"1q2w3e4rfakeidtest9o0p1a2s3d4f5g": {
+					ID:         "internal-id-fake",
+					ExternalID: "00000000-fake-uuid-test-999999999999",
+				},
+			},
+		)
+		assert.Equal(t, []int{1}, result["INC001"])
+	})
+}
+
+func TestEvaluateFlags_ClusterIDNoMatch(t *testing.T) {
+	t.Run("no match returns empty for that incident", func(t *testing.T) {
+		conditions := []FlagCondition{
+			{ID: 1, Type: FlagClusterID, Pattern: "nonexistent-cluster", CreatedAt: time.Now()},
+		}
+		result := evaluateFlags(
+			[]string{"INC001"},
+			conditions,
+			map[string][]string{"INC001": {"1q2w3e4rfakeidtest9o0p1a2s3d4f5g"}},
+			map[string]*ocm.ClusterInfo{},
+		)
+		assert.Empty(t, result["INC001"])
+	})
+}
+
+func TestEvaluateFlags_OrgNameContains(t *testing.T) {
+	t.Run("matches org name by contains", func(t *testing.T) {
+		conditions := []FlagCondition{
+			{ID: 1, Type: FlagOrgName, Pattern: "Aeronautical", CreatedAt: time.Now()},
+		}
+		result := evaluateFlags(
+			[]string{"INC001"},
+			conditions,
+			map[string][]string{"INC001": {"cluster1"}},
+			map[string]*ocm.ClusterInfo{
+				"cluster1": {ID: "cluster1", Organization: "Fake Aeronautical Ltd"},
+			},
+		)
+		assert.Equal(t, []int{1}, result["INC001"])
+	})
+}
+
+func TestEvaluateFlags_OrgNamePrefix(t *testing.T) {
+	t.Run("matches org name by prefix glob", func(t *testing.T) {
+		conditions := []FlagCondition{
+			{ID: 1, Type: FlagOrgName, Pattern: "^Fake*", CreatedAt: time.Now()},
+		}
+		result := evaluateFlags(
+			[]string{"INC001"},
+			conditions,
+			map[string][]string{"INC001": {"cluster1"}},
+			map[string]*ocm.ClusterInfo{
+				"cluster1": {ID: "cluster1", Organization: "Fake Aeronautical Ltd"},
+			},
+		)
+		assert.Equal(t, []int{1}, result["INC001"])
+	})
+}
+
+func TestEvaluateFlags_OrgNameNoMatch(t *testing.T) {
+	t.Run("no match when org doesn't match pattern", func(t *testing.T) {
+		conditions := []FlagCondition{
+			{ID: 1, Type: FlagOrgName, Pattern: "Nonexistent Corp", CreatedAt: time.Now()},
+		}
+		result := evaluateFlags(
+			[]string{"INC001"},
+			conditions,
+			map[string][]string{"INC001": {"cluster1"}},
+			map[string]*ocm.ClusterInfo{
+				"cluster1": {ID: "cluster1", Organization: "Fake Aeronautical Ltd"},
+			},
+		)
+		assert.Empty(t, result["INC001"])
+	})
+}
+
+func TestEvaluateFlags_NoOCMData(t *testing.T) {
+	t.Run("gracefully returns no matches without OCM data", func(t *testing.T) {
+		conditions := []FlagCondition{
+			{ID: 1, Type: FlagOrgName, Pattern: "Anything", CreatedAt: time.Now()},
+		}
+		result := evaluateFlags(
+			[]string{"INC001"},
+			conditions,
+			map[string][]string{"INC001": {"cluster1"}},
+			map[string]*ocm.ClusterInfo{},
+		)
+		assert.Empty(t, result["INC001"])
+	})
+}
+
+func TestEvaluateFlags_MultipleConditions(t *testing.T) {
+	t.Run("returns multiple matching condition IDs", func(t *testing.T) {
+		conditions := []FlagCondition{
+			{ID: 1, Type: FlagClusterID, Pattern: "cluster1", CreatedAt: time.Now()},
+			{ID: 2, Type: FlagOrgName, Pattern: "Aeronautical", CreatedAt: time.Now()},
+			{ID: 3, Type: FlagClusterID, Pattern: "nonexistent", CreatedAt: time.Now()},
+		}
+		result := evaluateFlags(
+			[]string{"INC001"},
+			conditions,
+			map[string][]string{"INC001": {"cluster1"}},
+			map[string]*ocm.ClusterInfo{
+				"cluster1": {ID: "cluster1", Organization: "Fake Aeronautical Ltd"},
+			},
+		)
+		assert.Equal(t, []int{1, 2}, result["INC001"])
+	})
+}
+
+func TestEvaluateFlags_MultipleIncidents(t *testing.T) {
+	t.Run("evaluates each incident independently", func(t *testing.T) {
+		conditions := []FlagCondition{
+			{ID: 1, Type: FlagClusterID, Pattern: "cluster1", CreatedAt: time.Now()},
+		}
+		result := evaluateFlags(
+			[]string{"INC001", "INC002"},
+			conditions,
+			map[string][]string{
+				"INC001": {"cluster1"},
+				"INC002": {"cluster2"},
+			},
+			map[string]*ocm.ClusterInfo{},
+		)
+		assert.Equal(t, []int{1}, result["INC001"])
+		assert.Empty(t, result["INC002"])
+	})
+}
+
+func TestEvaluateFlags_NoClusters(t *testing.T) {
+	t.Run("incident with no clusters never matches", func(t *testing.T) {
+		conditions := []FlagCondition{
+			{ID: 1, Type: FlagClusterID, Pattern: "cluster1", CreatedAt: time.Now()},
+		}
+		result := evaluateFlags(
+			[]string{"INC001"},
+			conditions,
+			map[string][]string{},
+			map[string]*ocm.ClusterInfo{},
+		)
+		assert.Empty(t, result["INC001"])
+	})
+}
+
+func TestAddFlagConditionMsg(t *testing.T) {
+	t.Run("adds condition and assigns ID", func(t *testing.T) {
+		m := createTestModel()
+		m.flagMarker = defaultFlagMarker
+		m.incidentClusterMap = make(map[string][]string)
+		m.clusterCache = make(map[string]*ocm.ClusterInfo)
+
+		cond := FlagCondition{
+			Type:      FlagClusterID,
+			Pattern:   "cluster1",
+			Label:     "cluster ID matches \"cluster1\"",
+			CreatedAt: time.Now(),
+		}
+
+		result, _ := m.Update(addFlagConditionMsg{condition: cond})
+		updated := result.(model)
+
+		assert.Len(t, updated.flagConditions, 1)
+		assert.Equal(t, 1, updated.flagConditions[0].ID)
+		assert.Equal(t, "cluster1", updated.flagConditions[0].Pattern)
+		assert.Equal(t, 1, updated.flagNextID)
+	})
+}
+
+func TestAddFlagConditionMsg_IncrementsID(t *testing.T) {
+	t.Run("auto-increments IDs", func(t *testing.T) {
+		m := createTestModel()
+		m.flagMarker = defaultFlagMarker
+		m.flagNextID = 5
+		m.flagConditions = []FlagCondition{
+			{ID: 5, Type: FlagClusterID, Pattern: "existing"},
+		}
+		m.incidentClusterMap = make(map[string][]string)
+		m.clusterCache = make(map[string]*ocm.ClusterInfo)
+
+		cond := FlagCondition{Type: FlagOrgName, Pattern: "Acme", CreatedAt: time.Now()}
+		result, _ := m.Update(addFlagConditionMsg{condition: cond})
+		updated := result.(model)
+
+		assert.Len(t, updated.flagConditions, 2)
+		assert.Equal(t, 6, updated.flagConditions[1].ID)
+		assert.Equal(t, 6, updated.flagNextID)
+	})
+}
+
+func TestRemoveFlagConditionMsg(t *testing.T) {
+	t.Run("removes condition by ID", func(t *testing.T) {
+		m := createTestModel()
+		m.flagMarker = defaultFlagMarker
+		m.flagConditions = []FlagCondition{
+			{ID: 1, Type: FlagClusterID, Pattern: "cluster1"},
+			{ID: 2, Type: FlagOrgName, Pattern: "Acme"},
+			{ID: 3, Type: FlagClusterID, Pattern: "cluster3"},
+		}
+		m.incidentClusterMap = make(map[string][]string)
+		m.clusterCache = make(map[string]*ocm.ClusterInfo)
+
+		result, _ := m.Update(removeFlagConditionMsg{id: 2})
+		updated := result.(model)
+
+		assert.Len(t, updated.flagConditions, 2)
+		assert.Equal(t, 1, updated.flagConditions[0].ID)
+		assert.Equal(t, 3, updated.flagConditions[1].ID)
+	})
+}
+
+func TestRemoveFlagConditionMsg_NotFound(t *testing.T) {
+	t.Run("no-op for unknown ID", func(t *testing.T) {
+		m := createTestModel()
+		m.flagMarker = defaultFlagMarker
+		m.flagConditions = []FlagCondition{
+			{ID: 1, Type: FlagClusterID, Pattern: "cluster1"},
+		}
+		m.incidentClusterMap = make(map[string][]string)
+		m.clusterCache = make(map[string]*ocm.ClusterInfo)
+
+		result, _ := m.Update(removeFlagConditionMsg{id: 99})
+		updated := result.(model)
+
+		assert.Len(t, updated.flagConditions, 1)
+	})
+}
+
+func TestClearFlagConditionsMsg(t *testing.T) {
+	t.Run("removes all conditions", func(t *testing.T) {
+		m := createTestModel()
+		m.flagMarker = defaultFlagMarker
+		m.flagConditions = []FlagCondition{
+			{ID: 1, Type: FlagClusterID, Pattern: "a"},
+			{ID: 2, Type: FlagOrgName, Pattern: "b"},
+		}
+		m.flagMatchCache = map[string][]int{"INC001": {1}}
+		m.incidentClusterMap = make(map[string][]string)
+		m.clusterCache = make(map[string]*ocm.ClusterInfo)
+
+		result, _ := m.Update(clearFlagConditionsMsg{})
+		updated := result.(model)
+
+		assert.Empty(t, updated.flagConditions)
+		assert.Nil(t, updated.flagMatchCache)
+	})
+}
+
+func TestRebuildFlagMatchCache(t *testing.T) {
+	t.Run("rebuilds cache from current state", func(t *testing.T) {
+		m := createTestModel()
+		m.flagMarker = defaultFlagMarker
+		m.flagConditions = []FlagCondition{
+			{ID: 1, Type: FlagClusterID, Pattern: "cluster1"},
+		}
+		m.incidentList = []pagerduty.Incident{
+			{APIObject: pagerduty.APIObject{ID: "INC001"}},
+		}
+		m.incidentClusterMap = map[string][]string{
+			"INC001": {"cluster1"},
+		}
+		m.clusterCache = make(map[string]*ocm.ClusterInfo)
+
+		m.rebuildFlagMatchCache()
+
+		assert.Equal(t, []int{1}, m.flagMatchCache["INC001"])
+	})
+}
+
+func TestRebuildFlagMatchCache_NoConditions(t *testing.T) {
+	t.Run("clears cache when no conditions", func(t *testing.T) {
+		m := createTestModel()
+		m.flagMarker = defaultFlagMarker
+		m.flagConditions = nil
+		m.flagMatchCache = map[string][]int{"INC001": {1}}
+
+		m.rebuildFlagMatchCache()
+
+		assert.Nil(t, m.flagMatchCache)
+	})
+}
+
+func TestRenderFlagConditionsSection(t *testing.T) {
+	t.Run("renders flag section for flagged incident", func(t *testing.T) {
+		m := createTestModel()
+		m.flagMarker = defaultFlagMarker
+		m.flagConditions = []FlagCondition{
+			{ID: 1, Type: FlagClusterID, Pattern: "cluster1", Label: "cluster ID matches \"cluster1\""},
+			{ID: 2, Type: FlagOrgName, Pattern: "Acme", Label: "org name matches \"Acme\""},
+		}
+		m.flagMatchCache = map[string][]int{"INC001": {1, 2}}
+		m.selectedIncident = &pagerduty.Incident{
+			APIObject: pagerduty.APIObject{ID: "INC001"},
+		}
+
+		content := m.renderFlagConditionsSection()
+		assert.Contains(t, content, "Flag Conditions")
+		assert.Contains(t, content, "cluster ID matches")
+		assert.Contains(t, content, "org name matches")
+	})
+}
+
+func TestRenderFlagConditionsSection_NoFlags(t *testing.T) {
+	t.Run("returns empty when incident not flagged", func(t *testing.T) {
+		m := createTestModel()
+		m.flagMarker = defaultFlagMarker
+		m.selectedIncident = &pagerduty.Incident{
+			APIObject: pagerduty.APIObject{ID: "INC001"},
+		}
+
+		content := m.renderFlagConditionsSection()
+		assert.Empty(t, content)
+	})
+}
+
+func TestRenderFlagConditionsSection_NoIncident(t *testing.T) {
+	t.Run("returns empty when no incident selected", func(t *testing.T) {
+		m := createTestModel()
+		m.flagMarker = defaultFlagMarker
+
+		content := m.renderFlagConditionsSection()
+		assert.Empty(t, content)
+	})
+}
+
+func TestFormatFlagsList(t *testing.T) {
+	t.Run("formats list of active flags", func(t *testing.T) {
+		conditions := []FlagCondition{
+			{ID: 1, Type: FlagClusterID, Pattern: "cluster1", Label: "cluster ID matches \"cluster1\""},
+			{ID: 2, Type: FlagOrgName, Pattern: "^Acme*", Label: "org name matches \"^Acme*\""},
+		}
+
+		content := formatFlagsList(conditions)
+		assert.Contains(t, content, "#1")
+		assert.Contains(t, content, "#2")
+		assert.Contains(t, content, "cluster ID matches")
+		assert.Contains(t, content, "org name matches")
+	})
+}
+
+func TestFormatFlagsList_Empty(t *testing.T) {
+	t.Run("shows no active flags message", func(t *testing.T) {
+		content := formatFlagsList(nil)
+		assert.Contains(t, content, "No active flag conditions")
+	})
+}

--- a/pkg/tui/keymap.go
+++ b/pkg/tui/keymap.go
@@ -17,7 +17,7 @@ func (k keymap) FullHelp() [][]key.Binding {
 		// Column 1: Help at top, navigation
 		{k.Help, k.Up, k.Down, k.Top, k.Bottom, k.Enter, k.Back},
 		// Column 2: Primary incident actions
-		{k.Ack, k.Note, k.Login, k.Open, k.SOP, k.UnAck, k.Silence, k.Merge},
+		{k.Ack, k.Note, k.Login, k.Open, k.SOP, k.UnAck, k.Silence, k.Merge, k.Flag},
 		// Column 3: Settings & toggles, Quit at bottom
 		{k.Team, k.Refresh, k.AutoRefresh, k.AutoAck, k.Urgency, k.ViewLog, k.Quit},
 		// Column 4: Tab navigation (incident viewer)
@@ -57,6 +57,7 @@ type keymap struct {
 	SOP         key.Binding
 	ViewLog     key.Binding
 	Merge       key.Binding
+	Flag        key.Binding
 	TabNext     key.Binding
 	TabPrev     key.Binding
 }
@@ -186,6 +187,10 @@ var defaultKeyMap = keymap{
 	Merge: key.NewBinding(
 		key.WithKeys("m"),
 		key.WithHelp("m", "merge incident"),
+	),
+	Flag: key.NewBinding(
+		key.WithKeys("f"),
+		key.WithHelp("f", "flag condition"),
 	),
 	TabNext: key.NewBinding(
 		key.WithKeys("tab", "right"),

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -161,6 +161,12 @@ type model struct {
 	serviceLogCache       map[string][]ocm.ServiceLog
 	limitedSupportCache   map[string][]ocm.LimitedSupportReason
 
+	// Flag conditions state
+	flagConditions []FlagCondition
+	flagNextID     int
+	flagMarker     string
+	flagMatchCache map[string][]int // incident ID → matching condition IDs
+
 	// Dependency injection for testability
 	pdClientFactory func(string) pd.PagerDutyClient
 	configFS        pkgconfig.ConfigFS
@@ -243,6 +249,7 @@ func InitialModel(
 		clusterCache:          make(map[string]*ocm.ClusterInfo),
 		serviceLogCache:       make(map[string][]ocm.ServiceLog),
 		limitedSupportCache:   make(map[string][]ocm.LimitedSupportReason),
+		flagMarker:            defaultFlagMarker,
 		chordPrefix:           "ctrl+x",
 		theme:                 theme,
 		styles:                styles,
@@ -327,6 +334,7 @@ func InitialModelWithConfig(
 		clusterCache:          make(map[string]*ocm.ClusterInfo),
 		serviceLogCache:       make(map[string][]ocm.ServiceLog),
 		limitedSupportCache:   make(map[string][]ocm.LimitedSupportReason),
+		flagMarker:            defaultFlagMarker,
 		theme:                 theme,
 		styles:                styles,
 	}

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -155,6 +155,14 @@ func (m model) keyMsgHandler(msg tea.Msg) (tea.Model, tea.Cmd) {
 		)
 	}
 
+	if key.Matches(msg.(tea.KeyMsg), defaultKeyMap.Flag) {
+		m.input.SetValue("/flag ")
+		m.input.SetCursor(len("/flag "))
+		return m, tea.Sequence(
+			m.input.Focus(),
+		)
+	}
+
 	// Default commands for the table view
 	switch {
 	case m.configMode:
@@ -687,15 +695,17 @@ func switchInputFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 
 		case key.Matches(msg, defaultKeyMap.Enter):
-			// Extract the input text, reset input, and dispatch to Claude
 			prompt := m.input.Value()
 			m.input.Reset()
 			m.input.Blur()
 			m.table.Focus()
 
-			// Don't dispatch on empty input
 			if prompt == "" {
 				return m, nil
+			}
+
+			if isFlagCommand(prompt) {
+				return m, m.dispatchFlagCommand(prompt)
 			}
 
 			return m, func() tea.Msg {

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -374,6 +374,61 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		enrichCmds = append(enrichCmds, m.flashNotification("OCM connected — enriching cluster data"))
 		return m, tea.Batch(enrichCmds...)
 
+	case addFlagConditionMsg:
+		m.flagNextID++
+		msg.condition.ID = m.flagNextID
+		m.flagConditions = append(m.flagConditions, msg.condition)
+		m.rebuildFlagMatchCache()
+		return m, m.flashNotification(fmt.Sprintf("flag #%d added: %s", msg.condition.ID, msg.condition.Label))
+
+	case removeFlagConditionMsg:
+		for i, c := range m.flagConditions {
+			if c.ID == msg.id {
+				m.flagConditions = append(m.flagConditions[:i], m.flagConditions[i+1:]...)
+				break
+			}
+		}
+		m.rebuildFlagMatchCache()
+		return m, m.flashNotification(fmt.Sprintf("flag #%d removed", msg.id))
+
+	case clearFlagConditionsMsg:
+		m.flagConditions = nil
+		m.rebuildFlagMatchCache()
+		return m, m.flashNotification("all flags cleared")
+
+	case listFlagConditionsMsg:
+		content := formatFlagsList(m.flagConditions)
+		rendered, renderErr := renderIncidentMarkdown(&m, content)
+		if renderErr != nil {
+			rendered = content
+		}
+		m.incidentViewer.SetContent(rendered)
+		m.incidentViewer.GotoTop()
+		m.viewingIncident = true
+		m.table.Blur()
+		return m, nil
+
+	case flagsSavedMsg:
+		if msg.err != nil {
+			return m, m.flashNotification("flags save failed: " + msg.err.Error())
+		}
+		return m, m.flashNotification(fmt.Sprintf("flags saved (%d conditions)", len(m.flagConditions)))
+
+	case flagsLoadedMsg:
+		if msg.err != nil {
+			return m, m.flashNotification("flags load failed: " + msg.err.Error())
+		}
+		m.flagConditions = msg.conditions
+		maxID := 0
+		for _, c := range m.flagConditions {
+			if c.ID > maxID {
+				maxID = c.ID
+			}
+		}
+		m.flagNextID = maxID
+		m.rebuildFlagMatchCache()
+		return m, m.flashNotification(fmt.Sprintf("flags loaded (%d conditions)", len(m.flagConditions)))
+
 	case spinner.TickMsg:
 		var cmd tea.Cmd
 		m.spinner, cmd = m.spinner.Update(msg)
@@ -695,6 +750,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Apply urgency filter before building table rows
 		filteredIncidents := filterByUrgency(m.incidentList, m.showLowUrgency)
 
+		m.rebuildFlagMatchCache()
+
 		var rows []table.Row
 
 		for _, i := range filteredIncidents {
@@ -738,7 +795,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						serviceName = serviceName + suffix
 					}
 				}
-				rows = append(rows, table.Row{state, i.ID, i.Title, serviceName})
+				title := i.Title
+				if matchedFlags, ok := m.flagMatchCache[i.ID]; ok && len(matchedFlags) > 0 {
+					title = m.flagMarker + title
+				}
+				rows = append(rows, table.Row{state, i.ID, title, serviceName})
 			}
 		}
 

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -333,6 +333,8 @@ func (m model) renderDetailsTab(summary incidentSummary) (string, error) {
 		content += clusters.String()
 	}
 
+	content += m.renderFlagConditionsSection()
+
 	return content, nil
 }
 


### PR DESCRIPTION
## Summary

- Add session-only flag conditions that visually mark matching incidents in the table with a configurable marker prefix (default 🚩, configurable to `|►` via `flag_marker` config)
- Conditions match by cluster ID (internal, external, or raw alert ID) or organization name with glob patterns (`^STRING`, `STRING$`, `STRING*`, plain `STRING`)
- `/flag cluster <id>`, `/flag org <pattern>` to add; `/flags` to list; `/unflag <id>` to remove
- `f` key opens input with `/flag ` pre-filled; `:` then `/flag ...` also works
- Matched flags shown in the Details tab of the incident viewer
- Save/load to JSON via `/flags save` and `/flags load`
- Full feature documentation in `docs/flag-conditions.md` with save file spec

Fixes #280

Follow-up issue for SUPPORTEX and OHSS condition types: #303

## Test plan

- [x] `make test-all` passes (fmt, vet, lint, unit tests, race detector)
- [x] 76 new tests across `flags_test.go` and `flag_commands_test.go`
- [x] Core matching logic at 100% coverage
- [x] Command parsing at 77-100% coverage
- [x] Save/load round-trip tested with temp dirs
- [x] All tests self-contained — no API calls, no real FS paths, no host access

🤖 Generated with [Claude Code](https://claude.com/claude-code)