### PR TITLE
Fix global key bindings intercepting text input during input mode (#308)

### DIFF
--- a/docs/plans/092-fix-input-mode-keybinding-conflict.md
+++ b/docs/plans/092-fix-input-mode-keybinding-conflict.md
@@ -1,0 +1,30 @@
+# Plan: Fix input mode key binding conflict (#308)
+
+**Status:** Complete
+**Issue:** #308
+**PR:** #310
+
+## Problem
+
+Global key handlers in `keyMsgHandler()` intercept keypresses before
+they reach `switchInputFocusMode()`. Keys like `u` (urgency toggle),
+`i`/`:` (input focus), `ctrl+r` (auto-refresh), and `ctrl+a` (auto-ack)
+are consumed by global handlers, preventing users from typing those
+characters in the input field.
+
+## Solution
+
+Add an `m.input.Focused()` early return after chord handling (which
+already correctly gates on `!m.input.Focused()`) and before global key
+handlers. When input is focused, only Quit passes through globally;
+everything else routes to `switchInputFocusMode()`.
+
+## Files changed
+
+- `pkg/tui/msgHandlers.go` — 7-line guard added at line 132
+- `pkg/tui/msgHandlers_test.go` — 8 new tests covering all intercepted
+  keys plus preserved Escape/Enter/Ctrl+C behavior
+
+## Post-mortem / lessons learned
+
+_(to be completed after merge)_

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -129,6 +129,13 @@ func (m model) keyMsgHandler(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 
+	if m.input.Focused() {
+		if key.Matches(msg.(tea.KeyMsg), defaultKeyMap.Quit) {
+			return m, tea.Quit
+		}
+		return switchInputFocusMode(m, msg)
+	}
+
 	if key.Matches(msg.(tea.KeyMsg), defaultKeyMap.Quit) {
 		return m, tea.Quit
 	}

--- a/pkg/tui/msgHandlers_test.go
+++ b/pkg/tui/msgHandlers_test.go
@@ -969,3 +969,116 @@ func TestBulkSilenceMode_ConfirmationPrompt(t *testing.T) {
 		assert.Contains(t, updated.pendingConfirmation.prompt, "2 incident(s)")
 	})
 }
