### PR TITLE
Make agent CLI command configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ If no config file exists, running `srepd` automatically enters the configuration
 | `toolbox_mode` | `string` | `auto` | Toolbox detection: `auto`, `true`, or `false` |
 | `chord_prefix` | `string` | `ctrl+x` | Prefix key for chord commands |
 | `flag_marker` | `string` | `🚩 ` | Prefix marker for flagged incidents (alt: `\|►`) |
+| `agent_cli_command` | `string` | `claude --print` | CLI agent command for `/agent` queries |
 | `colors` | `map[string]string` | (defaults) | Custom color scheme (hex values) |
 
 ### Colors

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -106,6 +106,7 @@ func launchTUIWithConfig() {
 		true, // configMode
 		ocmAuthPending,
 		nil, // aiProvider — not needed in config mode
+		"",  // agentCLICommand — not needed in config mode
 	)
 
 	p := tea.NewProgram(m, tea.WithAltScreen())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -201,6 +201,7 @@ func launchTUI() {
 		false,
 		ocmAuthPending,
 		aiProvider,
+		viper.GetString("agent_cli_command"),
 	)
 
 	p := tea.NewProgram(m, tea.WithAltScreen())
@@ -382,6 +383,7 @@ func runDevMode() {
 		viper.GetBool("debug"),
 		ocmMock,
 		nil, // aiProvider — not used in dev mode
+		"",  // agentCLICommand — uses default in dev mode
 	)
 
 	p := tea.NewProgram(m, tea.WithAltScreen())

