### PR TITLE
Require /agent prefix for Claude queries in input mode (#309)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Press `h` to toggle the help overlay inside srepd.
 | `ctrl+r` | Toggle auto-refresh | `u` | Toggle urgency filter |
 | `ctrl+a` | Toggle auto-acknowledge | `ctrl+l` | View debug log |
 | `ctrl+q`/`ctrl+c` | Quit | `1`-`9` | Select cluster |
-| `i`/`:` | Ask Claude | `m` | Merge incident |
+| `i`/`:` | Command input | `m` | Merge incident |
 | `f` | Flag condition | | |
 | `ctrl+x` + key | Chord commands | `ctrl+x ?` | Show chord help |
 | `Tab`/`Shift+Tab`/`←`/`→` | Switch tabs (incident view) | `↑`/`↓` | Scroll within tab |

--- a/docs/plans/093-agent-slash-command.md
+++ b/docs/plans/093-agent-slash-command.md
@@ -1,0 +1,32 @@
+# Plan: Require /agent prefix for Claude queries (#309)
+
+**Status:** Complete
+**Issue:** #309
+**PR:** TBD
+
+## Problem
+
+With flag conditions (PR #304), the input field supports `/flag` slash
+commands. Bare text still falls through to Claude dispatch, which is
+inconsistent. All input commands should use explicit prefixes.
+
+## Solution
+
+Require `/agent <query>` prefix for Claude queries. Bare text without a
+recognized slash command shows an error with available commands.
+
+The `i`/`:` keys open a blank input prompt (no pre-fill) so users can
+type any command: `/agent`, `/flag`, `/flags`, `/unflag`.
+
+## Files changed
+
+- `pkg/tui/claude.go` — add `isAgentCommand()`, `parseAgentQuery()`
+- `pkg/tui/claude_test.go` — 11 new tests, 2 updated existing tests
+- `pkg/tui/msgHandlers.go` — update Enter dispatch to require prefix
+- `pkg/tui/msgHandlers_test.go` — update 1 existing test for /agent
+- `pkg/tui/keymap.go` — update help text to "command input"
+- `README.md` — update key binding table
+
+## Post-mortem / lessons learned
+
+_(to be completed after merge)_

--- a/pkg/tui/claude.go
+++ b/pkg/tui/claude.go
@@ -183,3 +183,12 @@ func truncatePrompt(s string, maxLen int) string {
 func defaultHasClaudeCode() bool {
 	return launcher.HasClaudeCode()
 }
+
+func isAgentCommand(input string) bool {
+	trimmed := strings.TrimSpace(input)
+	return strings.HasPrefix(trimmed, "/agent ") || trimmed == "/agent"
+}
+
+func parseAgentQuery(input string) string {
+	return strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(input), "/agent"))
+}

--- a/pkg/tui/claude_test.go
+++ b/pkg/tui/claude_test.go
@@ -16,14 +16,14 @@ func TestInputCharLimit_Increased(t *testing.T) {
 }
 
 func TestClaudePrompt_DispatchesCommand(t *testing.T) {
-	// When the user is in input focus mode and presses Enter,
-	// a claudePromptMsg should be dispatched with the input text,
+	// When the user is in input focus mode and presses Enter with /agent prefix,
+	// a claudePromptMsg should be dispatched with the query text (prefix stripped),
 	// the input should be reset and blurred.
 
 	m := createTestModel()
 	m.input = newTextInput()
 	m.input.Focus()
-	m.input.SetValue("investigate this alert")
+	m.input.SetValue("/agent investigate this alert")
 
 	// Simulate pressing Enter in input focus mode
 	enterMsg := tea.KeyMsg{Type: tea.KeyEnter}
@@ -37,11 +37,11 @@ func TestClaudePrompt_DispatchesCommand(t *testing.T) {
 	// A command should be returned
 	assert.NotNil(t, cmd, "Enter in input mode should return a command")
 
-	// The command should produce a claudePromptMsg
+	// The command should produce a claudePromptMsg with prefix stripped
 	msg := cmd()
 	promptMsg, ok := msg.(claudePromptMsg)
 	assert.True(t, ok, "Command should produce a claudePromptMsg, got %T", msg)
-	assert.Equal(t, "investigate this alert", promptMsg.prompt, "Prompt text should match input value")
+	assert.Equal(t, "investigate this alert", promptMsg.prompt, "Prompt text should have /agent prefix stripped")
 }
 
 func TestClaudePrompt_EmptyInput(t *testing.T) {
@@ -256,7 +256,7 @@ func TestInputFocusMode_TableRegainsFocusOnBlur(t *testing.T) {
 	m := createTestModelWithTableRows(incidents)
 	m.input = newTextInput()
 	m.input.Focus()
-	m.input.SetValue("query text")
+	m.input.SetValue("/agent query text")
 
 	// Simulate pressing Enter
 	enterMsg := tea.KeyMsg{Type: tea.KeyEnter}
@@ -444,4 +444,73 @@ func TestBuildClaudeEnvVars_NoAlerts(t *testing.T) {
 	assert.False(t, hasAlertNames, "no alerts means no alert names")
 }
 
-// Helper to create a model with a table for input focus testing
+func TestIsAgentCommand_Valid(t *testing.T) {
+	assert.True(t, isAgentCommand("/agent investigate this alert"))
+}
+
+func TestIsAgentCommand_BareSlashAgent(t *testing.T) {
+	assert.True(t, isAgentCommand("/agent"))
+}
+
+func TestIsAgentCommand_WithLeadingSpace(t *testing.T) {
+	assert.True(t, isAgentCommand("  /agent query"))
+}
+
+func TestIsAgentCommand_NotAgent(t *testing.T) {
+	assert.False(t, isAgentCommand("/flag cluster abc"))
+}
+
+func TestIsAgentCommand_PlainText(t *testing.T) {
+	assert.False(t, isAgentCommand("hello world"))
+}
+
+func TestParseAgentQuery_ExtractsQuery(t *testing.T) {
+	assert.Equal(t, "investigate this", parseAgentQuery("/agent investigate this"))
+}
+
+func TestParseAgentQuery_EmptyAfterPrefix(t *testing.T) {
+	assert.Equal(t, "", parseAgentQuery("/agent"))
+}
+
+func TestParseAgentQuery_PreservesExtraSpaces(t *testing.T) {
+	assert.Equal(t, "what happened to cluster abc", parseAgentQuery("/agent what happened to cluster abc"))
+}
+
+func TestInputMode_AgentCommand_DispatchesClaude(t *testing.T) {
+	m := createInputFocusedModel("/agent what happened")
+
+	keyMsg := tea.KeyMsg{Type: tea.KeyEnter}
+	result, cmd := m.keyMsgHandler(keyMsg)
+	updated := result.(model)
+
+	assert.False(t, updated.input.Focused(), "input must be blurred after Enter")
+	assert.NotNil(t, cmd, "/agent command must dispatch a command")
+
+	msg := cmd()
+	promptMsg, ok := msg.(claudePromptMsg)
+	assert.True(t, ok, "dispatched message must be claudePromptMsg")
+	assert.Equal(t, "what happened", promptMsg.prompt, "query must have /agent prefix stripped")
+}
+
+func TestInputMode_BareText_ShowsError(t *testing.T) {
+	m := createInputFocusedModel("hello world")
+
+	keyMsg := tea.KeyMsg{Type: tea.KeyEnter}
+	result, cmd := m.keyMsgHandler(keyMsg)
+	updated := result.(model)
+
+	assert.False(t, updated.input.Focused(), "input must be blurred after Enter")
+	assert.Nil(t, cmd, "bare text must not dispatch any command")
+	assert.Contains(t, updated.status, "unknown command", "status must show error for bare text")
+}
+
+func TestInputMode_EmptyAgent_ShowsUsage(t *testing.T) {
+	m := createInputFocusedModel("/agent")
+
+	keyMsg := tea.KeyMsg{Type: tea.KeyEnter}
+	result, cmd := m.keyMsgHandler(keyMsg)
+	updated := result.(model)
+
+	assert.Nil(t, cmd, "/agent with no query must not dispatch")
+	assert.Contains(t, updated.status, "usage", "status must show usage hint")
+}

--- a/pkg/tui/keymap.go
+++ b/pkg/tui/keymap.go
@@ -166,7 +166,7 @@ var defaultKeyMap = keymap{
 	),
 	Input: key.NewBinding(
 		key.WithKeys("i", ":"),
-		key.WithHelp("i/:", "input"),
+		key.WithHelp("i/:", "command input"),
 	),
 	Login: key.NewBinding(
 		key.WithKeys("l"),

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -715,9 +715,19 @@ func switchInputFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, m.dispatchFlagCommand(prompt)
 			}
 
-			return m, func() tea.Msg {
-				return claudePromptMsg{prompt: prompt}
+			if isAgentCommand(prompt) {
+				query := parseAgentQuery(prompt)
+				if query == "" {
+					m.setStatus("usage: /agent <query>")
+					return m, nil
+				}
+				return m, func() tea.Msg {
+					return claudePromptMsg{prompt: query}
+				}
 			}
+
+			m.setStatus("unknown command — try /agent <query> or /flag <type> <value>")
+			return m, nil
 
 		default:
 			// Pass ALL other keypresses (including 'h') to the input component

--- a/pkg/tui/msgHandlers_test.go
+++ b/pkg/tui/msgHandlers_test.go
@@ -1067,7 +1067,7 @@ func TestInputMode_Escape_StillExitsInput(t *testing.T) {
 }
 
 func TestInputMode_Enter_StillDispatchesPrompt(t *testing.T) {
-	m := createInputFocusedModel("investigate this alert")
+	m := createInputFocusedModel("/agent investigate this alert")
 
 	keyMsg := tea.KeyMsg{Type: tea.KeyEnter}
 	result, cmd := m.keyMsgHandler(keyMsg)


### PR DESCRIPTION
## Summary

- Input field now uses slash commands consistently: `/agent <query>` for Claude queries, `/flag` for flag conditions
- Bare text without a recognized prefix shows an error: `"unknown command — try /agent <query> or /flag <type> <value>"`
- `/agent` with no query shows usage hint
- `i`/`:` keys open a blank prompt (no pre-fill) — users type any command
- Help text updated from "Ask Claude" to "command input"

## Test plan

- [x] `make fmt-check` — clean
- [x] `make vet` — clean
- [x] `make lint` — 0 issues
- [x] `make test` — all tests pass (11 new, 3 updated)
- [x] `make test-race` — no race conditions
- [x] Built binary to `~/.local/bin/srepd` for manual testing

Fixes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)