+
+// createInputFocusedModel creates a test model with a focused text input
+// containing the given initial value. Used for testing that global key
+// bindings are bypassed during input mode.
+func createInputFocusedModel(initialValue string) model {
+	m := createTestModel()
+	m.input = newTextInput()
+	m.input.Focus()
+	if initialValue != "" {
+		m.input.SetValue(initialValue)
+		m.input.SetCursor(len(initialValue))
+	}
+	return m
+}
+
+func TestInputMode_TypingU_DoesNotToggleUrgency(t *testing.T) {
+	m := createInputFocusedModel("")
+	m.showLowUrgency = false
+
+	keyMsg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'u'}}
+	result, _ := m.keyMsgHandler(keyMsg)
+	updated := result.(model)
+
+	assert.False(t, updated.showLowUrgency, "pressing 'u' in input mode must not toggle urgency")
+	assert.True(t, updated.input.Focused(), "input must remain focused")
+	assert.Contains(t, updated.input.Value(), "u", "input value must contain the typed 'u'")
+}
+
+func TestInputMode_TypingI_DoesNotReFocusInput(t *testing.T) {
+	m := createInputFocusedModel("test")
+
+	keyMsg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}}
+	result, _ := m.keyMsgHandler(keyMsg)
+	updated := result.(model)
+
+	assert.True(t, updated.input.Focused(), "input must remain focused")
+	assert.Contains(t, updated.input.Value(), "i", "input value must contain the typed 'i'")
+}
+
+func TestInputMode_TypingColon_DoesNotReFocusInput(t *testing.T) {
+	m := createInputFocusedModel("test")
+
+	keyMsg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{':'}}
+	result, _ := m.keyMsgHandler(keyMsg)
+	updated := result.(model)
+
+	assert.True(t, updated.input.Focused(), "input must remain focused")
+	assert.Contains(t, updated.input.Value(), ":", "input value must contain the typed ':'")
+}
+
+func TestInputMode_CtrlR_DoesNotToggleAutoRefresh(t *testing.T) {
+	m := createInputFocusedModel("test")
+	m.autoRefresh = false
+
+	keyMsg := tea.KeyMsg{Type: tea.KeyCtrlR}
+	result, _ := m.keyMsgHandler(keyMsg)
+	updated := result.(model)
+
+	assert.False(t, updated.autoRefresh, "ctrl+r in input mode must not toggle autoRefresh")
+	assert.True(t, updated.input.Focused(), "input must remain focused")
+}
+
+func TestInputMode_CtrlA_DoesNotToggleAutoAck(t *testing.T) {
+	m := createInputFocusedModel("test")
+	m.autoAcknowledge = false
+
+	keyMsg := tea.KeyMsg{Type: tea.KeyCtrlA}
+	result, _ := m.keyMsgHandler(keyMsg)
+	updated := result.(model)
+
+	assert.False(t, updated.autoAcknowledge, "ctrl+a in input mode must not toggle autoAcknowledge")
+	assert.True(t, updated.input.Focused(), "input must remain focused")
+}
+
+func TestInputMode_CtrlC_StillQuits(t *testing.T) {
+	m := createInputFocusedModel("test")
+
+	keyMsg := tea.KeyMsg{Type: tea.KeyCtrlC}
+	_, cmd := m.keyMsgHandler(keyMsg)
+
+	assert.NotNil(t, cmd, "ctrl+c must still produce a command")
+	msg := cmd()
+	_, isQuit := msg.(tea.QuitMsg)
+	assert.True(t, isQuit, "ctrl+c in input mode must still quit")
+}
+
+func TestInputMode_Escape_StillExitsInput(t *testing.T) {
+	m := createInputFocusedModel("test")
+
+	keyMsg := tea.KeyMsg{Type: tea.KeyEscape}
+	result, _ := m.keyMsgHandler(keyMsg)
+	updated := result.(model)
+
+	assert.False(t, updated.input.Focused(), "Escape must blur the input")
+	assert.Empty(t, updated.input.Value(), "Escape must reset the input value")
+}
+
+func TestInputMode_Enter_StillDispatchesPrompt(t *testing.T) {
+	m := createInputFocusedModel("investigate this alert")
+
+	keyMsg := tea.KeyMsg{Type: tea.KeyEnter}
+	result, cmd := m.keyMsgHandler(keyMsg)
+	updated := result.(model)
+
+	assert.False(t, updated.input.Focused(), "Enter must blur the input")
+	assert.Empty(t, updated.input.Value(), "Enter must reset the input value")
+	assert.NotNil(t, cmd, "Enter must dispatch a command")
+
+	msg := cmd()
+	promptMsg, ok := msg.(claudePromptMsg)
+	assert.True(t, ok, "dispatched message must be claudePromptMsg")
+	assert.Equal(t, "investigate this alert", promptMsg.prompt)
+}


### PR DESCRIPTION
## Summary

- Add input-focused guard in `keyMsgHandler()` that routes all keys except Quit directly to `switchInputFocusMode()`, preventing global handlers from consuming keys like `u`, `i`, `:`, `ctrl+r`, and `ctrl+a` during text input
- Add 8 tests covering all intercepted key bindings plus preserved behavior (Escape, Enter, Ctrl+C)

## Test plan

- [x] `make test` — all tests pass
- [x] `make test-race` — no race conditions
- [x] `make lint` — 0 issues
- [x] `make fmt-check` — clean
- [x] `make vet` — clean
- [x] Manual test: built binary to `~/.local/bin/srepd`, verified `u`/`i`/`:` type correctly in input mode

Fixes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)