--- a/docs/plans/061-configurable-agent-cli.md
+++ b/docs/plans/061-configurable-agent-cli.md
@@ -1,0 +1,24 @@
+# Plan: Configurable CLI Agent Command
+
+**Issue:** #307
+**Branch:** `srepd/configurable-agent-cli`
+
+## Goal
+
+Replace the hardcoded `claude --print` command in `/agent` queries with a
+configurable `agent_cli_command` config key. This fixes the bug where
+`exec.CommandContext(ctx, "claude", "--print")` fails when `claude` is a
+shell alias/function or not on PATH.
+
+## Changes
+
+- `pkg/config/config.go`: Add `agent_cli_command` to DefaultOptionalKeys
+  (default: `"claude --print"`) and OptionalKeys
+- `pkg/tui/model.go`: Add `agentCLICommand string` field, add parameter
+  to both `InitialModel` and `InitialModelWithConfig`
+- `pkg/tui/claude.go`: Replace hardcoded `exec.CommandContext(ctx, "claude", "--print")`
+  with command parsed from `m.agentCLICommand` via `strings.Fields()`.
+  Change `handleClaudePrompt` to accept `lookPath func(string) (string, error)`
+  instead of `hasClaudeCode func() bool` for binary detection.
+- `cmd/root.go`: Read `viper.GetString("agent_cli_command")`, pass to InitialModel
+- All call sites and tests updated

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,6 +31,7 @@ var (
 		"toolbox_mode":          "auto",
 		"chord_prefix":          "ctrl+x",
 		"flag_marker":           "🚩 ",
+		"agent_cli_command":     "claude --print",
 	}
 	OptionalKeys = map[string]string{
 		"editor":                             fmt.Sprintf("Editor to use for notes (default: %v)", DefaultOptionalKeys["editor"]),
@@ -39,6 +40,7 @@ var (
 		"toolbox_mode":                       fmt.Sprintf("Toolbox detection mode: auto, true, false (default: %v)", DefaultOptionalKeys["toolbox_mode"]),
 		"chord_prefix":                       fmt.Sprintf("Chord prefix key for multi-key commands (default: %v)", DefaultOptionalKeys["chord_prefix"]),
 		"flag_marker":                        fmt.Sprintf("Prefix marker for flagged incidents (default: %v, alt: |►)", DefaultOptionalKeys["flag_marker"]),
+		"agent_cli_command":                  fmt.Sprintf("CLI agent command for /agent queries (default: %v)", DefaultOptionalKeys["agent_cli_command"]),
 		"colors":                             "Custom color scheme (map of color name to hex value)",
 		"default_silent_escalation_policy":   "Default silent escalation policy ID (auto-discovered via srepd config)",
 		"custom_service_escalation_policies": "Per-service silent policy overrides (service ID → policy ID)",

--- a/pkg/tui/claude.go
+++ b/pkg/tui/claude.go
@@ -90,14 +90,27 @@ func agentQuery(agentCLICommand string, prompt string, incident *pagerduty.Incid
 		cmd.Stdin = strings.NewReader(claudeSystemPrompt + "\n\n" + prompt)
 		cmd.Env = append(os.Environ(), buildClaudeEnvVars(incident, alerts)...)
 
+		var stderr strings.Builder
+		cmd.Stderr = &stderr
+
 		log.Debug("tui.agentQuery()", "command", agentCLICommand, "prompt", prompt)
 
 		output, err := cmd.Output()
 		if err != nil {
+			stderrStr := strings.TrimSpace(stderr.String())
+			if stderrStr != "" {
+				log.Warn("tui.agentQuery()", "stderr", stderrStr)
+			}
 			if ctx.Err() == context.DeadlineExceeded {
 				return claudeResponseMsg{
 					response: "",
 					err:      fmt.Errorf("query timed out after %s", claudeTimeout),
+				}
+			}
+			if stderrStr != "" {
+				return claudeResponseMsg{
+					response: "",
+					err:      fmt.Errorf("agent error: %w: %s", err, stderrStr),
 				}
 			}
 			return claudeResponseMsg{

--- a/pkg/tui/claude.go
+++ b/pkg/tui/claude.go
@@ -11,7 +11,6 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/log"
-	"github.com/clcollins/srepd/pkg/launcher"
 )
 
 const (
@@ -74,20 +73,24 @@ func buildClaudeEnvVars(incident *pagerduty.Incident, alerts []pagerduty.Inciden
 	return envVars
 }
 
-// claudeQuery dispatches a prompt to the Claude CLI and returns the response.
-// The prompt is piped via stdin (no -p flag) for safety.
-func claudeQuery(prompt string, incident *pagerduty.Incident, alerts []pagerduty.IncidentAlert) tea.Cmd {
+// agentQuery dispatches a prompt to the configured CLI agent and returns the
+// response. The command is parsed from the agentCLICommand config string.
+// The prompt is piped via stdin for safety.
+func agentQuery(agentCLICommand string, prompt string, incident *pagerduty.Incident, alerts []pagerduty.IncidentAlert) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), claudeTimeout)
 		defer cancel()
 
-		cmd := exec.CommandContext(ctx, "claude", "--print")
-		cmd.Stdin = strings.NewReader(claudeSystemPrompt + "\n\n" + prompt)
+		args := strings.Fields(agentCLICommand)
+		if len(args) == 0 {
+			return claudeResponseMsg{err: fmt.Errorf("agent_cli_command is empty")}
+		}
 
-		// Set environment variables with PagerDuty context
+		cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+		cmd.Stdin = strings.NewReader(claudeSystemPrompt + "\n\n" + prompt)
 		cmd.Env = append(os.Environ(), buildClaudeEnvVars(incident, alerts)...)
 
-		log.Debug("tui.claudeQuery()", "prompt", prompt)
+		log.Debug("tui.agentQuery()", "command", agentCLICommand, "prompt", prompt)
 
 		output, err := cmd.Output()
 		if err != nil {
@@ -99,7 +102,7 @@ func claudeQuery(prompt string, incident *pagerduty.Incident, alerts []pagerduty
 			}
 			return claudeResponseMsg{
 				response: "",
-				err:      fmt.Errorf("claude error: %w", err),
+				err:      fmt.Errorf("agent error: %w", err),
 			}
 		}
 
@@ -111,12 +114,18 @@ func claudeQuery(prompt string, incident *pagerduty.Incident, alerts []pagerduty
 	}
 }
 
-// handleClaudePrompt processes a claudePromptMsg, checking for Claude availability
-// and dispatching the query command. The hasClaudeCode parameter allows injecting
-// a mock for testing.
-func (m model) handleClaudePrompt(msg claudePromptMsg, hasClaudeCode func() bool) (tea.Model, tea.Cmd) {
-	if !hasClaudeCode() {
-		m.setStatus("Claude Code not installed - install from https://claude.ai/download")
+// handleClaudePrompt processes a claudePromptMsg, checking for agent CLI
+// availability and dispatching the query command. The lookPath parameter
+// allows injecting a mock for testing.
+func (m model) handleClaudePrompt(msg claudePromptMsg, lookPath func(string) (string, error)) (tea.Model, tea.Cmd) {
+	agentCmd := m.agentCLICommand
+	if agentCmd == "" {
+		agentCmd = "claude --print"
+	}
+
+	binary := strings.Fields(agentCmd)[0]
+	if _, err := lookPath(binary); err != nil {
+		m.setStatus(fmt.Sprintf("agent CLI %q not found on PATH", binary))
 		return m, nil
 	}
 
@@ -124,14 +133,14 @@ func (m model) handleClaudePrompt(msg claudePromptMsg, hasClaudeCode func() bool
 	if m.selectedIncident != nil {
 		incidentID = m.selectedIncident.ID
 	}
-	log.Info("claude query initiated", "incident_id", incidentID, "prompt", truncatePrompt(msg.prompt, 80))
-	m.setStatus(fmt.Sprintf("querying Claude: %s", truncatePrompt(msg.prompt, 40)))
+	log.Info("agent query initiated", "command", agentCmd, "incident_id", incidentID, "prompt", truncatePrompt(msg.prompt, 80))
+	m.setStatus(fmt.Sprintf("querying agent: %s", truncatePrompt(msg.prompt, 40)))
 	m.claudeQuerying = true
 	m.apiInProgress = true
 
 	return m, tea.Batch(
 		m.spinner.Tick,
-		claudeQuery(msg.prompt, m.selectedIncident, m.selectedIncidentAlerts),
+		agentQuery(agentCmd, msg.prompt, m.selectedIncident, m.selectedIncidentAlerts),
 	)
 }
 
@@ -179,9 +188,9 @@ func truncatePrompt(s string, maxLen int) string {
 	return s[:maxLen] + "..."
 }
 
-// defaultHasClaudeCode wraps launcher.HasClaudeCode for production use
-func defaultHasClaudeCode() bool {
-	return launcher.HasClaudeCode()
+// defaultLookPath wraps exec.LookPath for production use
+func defaultLookPath(file string) (string, error) {
+	return exec.LookPath(file)
 }
 
 func isAgentCommand(input string) bool {

--- a/pkg/tui/claude_test.go
+++ b/pkg/tui/claude_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/PagerDuty/go-pagerduty"
@@ -64,21 +65,19 @@ func TestClaudePrompt_EmptyInput(t *testing.T) {
 }
 
 func TestClaudeNotFound_ShowsStatus(t *testing.T) {
-	// When claudePromptMsg is received but Claude is not installed,
-	// the status should show an appropriate message
-
 	m := createTestModel()
 	m.incidentCache = make(map[string]*cachedIncidentData)
+	m.agentCLICommand = "nonexistent-binary --print"
 
 	msg := claudePromptMsg{prompt: "test query"}
 
-	// Use the handler directly with a custom hasClaudeCode that returns false
-	result, cmd := m.handleClaudePrompt(msg, func() bool { return false })
+	result, cmd := m.handleClaudePrompt(msg, func(s string) (string, error) {
+		return "", fmt.Errorf("not found: %s", s)
+	})
 	updatedModel := result.(model)
 
-	assert.Contains(t, updatedModel.status, "Claude Code not installed",
-		"Status should indicate Claude is not available")
-	assert.Nil(t, cmd, "No command should be returned when Claude is not installed")
+	assert.Contains(t, updatedModel.status, "not found on PATH")
+	assert.Nil(t, cmd)
 }
 
 func TestClaudePrompt_ShowsSpinner(t *testing.T) {
@@ -93,13 +92,14 @@ func TestClaudePrompt_ShowsSpinner(t *testing.T) {
 
 	msg := claudePromptMsg{prompt: "test query"}
 
-	result, cmd := m.handleClaudePrompt(msg, func() bool { return true })
+	result, cmd := m.handleClaudePrompt(msg, func(s string) (string, error) {
+		return "/usr/bin/" + s, nil
+	})
 	updatedModel := result.(model)
 
 	assert.True(t, updatedModel.claudeQuerying, "claudeQuerying should be true")
 	assert.True(t, updatedModel.apiInProgress, "apiInProgress should be true for spinner")
-	assert.Contains(t, updatedModel.status, "querying Claude",
-		"Status should indicate Claude is being queried")
+	assert.Contains(t, updatedModel.status, "querying agent")
 	assert.NotNil(t, cmd, "A command should be returned to execute the query")
 }
 
@@ -287,7 +287,9 @@ func TestClaudePrompt_WithViewingIncident(t *testing.T) {
 
 	msg := claudePromptMsg{prompt: "what is wrong with this cluster?"}
 
-	result, cmd := m.handleClaudePrompt(msg, func() bool { return true })
+	result, cmd := m.handleClaudePrompt(msg, func(s string) (string, error) {
+		return "/usr/bin/" + s, nil
+	})
 	updatedModel := result.(model)
 
 	assert.True(t, updatedModel.claudeQuerying, "Should start querying")
@@ -323,17 +325,11 @@ func TestClaudeResponse_RendersWithPrefix(t *testing.T) {
 	// The actual prefix is added in the Update handler
 }
 
-func TestDefaultHasClaudeCode_NoPanic(t *testing.T) {
-	t.Run("defaultHasClaudeCode does not panic", func(t *testing.T) {
-		// defaultHasClaudeCode wraps launcher.HasClaudeCode which calls exec.LookPath.
-		// In a test environment where 'claude' is not installed, it should return false
-		// without panicking.
+func TestDefaultLookPath_NoPanic(t *testing.T) {
+	t.Run("defaultLookPath does not panic", func(t *testing.T) {
 		assert.NotPanics(t, func() {
-			result := defaultHasClaudeCode()
-			// In most test environments, claude CLI is not installed
-			// We just verify the function runs without panic and returns a bool
-			_ = result
-		}, "defaultHasClaudeCode should not panic regardless of claude installation status")
+			_, _ = defaultLookPath("nonexistent-binary-12345")
+		}, "defaultLookPath should not panic for missing binaries")
 	})
 }
 

--- a/pkg/tui/claude_test.go
+++ b/pkg/tui/claude_test.go
@@ -2,6 +2,8 @@ package tui
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/PagerDuty/go-pagerduty"
@@ -331,6 +333,125 @@ func TestDefaultLookPath_NoPanic(t *testing.T) {
 			_, _ = defaultLookPath("nonexistent-binary-12345")
 		}, "defaultLookPath should not panic for missing binaries")
 	})
+}
+
+func TestAgentQuery_EmptyCommand(t *testing.T) {
+	cmd := agentQuery("", "test prompt", nil, nil)
+	msg := cmd()
+	resp, ok := msg.(claudeResponseMsg)
+	assert.True(t, ok)
+	assert.Error(t, resp.err)
+	assert.Contains(t, resp.err.Error(), "agent_cli_command is empty")
+}
+
+func TestAgentQuery_CommandParsing(t *testing.T) {
+	cmd := agentQuery("echo hello world", "ignored", nil, nil)
+	msg := cmd()
+	resp, ok := msg.(claudeResponseMsg)
+	assert.True(t, ok)
+	assert.NoError(t, resp.err)
+	assert.Equal(t, "hello world", resp.response)
+}
+
+func TestAgentQuery_MultiWordCommand(t *testing.T) {
+	cmd := agentQuery("echo -n test", "ignored", nil, nil)
+	msg := cmd()
+	resp, ok := msg.(claudeResponseMsg)
+	assert.True(t, ok)
+	assert.NoError(t, resp.err)
+	assert.Equal(t, "test", resp.response)
+}
+
+func TestAgentQuery_CommandNotFound(t *testing.T) {
+	cmd := agentQuery("nonexistent-binary-99999 --flag", "test", nil, nil)
+	msg := cmd()
+	resp, ok := msg.(claudeResponseMsg)
+	assert.True(t, ok)
+	assert.Error(t, resp.err)
+	assert.Contains(t, resp.err.Error(), "agent error")
+}
+
+func TestAgentQuery_StderrCaptured(t *testing.T) {
+	script := filepath.Join(t.TempDir(), "fail.sh")
+	err := os.WriteFile(script, []byte("#!/bin/sh\necho oops >&2\nexit 1\n"), 0755)
+	assert.NoError(t, err)
+
+	cmd := agentQuery(script, "test", nil, nil)
+	msg := cmd()
+	resp, ok := msg.(claudeResponseMsg)
+	assert.True(t, ok)
+	assert.Error(t, resp.err)
+	assert.Contains(t, resp.err.Error(), "oops")
+}
+
+func TestAgentQuery_PassesEnvVars(t *testing.T) {
+	script := filepath.Join(t.TempDir(), "env.sh")
+	err := os.WriteFile(script, []byte("#!/bin/sh\necho $PAGERDUTY_INCIDENT_ID\n"), 0755)
+	assert.NoError(t, err)
+
+	incident := &pagerduty.Incident{
+		APIObject: pagerduty.APIObject{ID: "PD999"},
+		Title:     "Test",
+		Urgency:   "high",
+		Status:    "triggered",
+		Service:   pagerduty.APIObject{Summary: "svc"},
+	}
+
+	cmd := agentQuery(script, "test", incident, nil)
+	msg := cmd()
+	resp, ok := msg.(claudeResponseMsg)
+	assert.True(t, ok)
+	assert.NoError(t, resp.err)
+	assert.Equal(t, "PD999", resp.response)
+}
+
+func TestAgentQuery_PipesStdin(t *testing.T) {
+	cmd := agentQuery("cat", "user question here", nil, nil)
+	msg := cmd()
+	resp, ok := msg.(claudeResponseMsg)
+	assert.True(t, ok)
+	assert.NoError(t, resp.err)
+	assert.Contains(t, resp.response, "user question here")
+	assert.Contains(t, resp.response, claudeSystemPrompt)
+}
+
+func TestHandleClaudePrompt_DefaultCommand(t *testing.T) {
+	m := createTestModel()
+	m.agentCLICommand = ""
+
+	msg := claudePromptMsg{prompt: "test"}
+	result, _ := m.handleClaudePrompt(msg, func(s string) (string, error) {
+		assert.Equal(t, "claude", s, "should look up 'claude' when agentCLICommand is empty")
+		return "/usr/bin/claude", nil
+	})
+	updated := result.(model)
+	assert.True(t, updated.claudeQuerying)
+}
+
+func TestHandleClaudePrompt_CustomCommand(t *testing.T) {
+	m := createTestModel()
+	m.agentCLICommand = "/opt/bin/my-agent --verbose --print"
+
+	msg := claudePromptMsg{prompt: "test"}
+	result, _ := m.handleClaudePrompt(msg, func(s string) (string, error) {
+		assert.Equal(t, "/opt/bin/my-agent", s, "should look up the first word of the configured command")
+		return s, nil
+	})
+	updated := result.(model)
+	assert.True(t, updated.claudeQuerying)
+}
+
+func TestHandleClaudePrompt_ToolboxCommand(t *testing.T) {
+	m := createTestModel()
+	m.agentCLICommand = "toolbox run -c devtools claude --print"
+
+	msg := claudePromptMsg{prompt: "test"}
+	result, _ := m.handleClaudePrompt(msg, func(s string) (string, error) {
+		assert.Equal(t, "toolbox", s, "should look up 'toolbox' as the first word")
+		return "/usr/bin/toolbox", nil
+	})
+	updated := result.(model)
+	assert.True(t, updated.claudeQuerying)
 }
 
 func TestTruncatePrompt(t *testing.T) {

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -118,7 +118,8 @@ type model struct {
 	chordHelpActive bool
 
 	// claudeQuerying is true while a Claude CLI query is in progress
-	claudeQuerying bool
+	claudeQuerying  bool
+	agentCLICommand string
 
 	// aiProvider is the configured LLM API provider, or nil when unconfigured
 	aiProvider ai.Provider
@@ -206,6 +207,7 @@ func InitialModel(
 	configMode bool,
 	ocmAuthPending bool,
 	aiProvider ai.Provider,
+	agentCLICommand string,
 ) (tea.Model, tea.Cmd) {
 	var err error
 
@@ -262,6 +264,7 @@ func InitialModel(
 		styles:                styles,
 		configModeRequested:   configMode,
 		aiProvider:            aiProvider,
+		agentCLICommand:       agentCLICommand,
 	}
 
 	if aiProvider != nil {
@@ -302,6 +305,7 @@ func InitialModelWithConfig(
 	debug bool,
 	ocmClient ocm.OCMClient,
 	aiProvider ai.Provider,
+	agentCLICommand string,
 ) (tea.Model, tea.Cmd) {
 
 	theme := DefaultTheme()
@@ -354,6 +358,7 @@ func InitialModelWithConfig(
 		theme:                 theme,
 		styles:                styles,
 		aiProvider:            aiProvider,
+		agentCLICommand:       agentCLICommand,
 	}
 
 	if aiProvider != nil {

--- a/pkg/tui/model_test.go
+++ b/pkg/tui/model_test.go
@@ -1444,7 +1444,7 @@ func TestInitialModel_ValidConfig(t *testing.T) {
 			},
 		}
 
-		teaModel, cmd := InitialModelWithConfig(config, editor, l, false, nil, nil)
+		teaModel, cmd := InitialModelWithConfig(config, editor, l, false, nil, nil, "")
 		assert.NotNil(t, teaModel, "InitialModelWithConfig should return a non-nil model")
 		assert.NotNil(t, cmd, "InitialModelWithConfig should return a non-nil cmd")
 
@@ -1471,7 +1471,7 @@ func TestInitialModel_DebugFlag(t *testing.T) {
 			},
 		}
 
-		teaModel, _ := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, true, nil, nil)
+		teaModel, _ := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, true, nil, nil, "")
 		m := teaModel.(model)
 
 		assert.True(t, m.debug, "debug should be true when passed as true")
@@ -1480,7 +1480,7 @@ func TestInitialModel_DebugFlag(t *testing.T) {
 
 func TestInitialModelWithConfig_NilConfig(t *testing.T) {
 	t.Run("nil config sets m.err", func(t *testing.T) {
-		teaModel, cmd := InitialModelWithConfig(nil, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil)
+		teaModel, cmd := InitialModelWithConfig(nil, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil, "")
 		m := teaModel.(model)
 
 		assert.NotNil(t, m.err, "m.err should be set when config is nil")
@@ -1498,7 +1498,7 @@ func TestInitialModelWithConfig_SetsConfig(t *testing.T) {
 			},
 		}
 
-		teaModel, _ := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil)
+		teaModel, _ := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil, "")
 		m := teaModel.(model)
 
 		assert.Equal(t, config, m.config, "config should be stored on the model")
@@ -1515,7 +1515,7 @@ func TestInitialModelWithConfig_CmdReturnsErrMsg(t *testing.T) {
 			},
 		}
 
-		_, cmd := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil)
+		_, cmd := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil, "")
 		assert.NotNil(t, cmd, "cmd should be non-nil")
 
 		msg := cmd()
@@ -1527,7 +1527,7 @@ func TestInitialModelWithConfig_CmdReturnsErrMsg(t *testing.T) {
 
 func TestInitialModelWithConfig_CmdReturnsErrMsgForNilConfig(t *testing.T) {
 	t.Run("cmd produces errMsg with non-nil error for nil config", func(t *testing.T) {
-		_, cmd := InitialModelWithConfig(nil, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil)
+		_, cmd := InitialModelWithConfig(nil, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil, "")
 		assert.NotNil(t, cmd, "cmd should be non-nil")
 
 		msg := cmd()
@@ -1546,7 +1546,7 @@ func TestInitialModel_ScheduledJobsInitialized(t *testing.T) {
 			},
 		}
 
-		teaModel, _ := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil)
+		teaModel, _ := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil, "")
 		m := teaModel.(model)
 
 		assert.GreaterOrEqual(t, len(m.scheduledJobs), 1, "should have at least one scheduled job (PollIncidents)")
@@ -1562,7 +1562,7 @@ func TestInitialModel_MarkdownRenderer(t *testing.T) {
 			},
 		}
 
-		teaModel, _ := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil)
+		teaModel, _ := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil, "")
 		m := teaModel.(model)
 
 		// markdownRenderer should be non-nil (created by NewTermRenderer)
@@ -1747,7 +1747,7 @@ func TestInitialModelWithConfig_FieldInitialization(t *testing.T) {
 	launcher := launcher.ClusterLauncher{}
 	debug := true
 
-	result, cmd := InitialModelWithConfig(mockConfig, editor, launcher, debug, nil, nil)
+	result, cmd := InitialModelWithConfig(mockConfig, editor, launcher, debug, nil, nil, "")
 
 	assert.NotNil(t, result, "model should not be nil")
 	assert.NotNil(t, cmd, "cmd should not be nil")

--- a/pkg/tui/ocm_enrichment_test.go
+++ b/pkg/tui/ocm_enrichment_test.go
@@ -293,7 +293,7 @@ func TestInitialModelWithConfig_MapsInitialized(t *testing.T) {
 			Client: &pd.MockPagerDutyClient{},
 		}
 
-		teaModel, _ := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil)
+		teaModel, _ := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil, "")
 		m := teaModel.(model)
 
 		assert.NotNil(t, m.incidentClusterMap, "incidentClusterMap should be initialized")

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -1324,7 +1324,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case claudePromptMsg:
-		return m.handleClaudePrompt(msg, defaultHasClaudeCode)
+		return m.handleClaudePrompt(msg, defaultLookPath)
 
 	case claudeResponseMsg:
 		return m.handleClaudeResponse(msg)

--- a/pkg/tui/update_test.go
+++ b/pkg/tui/update_test.go
@@ -334,7 +334,7 @@ func TestDevModeFieldSet(t *testing.T) {
 			Client: &pd.MockPagerDutyClient{},
 		}
 
-		teaModel, _ := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil)
+		teaModel, _ := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil, "")
 		m := teaModel.(model)
 
 		assert.True(t, m.devMode, "devMode should be true for InitialModelWithConfig")


### PR DESCRIPTION
## Summary

- Add `agent_cli_command` config key (default: `claude --print`) so the `/agent` CLI subprocess is no longer hardcoded
- Binary is resolved via `exec.LookPath` — works with full paths, toolbox commands, and alternative agent CLIs
- Handler signature changed from `hasClaudeCode func() bool` to `lookPath func(string) (string, error)` for proper binary detection

Closes #307

## Test plan

- [x] `make test-all` passes
- [x] golangci-lint clean
- [x] Default behavior unchanged — `claude --print` used when `agent_cli_command` not set
- [x] Custom command: set `agent_cli_command: /full/path/to/claude --print` in config
- [x] Missing binary: shows `agent CLI "binary" not found on PATH` in status

🤖 Generated with [Claude Code](https://claude.com/claude-code)