### PR TITLE
Add ambient LLM incident watcher with AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ A PagerDuty terminal user interface focused on common SRE tasks.
 * Add notes, auto-refresh with selection preservation, auto-acknowledge when on-call
 * PagerDuty environment variables passed automatically to terminal sessions
 * [Flag conditions](docs/flag-conditions.md): mark incidents matching cluster ID or organization name patterns
+* [AI agents](docs/ai-agents.md): `:agent` CLI queries and `:watcher` LLM analysis with ambient incident pattern detection
 * OCM integration: cluster enrichment with display names, service logs, limited support history
 * 6-tab incident viewer: Details, Alerts, Notes, Cluster, SLs, LS History
 * Auto-update notification and `srepd update` self-update command
+* Full [configuration reference](docs/configuration.md)
 
 ## Installation
 
@@ -70,8 +72,13 @@ If no config file exists, running `srepd` automatically enters the configuration
 | `toolbox_mode` | `string` | `auto` | Toolbox detection: `auto`, `true`, or `false` |
 | `chord_prefix` | `string` | `ctrl+x` | Prefix key for chord commands |
 | `flag_marker` | `string` | `🚩 ` | Prefix marker for flagged incidents (alt: `\|►`) |
-| `agent_cli_command` | `string` | `claude --print` | CLI agent command for `/agent` queries |
+| `agent_cli_command` | `string` | `claude --print` | CLI agent command for `:agent` queries |
+| `emoji` | `bool` | `true` | Use emoji markers or text fallbacks for flags/agent/watcher |
+| `agent_system_prompt` | `string` | (read-only investigation) | System prompt for `:agent` CLI queries |
+| `watcher_system_prompt` | `string` | (SRE assistant) | System prompt for `:watcher` LLM queries |
 | `colors` | `map[string]string` | (defaults) | Custom color scheme (hex values) |
+
+See [docs/configuration.md](docs/configuration.md) for the full reference including CLI arguments.
 
 ### Colors
 
@@ -129,7 +136,9 @@ OCM features are optional — if OCM is not configured, the remaining TUI functi
 
 ## LLM Integration
 
-SREPD supports configurable LLM providers for AI-assisted incident analysis. Configuration is entirely optional — AI features are disabled when unconfigured. See [docs/llm-providers.md](docs/llm-providers.md) for full provider documentation.
+SREPD supports configurable LLM providers for AI-assisted incident analysis and an ambient watcher that detects cross-incident patterns. Configuration is entirely optional — AI features are disabled when unconfigured. See [docs/ai-agents.md](docs/ai-agents.md) for usage and [docs/llm-providers.md](docs/llm-providers.md) for provider setup.
+
+Use `:agent <query>` for CLI agent queries and `:watcher <query>` for LLM analysis. Press `w` to toggle the watcher pane.
 
 ### Quick Start
 
@@ -175,8 +184,8 @@ Press `h` to toggle the help overlay inside srepd.
 | `ctrl+r` | Toggle auto-refresh | `u` | Toggle urgency filter |
 | `ctrl+a` | Toggle auto-acknowledge | `ctrl+l` | View debug log |
 | `ctrl+q`/`ctrl+c` | Quit | `1`-`9` | Select cluster |
-| `i`/`:` | Command input | `m` | Merge incident |
-| `f` | Flag condition | | |
+| `:`/`/` | Command input | `m` | Merge incident |
+| `w` | Toggle watcher pane | | |
 | `ctrl+x` + key | Chord commands | `ctrl+x ?` | Show chord help |
 | `Tab`/`Shift+Tab`/`←`/`→` | Switch tabs (incident view) | `↑`/`↓` | Scroll within tab |
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -462,6 +462,8 @@ func configureLogging() {
 	// Check if user wants to log to journal (default: true)
 	viper.SetDefault("log_to_journal", true)
 	viper.SetDefault("emoji", true)
+	viper.SetDefault("agent_system_prompt", pkgconfig.DefaultOptionalKeys["agent_system_prompt"])
+	viper.SetDefault("watcher_system_prompt", pkgconfig.DefaultOptionalKeys["watcher_system_prompt"])
 	logToJournal := viper.GetBool("log_to_journal")
 
 	dest, logPath := determineLogDestination(runtime.GOOS, logToJournal, journal.Enabled())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -461,6 +461,7 @@ func configureLogging() {
 
 	// Check if user wants to log to journal (default: true)
 	viper.SetDefault("log_to_journal", true)
+	viper.SetDefault("emoji", true)
 	logToJournal := viper.GetBool("log_to_journal")
 
 	dest, logPath := determineLogDestination(runtime.GOOS, logToJournal, journal.Enabled())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -204,7 +204,7 @@ func launchTUI() {
 		viper.GetString("agent_cli_command"),
 	)
 
-	p := tea.NewProgram(m, tea.WithAltScreen())
+	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion())
 
 	if ocmAuthPending {
 		go func() {
@@ -386,7 +386,7 @@ func runDevMode() {
 		"",  // agentCLICommand — uses default in dev mode
 	)
 
-	p := tea.NewProgram(m, tea.WithAltScreen())
+	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion())
 
 	go func() {
 		for {

--- a/docs/ai-agents.md
+++ b/docs/ai-agents.md
@@ -1,0 +1,169 @@
+# AI Agents
+
+SREPD integrates AI assistance for incident analysis through two complementary agents and an ambient watcher system.
+
+## Quickstart
+
+1. Configure an LLM provider in `~/.config/srepd/srepd.yaml`:
+
+```yaml
+llm_api:
+  provider: ollama
+  model: llama3.1:8b
+```
+
+2. Launch srepd, select an incident, and press `:` then type:
+
+```
+:watcher what's wrong with this cluster?
+```
+
+3. The response appears in the watcher pane below the incident table.
+
+For the CLI agent (requires [Claude Code](https://claude.ai/download) or another CLI agent):
+
+```
+:agent investigate this alert
+```
+
+## Architecture
+
+SREPD provides two distinct AI surfaces:
+
+| Surface | Command | Backend | Context | Use Case |
+|---------|---------|---------|---------|----------|
+| **CLI Agent** | `:agent` | Subprocess (`agent_cli_command`) | Stdin + env vars | Interactive investigation with tool access |
+| **LLM Watcher** | `:watcher` | LLM API (`llm_api` provider) | API prompt | Data analysis, pattern synthesis |
+| **Ambient Watcher** | (automatic) | LLM API (`llm_api` provider) | API prompt | Cross-incident pattern detection |
+
+Both surfaces share the same incident context via `buildWatcherContext` and display responses in the watcher pane with source-specific markers.
+
+## Commands
+
+### `:agent <query>`
+
+Dispatches a query to the configured CLI agent subprocess. The agent command is configurable via `agent_cli_command` (default: `claude --print`).
+
+```
+:agent what's wrong with this cluster?
+:agent suggest investigation steps for this alert
+:agent what oc commands should I run?
+```
+
+The query, system prompt, and full incident context are piped to the subprocess via stdin. PagerDuty environment variables are also set on the process.
+
+### `:watcher <query>`
+
+Queries the configured LLM API provider directly with rich incident context. Requires `llm_api` to be configured and healthy.
+
+```
+:watcher analyze the service logs for this cluster
+:watcher is this a known issue?
+:watcher what's the relationship between these incidents?
+```
+
+The watcher sends the selected incident's full context including alerts, cluster info from OCM, service logs, limited support history, notes, and the complete incident queue.
+
+### Ambient Analysis
+
+When the watcher pane is active and an LLM provider is configured and healthy, SREPD automatically analyzes the incident queue for patterns. Heuristic detectors identify:
+
+| Detector | Threshold | Description |
+|----------|-----------|-------------|
+| Service storm | 3+ incidents | Multiple incidents on the same PagerDuty service |
+| Cluster storm | 2+ incidents | Multiple incidents involving the same cluster ID |
+| Urgency shift | 3+ high | Majority of incidents are high urgency |
+
+When a pattern is detected, the observation is sent to the LLM for natural-language synthesis. If the LLM is unavailable, the raw heuristic text is shown instead. Observations are deduplicated with a 5-minute cooldown.
+
+## Watcher Pane
+
+The watcher pane appears below the incident table. Toggle visibility with `w`.
+
+- **Layout**: Dynamically splits vertical space — minimum 10 rows for the table, minimum 5 for the watcher, 2/3 table and 1/3 watcher when space allows
+- **Scrolling**: Mouse wheel scrolls the watcher pane content
+- **Markers**: Each line is prefixed with a source marker (see Markers below)
+- **Typewriter**: Responses display word-by-word for a live typing effect
+- **Word wrap**: Long lines wrap at the pane width
+
+### Footer Status
+
+When the watcher pane is visible, the footer shows provider status:
+
+```
+Watching for updates...                    [AI Watcher] | ollama | healthy | idle
+```
+
+During a query, the status shows a countdown timer:
+
+```
+Watching for updates...                    [AI Watcher] | ollama | healthy | ⠋ analyzing... 57s
+```
+
+## Context
+
+Both `:agent` and `:watcher` receive the same incident context:
+
+| Data Source | Included |
+|-------------|----------|
+| Selected incident | Title, ID, service, status, urgency |
+| Alerts | Alert names, SOP/runbook links, cluster IDs |
+| OCM cluster info | Display name, state, region, cloud provider, version |
+| Service logs | Up to 5 recent logs with severity and summary |
+| Limited support | All LS reasons with summaries |
+| Notes | Up to 5 recent notes (truncated to 300 chars) |
+| Incident queue | All incidents with ID, title, service, urgency |
+
+Context is pulled from the incident cache (populated by the OCM enrichment pipeline), not from the manually-loaded selected incident data.
+
+## System Prompts
+
+Both agents have configurable system prompts:
+
+```yaml
+agent_system_prompt: "You are in read-only investigation mode for SRE PagerDuty incident triage. Suggest commands for the user to run if changes are needed. Do not modify cluster state."
+
+watcher_system_prompt: "You are an SRE assistant with access to PagerDuty incident data and OpenShift cluster information. Provide concise, actionable analysis. Do not suggest destructive commands."
+```
+
+## Markers
+
+Responses are prefixed with source markers on every non-blank line:
+
+| Source | Emoji (`emoji: true`) | Text (`emoji: false`) |
+|--------|----------------------|----------------------|
+| CLI Agent | 🤖 | ☻ |
+| LLM Watcher | 📡 | ☺ |
+| Flags | 🚩 | \|► |
+
+Set `emoji: false` in config for terminals without emoji support.
+
+## Health Checks
+
+The LLM provider health is checked every 60 seconds via the provider's health endpoint:
+
+| Provider | Health Endpoint |
+|----------|----------------|
+| `ollama` | `GET /api/tags` |
+| `openai` | `GET /v1/models` |
+| `ramalama` | `GET /v1/models` |
+| `anthropic` | (no health check) |
+
+Health status is shown in the watcher footer. The `:watcher` command will show an error flash if the provider is offline.
+
+## Timeouts
+
+| Operation | Timeout |
+|-----------|---------|
+| CLI agent query | 60 seconds |
+| Watcher LLM query | 60 seconds |
+| Ambient synthesis | 30 seconds |
+| Health check | 10 seconds |
+
+A countdown timer is shown in the footer during active queries.
+
+## Privacy
+
+When using a remote provider (`anthropic`, `openai` pointed at a cloud endpoint), incident data including titles, service names, alert names, and cluster IDs is sent over the network. Use a local provider (`ollama`, `ramalama`) to keep all data on your machine.
+
+See [LLM Providers](llm-providers.md) for provider setup details.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,7 +39,7 @@ SREPD reads configuration from `~/.config/srepd/srepd.yaml` and supports the `SR
 | `cluster_login_command` | `string` | `ocm backplane login %%CLUSTER_ID%%` | Cluster login command. Supports `%%CLUSTER_ID%%` and `%%INCIDENT_ID%%` placeholders. |
 | `toolbox_mode` | `string` | `auto` | Toolbox detection: `auto`, `true`, or `false` |
 | `chord_prefix` | `string` | `ctrl+x` | Prefix key for chord commands |
-| `emoji` | `bool` | `true` | Use emoji markers (`🚩 🤖 📡`) or text fallbacks (`|► ☻ ☺`) |
+| `emoji` | `bool` | `true` | Use emoji markers (🚩 🤖 📡) or text fallbacks (\|► ☻ ☺) |
 
 #### Escalation Policies
 
@@ -52,7 +52,7 @@ SREPD reads configuration from `~/.config/srepd/srepd.yaml` and supports the `SR
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `flag_marker` | `string` | `🚩 ` | Prefix marker for flagged incidents (alt: `\|►`). Overridden by `emoji` setting. |
+| `flag_marker` | `string` | `🚩 ` | Prefix marker for flagged incidents (alt: \|►). Overridden by `emoji` setting. |
 
 See [Flag Conditions](flag-conditions.md) for usage.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,147 @@
+# Configuration Reference
+
+## CLI Arguments
+
+| Flag | Short | Type | Default | Description |
+|------|-------|------|---------|-------------|
+| `--debug` | `-d` | bool | `false` | Enable debug logging |
+| `--dev` | `-D` | bool | `false` | Run with fixture data (no PagerDuty connection) |
+| `--fixtures-dir` | `-F` | string | `testdata/fixtures` | Path to fixture data directory for dev mode |
+| `--version` | | | | Print version and git SHA |
+
+### Commands
+
+| Command | Description |
+|---------|-------------|
+| `srepd` | Start the TUI |
+| `srepd config` | Interactive configuration wizard |
+| `srepd update` | Update to the latest release in place |
+
+## Config File Reference
+
+SREPD reads configuration from `~/.config/srepd/srepd.yaml` and supports the `SREPD_` environment variable prefix (e.g., `SREPD_TOKEN`). Run `srepd config` to create or update your config interactively.
+
+### Required Keys
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `token` | `string` | PagerDuty API OAuth token |
+| `teams` | `[]string` | PagerDuty team IDs to filter incidents |
+
+### Optional Keys
+
+#### General
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `editor` | `string` | `vim` | Editor for incident notes |
+| `terminal` | `string` | `gnome-terminal --` | Terminal emulator for cluster login |
+| `cluster_login_command` | `string` | `ocm backplane login %%CLUSTER_ID%%` | Cluster login command. Supports `%%CLUSTER_ID%%` and `%%INCIDENT_ID%%` placeholders. |
+| `toolbox_mode` | `string` | `auto` | Toolbox detection: `auto`, `true`, or `false` |
+| `chord_prefix` | `string` | `ctrl+x` | Prefix key for chord commands |
+| `emoji` | `bool` | `true` | Use emoji markers (`🚩 🤖 📡`) or text fallbacks (`|► ☻ ☺`) |
+
+#### Escalation Policies
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `default_silent_escalation_policy` | `string` | (none) | Silent escalation policy ID for silencing incidents. Set via `srepd config`. |
+| `custom_service_escalation_policies` | `map[string]string` | (none) | Per-service silent policy overrides (service ID to policy ID) |
+
+#### Flag Conditions
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `flag_marker` | `string` | `🚩 ` | Prefix marker for flagged incidents (alt: `\|►`). Overridden by `emoji` setting. |
+
+See [Flag Conditions](flag-conditions.md) for usage.
+
+#### AI Agents
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `agent_cli_command` | `string` | `claude --print` | CLI command for `:agent` queries. Parsed with `strings.Fields`. |
+| `agent_system_prompt` | `string` | (read-only investigation prompt) | System prompt piped to the CLI agent via stdin. |
+| `watcher_system_prompt` | `string` | (SRE assistant prompt) | System prompt for `:watcher` LLM queries and ambient analysis. |
+
+See [AI Agents](ai-agents.md) for usage.
+
+#### LLM API
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `llm_api.provider` | `string` | (none) | LLM provider: `ollama`, `anthropic`, `openai`, `ramalama` |
+| `llm_api.endpoint` | `string` | (provider default) | API endpoint URL |
+| `llm_api.model` | `string` | (provider default) | Model identifier |
+| `llm_api.api_key_env` | `string` | (none) | Name of env var containing API key (optional for all providers) |
+
+See [LLM Providers](llm-providers.md) for provider-specific setup.
+
+#### Colors
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `colors` | `map[string]string` | (defaults) | Custom color scheme with hex values |
+
+Available color keys: `text`, `border`, `highlight`, `selected`, `warning`, `error`, `muted`, `tab`.
+
+```yaml
+colors:
+  text: "#778da9"
+  border: "#415a77"
+  highlight: "#ffffff"
+  selected: "#415a77"
+  warning: "#a4133c"
+  error: "#0d1b2a"
+  muted: "#5C5C5C"
+```
+
+### Example Config
+
+```yaml
+token: <PagerDuty API token>
+teams:
+  - <team ID>
+
+# Terminal and login
+terminal: ptyxis
+cluster_login_command: ocm-container --cluster-id %%CLUSTER_ID%%
+toolbox_mode: auto
+
+# Escalation policies
+default_silent_escalation_policy: PXXXXXX
+custom_service_escalation_policies:
+  SVCID1: POLID1
+
+# AI integration
+agent_cli_command: toolbox run -c devtools claude --print
+emoji: true
+
+llm_api:
+  provider: ollama
+  endpoint: http://zaphod.collins.is:11434
+  model: llama3.1
+```
+
+### Environment Variables
+
+All config keys can be set via environment variables with the `SREPD_` prefix:
+
+```bash
+SREPD_TOKEN=<token> srepd
+SREPD_DEBUG=true srepd
+```
+
+### Logging
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `log_to_journal` | `bool` | `true` | Log to systemd journal on Linux (falls back to file) |
+
+Log destinations by platform:
+
+| Platform | With journal | Without journal |
+|----------|-------------|----------------|
+| Linux | `journalctl --user -t srepd` | `/var/log/srepd.log` |
+| macOS | n/a | `~/Library/Logs/srepd.log` |
+| Other | n/a | stderr |

--- a/docs/flag-conditions.md
+++ b/docs/flag-conditions.md
@@ -7,29 +7,28 @@ which flags matched.
 
 ## Quick Start
 
-Press `f` to open the flag input prompt (pre-filled with `/flag `), or enter
-input mode with `:` and type the command manually.
+Press `:` to enter command mode, then type:
 
 ```
-/flag cluster 1q2w3e4rfakeidtest9o0p1a2s3d4f5g
-/flag org ^Acme*
+:flag cluster 1q2w3e4rfakeidtest9o0p1a2s3d4f5g
+:flag org ^Acme*
 ```
 
 ## Commands
 
 | Command | Description |
 |---------|-------------|
-| `/flag cluster <id>` | Flag incidents involving a specific cluster (matches OCM internal ID, external ID, or raw alert cluster ID) |
-| `/flag org <pattern>` | Flag incidents involving clusters owned by an organization matching the pattern |
-| `/flags` | List all active flag conditions |
-| `/unflag <id>` | Remove a flag condition by its session ID |
-| `/unflag all` | Clear all flag conditions |
-| `/flags save [path]` | Save flag conditions to a JSON file |
-| `/flags load [path]` | Load flag conditions from a JSON file |
+| `:flag cluster <id>` | Flag incidents involving a specific cluster (matches OCM internal ID, external ID, or raw alert cluster ID) |
+| `:flag org <pattern>` | Flag incidents involving clusters owned by an organization matching the pattern |
+| `:flags` | List all active flag conditions |
+| `:unflag <id>` | Remove a flag condition by its session ID |
+| `:unflag all` | Clear all flag conditions |
+| `:flags save [path]` | Save flag conditions to a JSON file |
+| `:flags load [path]` | Load flag conditions from a JSON file |
 
 ## Condition Types
 
-### Cluster ID (`/flag cluster <id>`)
+### Cluster ID (`:flag cluster <id>`)
 
 Matches any incident whose alerts reference the given cluster. The ID is
 compared against:
@@ -41,7 +40,7 @@ compared against:
 Matching is case-insensitive. If OCM enrichment has not yet completed for a
 cluster, only the raw alert cluster ID is checked.
 
-### Organization Name (`/flag org <pattern>`)
+### Organization Name (`:flag org <pattern>`)
 
 Matches incidents involving clusters whose `Organization` field (from OCM)
 matches the pattern. Requires OCM enrichment to be active.
@@ -102,10 +101,10 @@ Flag conditions are **session-only by default** — they are lost when srepd
 exits. To persist them:
 
 ```
-/flags save              # saves to ~/.config/srepd/flags.json
-/flags save /tmp/my.json # saves to a custom path
-/flags load              # loads from ~/.config/srepd/flags.json
-/flags load /tmp/my.json # loads from a custom path
+:flags save              # saves to ~/.config/srepd:flags.json
+:flags save /tmp/my.json # saves to a custom path
+:flags load              # loads from ~/.config/srepd:flags.json
+:flags load /tmp/my.json # loads from a custom path
 ```
 
 ### Save File Format (`flags.json`)
@@ -141,7 +140,7 @@ The save file is a JSON array of flag condition objects:
 | `label` | string | Human-readable description shown in the UI. |
 | `created_at` | string | ISO 8601 timestamp of when the condition was created. |
 
-**Default path:** `~/.config/srepd/flags.json`
+**Default path:** `~/.config/srepd:flags.json`
 
 The directory is created automatically if it doesn't exist. The file is
 overwritten on each save (not appended).

--- a/docs/flag-conditions.md
+++ b/docs/flag-conditions.md
@@ -81,19 +81,15 @@ section at the bottom:
 
 ## Configuration
 
-### `flag_marker` (optional)
+### `emoji` (optional)
 
-The prefix marker shown on flagged incidents. Default: `🚩 ` (flag emoji +
-space).
-
-For terminals that don't render emoji well, set to `|►` (no trailing space
-needed):
+Controls the flag marker style. Default: `true` (🚩). Set to `false` for text fallback (|►).
 
 ```yaml
-flag_marker: "|►"
+emoji: false
 ```
 
-Add this to your `~/.config/srepd/srepd.yaml`.
+This also controls the agent (🤖/☻) and watcher (📡/☺) markers. See [configuration.md](configuration.md) for details.
 
 ## Persistence
 

--- a/docs/llm-providers.md
+++ b/docs/llm-providers.md
@@ -164,6 +164,16 @@ Choose your provider based on your organization's data handling requirements.
 - Missing `api_key_env` environment variable: provider still created (key is optional), but authenticated endpoints will return 401 errors at query time
 - Provider health check failure: does not block startup; health is checked on demand
 
+## Watcher Integration
+
+The configured LLM provider is used by the ambient watcher system for:
+
+- **`:watcher` queries**: direct LLM analysis of incidents with full context
+- **Pattern synthesis**: when heuristic detectors identify cross-incident patterns, the LLM synthesizes a natural-language observation
+- **Health monitoring**: provider connectivity checked every 60 seconds, status shown in the footer
+
+The watcher system prompt is configurable via `watcher_system_prompt` in the config file. See [AI Agents](ai-agents.md) for full usage documentation.
+
 ## Adding New Providers
 
 The provider system is extensible. To add a new provider:

--- a/docs/plans/062-ambient-watcher.md
+++ b/docs/plans/062-ambient-watcher.md
@@ -1,0 +1,54 @@
+# Plan: Ambient LLM Incident Watcher
+
+**Issue:** #305
+**Depends on:** #195 (merged as PR #314), #307 (merged as PR #317)
+**Branch:** `srepd/ambient-watcher`
+
+## Goal
+
+Add an ambient watcher system that monitors the incident queue for
+cross-incident patterns and provides AI-assisted analysis through a
+collapsible pane below the incident table.
+
+## What was built
+
+### Phase 1: Watcher pane layout
+- Collapsible viewport below table, toggle via `w` key
+- Dynamic table/watcher height split (2/3 table, 1/3 watcher, min 10/5 rows)
+- Rounded border matching table style, mouse wheel scrolling
+- Provider status merged into footer line
+
+### Phase 2: Claude CLI responses refactored into watcher pane
+- `/agent` responses redirect from incident viewer to watcher pane
+- Ring buffer for observation history (50 entries)
+- Configurable emoji/text markers (emoji config toggle)
+- Per-line marker prefixing, word wrap at viewport width
+- Persistent input during agent queries (later reverted to vim-style blur)
+
+### Phase 3: Configurable CLI agent command
+- Merged separately as PR #317
+- `agent_cli_command` config key (default: `claude --print`)
+
+### Phase 4: Heuristic pattern detection
+- Service storm (3+ on same service), cluster storm (2+ on same cluster)
+- Urgency shift (3+ high urgency)
+- Deduplication with 5-minute cooldown
+- Triggered on incident list updates and flag changes
+
+### Phase 5: LLM synthesis
+- Heuristic observations sent to LLM for natural-language synthesis
+- Falls back to raw text when provider unavailable
+- `:watcher` command for direct LLM queries with full incident context
+- Typewriter word-by-word response display
+- Countdown timer in footer during queries
+
+### Additional improvements
+- `:` prefix for commands (vim-style), `/` reserved for future search
+- `f` and `i` keys removed, `:/` enter command input
+- Flag markers appear immediately on add/remove/load
+- Flags load triggers OCM enrichment for unenriched incidents
+- Flag cache rebuilt on cluster enrichment arrival
+- Configurable system prompts for agent and watcher
+- Shared incident context between agent and watcher
+- Flash notifications for all errors (timeouts, not found, offline)
+- Mouse event and OCM log noise suppressed from journal

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,6 +33,8 @@ var (
 		"flag_marker":           "🚩 ",
 		"agent_cli_command":     "claude --print",
 		"emoji":                 "true",
+		"agent_system_prompt":   "You are in read-only investigation mode for SRE PagerDuty incident triage. Suggest commands for the user to run if changes are needed. Do not modify cluster state. All cluster commands must be read-only (oc get, oc describe, NOT oc delete/patch). If a fix requires changes, OUTPUT the commands for the SRE to review and run manually.",
+		"watcher_system_prompt": "You are an SRE assistant with access to PagerDuty incident data and OpenShift cluster information. Provide concise, actionable analysis. Do not suggest destructive commands.",
 	}
 	OptionalKeys = map[string]string{
 		"editor":                             fmt.Sprintf("Editor to use for notes (default: %v)", DefaultOptionalKeys["editor"]),
@@ -43,6 +45,8 @@ var (
 		"flag_marker":                        fmt.Sprintf("Prefix marker for flagged incidents (default: %v, alt: |►)", DefaultOptionalKeys["flag_marker"]),
 		"agent_cli_command":                  fmt.Sprintf("CLI agent command for /agent queries (default: %v)", DefaultOptionalKeys["agent_cli_command"]),
 		"emoji":                              "Use emoji markers for flags/agent/watcher (default: true, set false for text fallbacks)",
+		"agent_system_prompt":                "System prompt for :agent CLI queries (customizable per-user)",
+		"watcher_system_prompt":              "System prompt for :watcher LLM queries and ambient analysis (customizable per-user)",
 		"colors":                             "Custom color scheme (map of color name to hex value)",
 		"default_silent_escalation_policy":   "Default silent escalation policy ID (auto-discovered via srepd config)",
 		"custom_service_escalation_policies": "Per-service silent policy overrides (service ID → policy ID)",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,6 +32,7 @@ var (
 		"chord_prefix":          "ctrl+x",
 		"flag_marker":           "🚩 ",
 		"agent_cli_command":     "claude --print",
+		"emoji":                 "true",
 	}
 	OptionalKeys = map[string]string{
 		"editor":                             fmt.Sprintf("Editor to use for notes (default: %v)", DefaultOptionalKeys["editor"]),
@@ -41,6 +42,7 @@ var (
 		"chord_prefix":                       fmt.Sprintf("Chord prefix key for multi-key commands (default: %v)", DefaultOptionalKeys["chord_prefix"]),
 		"flag_marker":                        fmt.Sprintf("Prefix marker for flagged incidents (default: %v, alt: |►)", DefaultOptionalKeys["flag_marker"]),
 		"agent_cli_command":                  fmt.Sprintf("CLI agent command for /agent queries (default: %v)", DefaultOptionalKeys["agent_cli_command"]),
+		"emoji":                              "Use emoji markers for flags/agent/watcher (default: true, set false for text fallbacks)",
 		"colors":                             "Custom color scheme (map of color name to hex value)",
 		"default_silent_escalation_policy":   "Default silent escalation policy ID (auto-discovered via srepd config)",
 		"custom_service_escalation_policies": "Per-service silent policy overrides (service ID → policy ID)",

--- a/pkg/tui/claude.go
+++ b/pkg/tui/claude.go
@@ -149,6 +149,7 @@ func (m model) handleClaudePrompt(msg claudePromptMsg, lookPath func(string) (st
 	m.setStatus(fmt.Sprintf("querying agent: %s", truncatePrompt(msg.prompt, 40)))
 	m.claudeQuerying = true
 	m.apiInProgress = true
+	m.watcherQueryStart = time.Now()
 
 	if !m.watcherExpanded {
 		m.watcherExpanded = true

--- a/pkg/tui/claude.go
+++ b/pkg/tui/claude.go
@@ -175,9 +175,6 @@ func (m model) handleClaudeResponse(msg claudeResponseMsg) (tea.Model, tea.Cmd) 
 		return m, m.flashNotification("agent returned empty response")
 	}
 
-	m.watcherBuffer.Append(prefixLines(m.agentMarker, msg.response))
-	m.updateWatcherViewport()
-
 	if !m.watcherExpanded {
 		m.watcherExpanded = true
 		m.recomputeLayout()
@@ -186,7 +183,8 @@ func (m model) handleClaudeResponse(msg claudeResponseMsg) (tea.Model, tea.Cmd) 
 	log.Info("claude response received")
 	m.setStatus("Claude response received")
 
-	return m, nil
+	m.watcherBuffer.Append("")
+	return m, m.startTypewriter(m.agentMarker, msg.response)
 }
 
 // truncatePrompt shortens a prompt string for display in the status bar

--- a/pkg/tui/claude.go
+++ b/pkg/tui/claude.go
@@ -76,7 +76,7 @@ func buildClaudeEnvVars(incident *pagerduty.Incident, alerts []pagerduty.Inciden
 // agentQuery dispatches a prompt to the configured CLI agent and returns the
 // response. The command is parsed from the agentCLICommand config string.
 // The prompt is piped via stdin for safety.
-func agentQuery(agentCLICommand string, prompt string, incident *pagerduty.Incident, alerts []pagerduty.IncidentAlert) tea.Cmd {
+func agentQuery(agentCLICommand string, prompt string, incidentContext string, incident *pagerduty.Incident, alerts []pagerduty.IncidentAlert) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), claudeTimeout)
 		defer cancel()
@@ -86,8 +86,13 @@ func agentQuery(agentCLICommand string, prompt string, incident *pagerduty.Incid
 			return claudeResponseMsg{err: fmt.Errorf("agent_cli_command is empty")}
 		}
 
+		fullPrompt := claudeSystemPrompt + "\n\n" + prompt
+		if incidentContext != "" {
+			fullPrompt += "\n\nContext:\n" + incidentContext
+		}
+
 		cmd := exec.CommandContext(ctx, args[0], args[1:]...)
-		cmd.Stdin = strings.NewReader(claudeSystemPrompt + "\n\n" + prompt)
+		cmd.Stdin = strings.NewReader(fullPrompt)
 		cmd.Env = append(os.Environ(), buildClaudeEnvVars(incident, alerts)...)
 
 		var stderr strings.Builder
@@ -157,9 +162,10 @@ func (m model) handleClaudePrompt(msg claudePromptMsg, lookPath func(string) (st
 		m.recomputeLayout()
 	}
 
+	incidentContext := buildWatcherContext(&m)
 	return m, tea.Batch(
 		m.spinner.Tick,
-		agentQuery(agentCmd, msg.prompt, m.selectedIncident, m.selectedIncidentAlerts),
+		agentQuery(agentCmd, msg.prompt, incidentContext, m.selectedIncident, m.selectedIncidentAlerts),
 	)
 }
 

--- a/pkg/tui/claude.go
+++ b/pkg/tui/claude.go
@@ -15,11 +15,6 @@ import (
 
 const (
 	claudeTimeout = 60 * time.Second
-
-	claudeSystemPrompt = "You are in read-only investigation mode for SRE PagerDuty incident triage. " +
-		"Suggest commands for the user to run if changes are needed. Do not modify cluster state. " +
-		"All cluster commands must be read-only (oc get, oc describe, NOT oc delete/patch). " +
-		"If a fix requires changes, OUTPUT the commands for the SRE to review and run manually."
 )
 
 // claudePromptMsg is sent when the user submits a prompt from the input field
@@ -76,7 +71,7 @@ func buildClaudeEnvVars(incident *pagerduty.Incident, alerts []pagerduty.Inciden
 // agentQuery dispatches a prompt to the configured CLI agent and returns the
 // response. The command is parsed from the agentCLICommand config string.
 // The prompt is piped via stdin for safety.
-func agentQuery(agentCLICommand string, prompt string, incidentContext string, incident *pagerduty.Incident, alerts []pagerduty.IncidentAlert) tea.Cmd {
+func agentQuery(agentCLICommand string, systemPrompt string, prompt string, incidentContext string, incident *pagerduty.Incident, alerts []pagerduty.IncidentAlert) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), claudeTimeout)
 		defer cancel()
@@ -86,7 +81,7 @@ func agentQuery(agentCLICommand string, prompt string, incidentContext string, i
 			return claudeResponseMsg{err: fmt.Errorf("agent_cli_command is empty")}
 		}
 
-		fullPrompt := claudeSystemPrompt + "\n\n" + prompt
+		fullPrompt := systemPrompt + "\n\n" + prompt
 		if incidentContext != "" {
 			fullPrompt += "\n\nContext:\n" + incidentContext
 		}
@@ -165,7 +160,7 @@ func (m model) handleClaudePrompt(msg claudePromptMsg, lookPath func(string) (st
 	incidentContext := buildWatcherContext(&m)
 	return m, tea.Batch(
 		m.spinner.Tick,
-		agentQuery(agentCmd, msg.prompt, incidentContext, m.selectedIncident, m.selectedIncidentAlerts),
+		agentQuery(agentCmd, m.agentSystemPrompt, msg.prompt, incidentContext, m.selectedIncident, m.selectedIncidentAlerts),
 	)
 }
 

--- a/pkg/tui/claude.go
+++ b/pkg/tui/claude.go
@@ -207,9 +207,9 @@ func defaultLookPath(file string) (string, error) {
 
 func isAgentCommand(input string) bool {
 	trimmed := strings.TrimSpace(input)
-	return strings.HasPrefix(trimmed, "/agent ") || trimmed == "/agent"
+	return strings.HasPrefix(trimmed, ":agent ") || trimmed == ":agent"
 }
 
 func parseAgentQuery(input string) string {
-	return strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(input), "/agent"))
+	return strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(input), ":agent"))
 }

--- a/pkg/tui/claude.go
+++ b/pkg/tui/claude.go
@@ -150,6 +150,7 @@ func (m model) handleClaudePrompt(msg claudePromptMsg, lookPath func(string) (st
 	m.claudeQuerying = true
 	m.apiInProgress = true
 	m.watcherQueryStart = time.Now()
+	m.watcherQueryTimeout = claudeTimeout
 
 	if !m.watcherExpanded {
 		m.watcherExpanded = true

--- a/pkg/tui/claude.go
+++ b/pkg/tui/claude.go
@@ -151,6 +151,11 @@ func (m model) handleClaudePrompt(msg claudePromptMsg, lookPath func(string) (st
 	m.claudeQuerying = true
 	m.apiInProgress = true
 
+	if !m.watcherExpanded {
+		m.watcherExpanded = true
+		m.recomputeLayout()
+	}
+
 	return m, tea.Batch(
 		m.spinner.Tick,
 		agentQuery(agentCmd, msg.prompt, m.selectedIncident, m.selectedIncidentAlerts),
@@ -173,20 +178,14 @@ func (m model) handleClaudeResponse(msg claudeResponseMsg) (tea.Model, tea.Cmd) 
 		return m, nil
 	}
 
-	// Format the response with a Claude header
-	content := fmt.Sprintf("# Claude Response\n\n%s", msg.response)
+	m.watcherBuffer.Append(prefixLines(m.agentMarker, msg.response))
+	m.updateWatcherViewport()
 
-	// Render as markdown if renderer is available
-	if m.markdownRenderer != nil {
-		rendered, err := m.markdownRenderer.Render(content)
-		if err == nil {
-			content = rendered
-		}
+	if !m.watcherExpanded {
+		m.watcherExpanded = true
+		m.recomputeLayout()
 	}
 
-	m.incidentViewer.SetContent(content)
-	m.incidentViewer.GotoTop()
-	m.viewingIncident = true
 	log.Info("claude response received")
 	m.setStatus("Claude response received")
 

--- a/pkg/tui/claude.go
+++ b/pkg/tui/claude.go
@@ -138,8 +138,7 @@ func (m model) handleClaudePrompt(msg claudePromptMsg, lookPath func(string) (st
 
 	binary := strings.Fields(agentCmd)[0]
 	if _, err := lookPath(binary); err != nil {
-		m.setStatus(fmt.Sprintf("agent CLI %q not found on PATH", binary))
-		return m, nil
+		return m, m.flashNotification(fmt.Sprintf("agent CLI %q not found on PATH", binary))
 	}
 
 	incidentID := ""
@@ -169,13 +168,11 @@ func (m model) handleClaudeResponse(msg claudeResponseMsg) (tea.Model, tea.Cmd) 
 	m.apiInProgress = false
 
 	if msg.err != nil {
-		m.setStatus(fmt.Sprintf("Claude query failed: %s", msg.err))
-		return m, nil
+		return m, m.flashNotification(fmt.Sprintf("agent query failed: %s", msg.err))
 	}
 
 	if msg.response == "" {
-		m.setStatus("no response from Claude")
-		return m, nil
+		return m, m.flashNotification("agent returned empty response")
 	}
 
 	m.watcherBuffer.Append(prefixLines(m.agentMarker, msg.response))

--- a/pkg/tui/claude_test.go
+++ b/pkg/tui/claude_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/PagerDuty/go-pagerduty"
 	tea "github.com/charmbracelet/bubbletea"
+	pkgconfig "github.com/clcollins/srepd/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -208,12 +209,16 @@ func TestClaudeQuery_PassesContext(t *testing.T) {
 		"Should include cluster ID from alerts")
 }
 
-func TestClaudeQuery_SystemPrompt(t *testing.T) {
-	// The system prompt should specify read-only investigation mode
-	assert.Contains(t, claudeSystemPrompt, "read-only",
-		"System prompt should specify read-only mode")
-	assert.Contains(t, claudeSystemPrompt, "investigation",
-		"System prompt should mention investigation")
+func TestDefaultAgentSystemPrompt(t *testing.T) {
+	defaultPrompt := pkgconfig.DefaultOptionalKeys["agent_system_prompt"]
+	assert.Contains(t, defaultPrompt, "read-only")
+	assert.Contains(t, defaultPrompt, "investigation")
+}
+
+func TestDefaultWatcherSystemPrompt(t *testing.T) {
+	defaultPrompt := pkgconfig.DefaultOptionalKeys["watcher_system_prompt"]
+	assert.Contains(t, defaultPrompt, "SRE assistant")
+	assert.Contains(t, defaultPrompt, "destructive")
 }
 
 func TestInputFocusMode_EscBlursInput(t *testing.T) {
@@ -319,7 +324,7 @@ func TestDefaultLookPath_NoPanic(t *testing.T) {
 }
 
 func TestAgentQuery_EmptyCommand(t *testing.T) {
-	cmd := agentQuery("", "test prompt", "", nil, nil)
+	cmd := agentQuery("", "test system", "test prompt", "", nil, nil)
 	msg := cmd()
 	resp, ok := msg.(claudeResponseMsg)
 	assert.True(t, ok)
@@ -328,7 +333,7 @@ func TestAgentQuery_EmptyCommand(t *testing.T) {
 }
 
 func TestAgentQuery_CommandParsing(t *testing.T) {
-	cmd := agentQuery("echo hello world", "ignored", "", nil, nil)
+	cmd := agentQuery("echo hello world", "", "ignored", "", nil, nil)
 	msg := cmd()
 	resp, ok := msg.(claudeResponseMsg)
 	assert.True(t, ok)
@@ -337,7 +342,7 @@ func TestAgentQuery_CommandParsing(t *testing.T) {
 }
 
 func TestAgentQuery_MultiWordCommand(t *testing.T) {
-	cmd := agentQuery("echo -n test", "ignored", "", nil, nil)
+	cmd := agentQuery("echo -n test", "", "ignored", "", nil, nil)
 	msg := cmd()
 	resp, ok := msg.(claudeResponseMsg)
 	assert.True(t, ok)
@@ -346,7 +351,7 @@ func TestAgentQuery_MultiWordCommand(t *testing.T) {
 }
 
 func TestAgentQuery_CommandNotFound(t *testing.T) {
-	cmd := agentQuery("nonexistent-binary-99999 --flag", "test", "", nil, nil)
+	cmd := agentQuery("nonexistent-binary-99999 --flag", "", "test", "", nil, nil)
 	msg := cmd()
 	resp, ok := msg.(claudeResponseMsg)
 	assert.True(t, ok)
@@ -359,7 +364,7 @@ func TestAgentQuery_StderrCaptured(t *testing.T) {
 	err := os.WriteFile(script, []byte("#!/bin/sh\necho oops >&2\nexit 1\n"), 0755)
 	assert.NoError(t, err)
 
-	cmd := agentQuery(script, "test", "", nil, nil)
+	cmd := agentQuery(script, "", "test", "", nil, nil)
 	msg := cmd()
 	resp, ok := msg.(claudeResponseMsg)
 	assert.True(t, ok)
@@ -380,7 +385,7 @@ func TestAgentQuery_PassesEnvVars(t *testing.T) {
 		Service:   pagerduty.APIObject{Summary: "svc"},
 	}
 
-	cmd := agentQuery(script, "test", "", incident, nil)
+	cmd := agentQuery(script, "", "test", "", incident, nil)
 	msg := cmd()
 	resp, ok := msg.(claudeResponseMsg)
 	assert.True(t, ok)
@@ -389,13 +394,13 @@ func TestAgentQuery_PassesEnvVars(t *testing.T) {
 }
 
 func TestAgentQuery_PipesStdin(t *testing.T) {
-	cmd := agentQuery("cat", "user question here", "", nil, nil)
+	cmd := agentQuery("cat", "test system prompt", "user question here", "", nil, nil)
 	msg := cmd()
 	resp, ok := msg.(claudeResponseMsg)
 	assert.True(t, ok)
 	assert.NoError(t, resp.err)
 	assert.Contains(t, resp.response, "user question here")
-	assert.Contains(t, resp.response, claudeSystemPrompt)
+	assert.Contains(t, resp.response, "test system prompt")
 }
 
 func TestHandleClaudePrompt_DefaultCommand(t *testing.T) {

--- a/pkg/tui/claude_test.go
+++ b/pkg/tui/claude_test.go
@@ -302,12 +302,12 @@ func TestClaudeResponse_AppendsToWatcherBuffer(t *testing.T) {
 		err:      nil,
 	}
 
-	result, _ := m.Update(msg)
+	result, cmd := m.Update(msg)
 	updatedModel := result.(model)
 
-	assert.Equal(t, 1, updatedModel.watcherBuffer.Len())
-	assert.Contains(t, updatedModel.watcherBuffer.Content(), "high CPU usage")
-	assert.Contains(t, updatedModel.watcherBuffer.Content(), emojiAgentMarker, "response should be prefixed with agent marker")
+	assert.Equal(t, 1, updatedModel.watcherBuffer.Len(), "should have placeholder entry for typewriter")
+	assert.NotNil(t, updatedModel.typewriter, "typewriter should be active")
+	assert.NotNil(t, cmd, "should return typewriter tick command")
 }
 
 func TestDefaultLookPath_NoPanic(t *testing.T) {

--- a/pkg/tui/claude_test.go
+++ b/pkg/tui/claude_test.go
@@ -66,20 +66,18 @@ func TestClaudePrompt_EmptyInput(t *testing.T) {
 	assert.Nil(t, cmd, "Empty input should not dispatch a command")
 }
 
-func TestClaudeNotFound_ShowsStatus(t *testing.T) {
+func TestClaudeNotFound_ShowsFlash(t *testing.T) {
 	m := createTestModel()
 	m.incidentCache = make(map[string]*cachedIncidentData)
 	m.agentCLICommand = "nonexistent-binary --print"
 
 	msg := claudePromptMsg{prompt: "test query"}
 
-	result, cmd := m.handleClaudePrompt(msg, func(s string) (string, error) {
+	_, cmd := m.handleClaudePrompt(msg, func(s string) (string, error) {
 		return "", fmt.Errorf("not found: %s", s)
 	})
-	updatedModel := result.(model)
 
-	assert.Contains(t, updatedModel.status, "not found on PATH")
-	assert.Nil(t, cmd)
+	assert.NotNil(t, cmd, "should return flash notification command")
 }
 
 func TestClaudePrompt_ShowsSpinner(t *testing.T) {
@@ -139,19 +137,15 @@ func TestClaudeResponse_Error(t *testing.T) {
 		err:      assert.AnError,
 	}
 
-	result, _ := m.Update(msg)
+	result, cmd := m.Update(msg)
 	updatedModel := result.(model)
 
 	assert.False(t, updatedModel.claudeQuerying, "claudeQuerying should be false after error")
 	assert.False(t, updatedModel.apiInProgress, "apiInProgress should be false after error")
-	assert.Contains(t, updatedModel.status, "Claude query failed",
-		"Status should indicate failure")
+	assert.NotNil(t, cmd, "should return flash notification for error")
 }
 
 func TestClaudeResponse_EmptyResponse(t *testing.T) {
-	// When claudeResponseMsg has no error but empty response,
-	// the status should indicate no response
-
 	m := createTestModel()
 	m.incidentCache = make(map[string]*cachedIncidentData)
 	m.claudeQuerying = true
@@ -162,12 +156,11 @@ func TestClaudeResponse_EmptyResponse(t *testing.T) {
 		err:      nil,
 	}
 
-	result, _ := m.Update(msg)
+	result, cmd := m.Update(msg)
 	updatedModel := result.(model)
 
 	assert.False(t, updatedModel.claudeQuerying, "claudeQuerying should be false after empty response")
-	assert.Contains(t, updatedModel.status, "no response",
-		"Status should indicate no response")
+	assert.NotNil(t, cmd, "should return flash notification for empty response")
 }
 
 func TestClaudeQuery_PassesContext(t *testing.T) {

--- a/pkg/tui/claude_test.go
+++ b/pkg/tui/claude_test.go
@@ -33,8 +33,7 @@ func TestClaudePrompt_DispatchesCommand(t *testing.T) {
 	result, cmd := switchInputFocusMode(m, enterMsg)
 	updatedModel := result.(model)
 
-	// Input stays focused for follow-up queries, value is cleared
-	assert.True(t, updatedModel.input.Focused(), "Input should stay focused after :agent dispatch")
+	assert.False(t, updatedModel.input.Focused(), "Input should blur after :agent dispatch")
 	assert.Equal(t, "", updatedModel.input.Value(), "Input value should be cleared after dispatch")
 
 	// A command should be returned
@@ -584,7 +583,7 @@ func TestInputMode_AgentCommand_DispatchesClaude(t *testing.T) {
 	result, cmd := m.keyMsgHandler(keyMsg)
 	updated := result.(model)
 
-	assert.True(t, updated.input.Focused(), "input stays focused after :agent dispatch")
+	assert.False(t, updated.input.Focused(), "input should blur after :agent dispatch")
 	assert.NotNil(t, cmd, ":agent command must dispatch a command")
 
 	msg := cmd()

--- a/pkg/tui/claude_test.go
+++ b/pkg/tui/claude_test.go
@@ -319,7 +319,7 @@ func TestDefaultLookPath_NoPanic(t *testing.T) {
 }
 
 func TestAgentQuery_EmptyCommand(t *testing.T) {
-	cmd := agentQuery("", "test prompt", nil, nil)
+	cmd := agentQuery("", "test prompt", "", nil, nil)
 	msg := cmd()
 	resp, ok := msg.(claudeResponseMsg)
 	assert.True(t, ok)
@@ -328,7 +328,7 @@ func TestAgentQuery_EmptyCommand(t *testing.T) {
 }
 
 func TestAgentQuery_CommandParsing(t *testing.T) {
-	cmd := agentQuery("echo hello world", "ignored", nil, nil)
+	cmd := agentQuery("echo hello world", "ignored", "", nil, nil)
 	msg := cmd()
 	resp, ok := msg.(claudeResponseMsg)
 	assert.True(t, ok)
@@ -337,7 +337,7 @@ func TestAgentQuery_CommandParsing(t *testing.T) {
 }
 
 func TestAgentQuery_MultiWordCommand(t *testing.T) {
-	cmd := agentQuery("echo -n test", "ignored", nil, nil)
+	cmd := agentQuery("echo -n test", "ignored", "", nil, nil)
 	msg := cmd()
 	resp, ok := msg.(claudeResponseMsg)
 	assert.True(t, ok)
@@ -346,7 +346,7 @@ func TestAgentQuery_MultiWordCommand(t *testing.T) {
 }
 
 func TestAgentQuery_CommandNotFound(t *testing.T) {
-	cmd := agentQuery("nonexistent-binary-99999 --flag", "test", nil, nil)
+	cmd := agentQuery("nonexistent-binary-99999 --flag", "test", "", nil, nil)
 	msg := cmd()
 	resp, ok := msg.(claudeResponseMsg)
 	assert.True(t, ok)
@@ -359,7 +359,7 @@ func TestAgentQuery_StderrCaptured(t *testing.T) {
 	err := os.WriteFile(script, []byte("#!/bin/sh\necho oops >&2\nexit 1\n"), 0755)
 	assert.NoError(t, err)
 
-	cmd := agentQuery(script, "test", nil, nil)
+	cmd := agentQuery(script, "test", "", nil, nil)
 	msg := cmd()
 	resp, ok := msg.(claudeResponseMsg)
 	assert.True(t, ok)
@@ -380,7 +380,7 @@ func TestAgentQuery_PassesEnvVars(t *testing.T) {
 		Service:   pagerduty.APIObject{Summary: "svc"},
 	}
 
-	cmd := agentQuery(script, "test", incident, nil)
+	cmd := agentQuery(script, "test", "", incident, nil)
 	msg := cmd()
 	resp, ok := msg.(claudeResponseMsg)
 	assert.True(t, ok)
@@ -389,7 +389,7 @@ func TestAgentQuery_PassesEnvVars(t *testing.T) {
 }
 
 func TestAgentQuery_PipesStdin(t *testing.T) {
-	cmd := agentQuery("cat", "user question here", nil, nil)
+	cmd := agentQuery("cat", "user question here", "", nil, nil)
 	msg := cmd()
 	resp, ok := msg.(claudeResponseMsg)
 	assert.True(t, ok)

--- a/pkg/tui/claude_test.go
+++ b/pkg/tui/claude_test.go
@@ -19,14 +19,14 @@ func TestInputCharLimit_Increased(t *testing.T) {
 }
 
 func TestClaudePrompt_DispatchesCommand(t *testing.T) {
-	// When the user is in input focus mode and presses Enter with /agent prefix,
+	// When the user is in input focus mode and presses Enter with :agent prefix,
 	// a claudePromptMsg should be dispatched with the query text (prefix stripped),
 	// the input should be reset and blurred.
 
 	m := createTestModel()
 	m.input = newTextInput()
 	m.input.Focus()
-	m.input.SetValue("/agent investigate this alert")
+	m.input.SetValue(":agent investigate this alert")
 
 	// Simulate pressing Enter in input focus mode
 	enterMsg := tea.KeyMsg{Type: tea.KeyEnter}
@@ -34,7 +34,7 @@ func TestClaudePrompt_DispatchesCommand(t *testing.T) {
 	updatedModel := result.(model)
 
 	// Input stays focused for follow-up queries, value is cleared
-	assert.True(t, updatedModel.input.Focused(), "Input should stay focused after /agent dispatch")
+	assert.True(t, updatedModel.input.Focused(), "Input should stay focused after :agent dispatch")
 	assert.Equal(t, "", updatedModel.input.Value(), "Input value should be cleared after dispatch")
 
 	// A command should be returned
@@ -44,7 +44,7 @@ func TestClaudePrompt_DispatchesCommand(t *testing.T) {
 	msg := cmd()
 	promptMsg, ok := msg.(claudePromptMsg)
 	assert.True(t, ok, "Command should produce a claudePromptMsg, got %T", msg)
-	assert.Equal(t, "investigate this alert", promptMsg.prompt, "Prompt text should have /agent prefix stripped")
+	assert.Equal(t, "investigate this alert", promptMsg.prompt, "Prompt text should have :agent prefix stripped")
 }
 
 func TestClaudePrompt_EmptyInput(t *testing.T) {
@@ -255,7 +255,7 @@ func TestInputFocusMode_TableRegainsFocusOnBlur(t *testing.T) {
 	m := createTestModelWithTableRows(incidents)
 	m.input = newTextInput()
 	m.input.Focus()
-	m.input.SetValue("/agent query text")
+	m.input.SetValue(":agent query text")
 
 	// Simulate pressing Enter
 	enterMsg := tea.KeyMsg{Type: tea.KeyEnter}
@@ -553,15 +553,15 @@ func TestBuildClaudeEnvVars_NoAlerts(t *testing.T) {
 }
 
 func TestIsAgentCommand_Valid(t *testing.T) {
-	assert.True(t, isAgentCommand("/agent investigate this alert"))
+	assert.True(t, isAgentCommand(":agent investigate this alert"))
 }
 
 func TestIsAgentCommand_BareSlashAgent(t *testing.T) {
-	assert.True(t, isAgentCommand("/agent"))
+	assert.True(t, isAgentCommand(":agent"))
 }
 
 func TestIsAgentCommand_WithLeadingSpace(t *testing.T) {
-	assert.True(t, isAgentCommand("  /agent query"))
+	assert.True(t, isAgentCommand("  :agent query"))
 }
 
 func TestIsAgentCommand_NotAgent(t *testing.T) {
@@ -573,31 +573,31 @@ func TestIsAgentCommand_PlainText(t *testing.T) {
 }
 
 func TestParseAgentQuery_ExtractsQuery(t *testing.T) {
-	assert.Equal(t, "investigate this", parseAgentQuery("/agent investigate this"))
+	assert.Equal(t, "investigate this", parseAgentQuery(":agent investigate this"))
 }
 
 func TestParseAgentQuery_EmptyAfterPrefix(t *testing.T) {
-	assert.Equal(t, "", parseAgentQuery("/agent"))
+	assert.Equal(t, "", parseAgentQuery(":agent"))
 }
 
 func TestParseAgentQuery_PreservesExtraSpaces(t *testing.T) {
-	assert.Equal(t, "what happened to cluster abc", parseAgentQuery("/agent what happened to cluster abc"))
+	assert.Equal(t, "what happened to cluster abc", parseAgentQuery(":agent what happened to cluster abc"))
 }
 
 func TestInputMode_AgentCommand_DispatchesClaude(t *testing.T) {
-	m := createInputFocusedModel("/agent what happened")
+	m := createInputFocusedModel(":agent what happened")
 
 	keyMsg := tea.KeyMsg{Type: tea.KeyEnter}
 	result, cmd := m.keyMsgHandler(keyMsg)
 	updated := result.(model)
 
-	assert.True(t, updated.input.Focused(), "input stays focused after /agent dispatch")
-	assert.NotNil(t, cmd, "/agent command must dispatch a command")
+	assert.True(t, updated.input.Focused(), "input stays focused after :agent dispatch")
+	assert.NotNil(t, cmd, ":agent command must dispatch a command")
 
 	msg := cmd()
 	promptMsg, ok := msg.(claudePromptMsg)
 	assert.True(t, ok, "dispatched message must be claudePromptMsg")
-	assert.Equal(t, "what happened", promptMsg.prompt, "query must have /agent prefix stripped")
+	assert.Equal(t, "what happened", promptMsg.prompt, "query must have :agent prefix stripped")
 }
 
 func TestInputMode_BareText_ShowsError(t *testing.T) {
@@ -613,12 +613,12 @@ func TestInputMode_BareText_ShowsError(t *testing.T) {
 }
 
 func TestInputMode_EmptyAgent_ShowsUsage(t *testing.T) {
-	m := createInputFocusedModel("/agent")
+	m := createInputFocusedModel(":agent")
 
 	keyMsg := tea.KeyMsg{Type: tea.KeyEnter}
 	result, cmd := m.keyMsgHandler(keyMsg)
 	updated := result.(model)
 
-	assert.Nil(t, cmd, "/agent with no query must not dispatch")
+	assert.Nil(t, cmd, ":agent with no query must not dispatch")
 	assert.Contains(t, updated.status, "usage", "status must show usage hint")
 }

--- a/pkg/tui/claude_test.go
+++ b/pkg/tui/claude_test.go
@@ -33,9 +33,9 @@ func TestClaudePrompt_DispatchesCommand(t *testing.T) {
 	result, cmd := switchInputFocusMode(m, enterMsg)
 	updatedModel := result.(model)
 
-	// Input should be blurred and reset
-	assert.False(t, updatedModel.input.Focused(), "Input should be blurred after Enter")
-	assert.Equal(t, "", updatedModel.input.Value(), "Input should be reset after Enter")
+	// Input stays focused for follow-up queries, value is cleared
+	assert.True(t, updatedModel.input.Focused(), "Input should stay focused after /agent dispatch")
+	assert.Equal(t, "", updatedModel.input.Value(), "Input value should be cleared after dispatch")
 
 	// A command should be returned
 	assert.NotNil(t, cmd, "Enter in input mode should return a command")
@@ -105,16 +105,11 @@ func TestClaudePrompt_ShowsSpinner(t *testing.T) {
 	assert.NotNil(t, cmd, "A command should be returned to execute the query")
 }
 
-func TestClaudeResponse_RendersInViewport(t *testing.T) {
-	// When claudeResponseMsg is received with a successful response,
-	// the content should be set in the incidentViewer and viewingIncident
-	// should be true
-
+func TestClaudeResponse_RendersInWatcherPane(t *testing.T) {
 	m := createTestModel()
 	m.incidentCache = make(map[string]*cachedIncidentData)
 	m.claudeQuerying = true
 	m.apiInProgress = true
-	m.incidentViewer = newIncidentViewer()
 
 	msg := claudeResponseMsg{
 		response: "Based on the alert, the cluster appears to have high CPU usage.",
@@ -126,7 +121,9 @@ func TestClaudeResponse_RendersInViewport(t *testing.T) {
 
 	assert.False(t, updatedModel.claudeQuerying, "claudeQuerying should be false after response")
 	assert.False(t, updatedModel.apiInProgress, "apiInProgress should be false after response")
-	assert.True(t, updatedModel.viewingIncident, "viewingIncident should be true to show response")
+	assert.False(t, updatedModel.viewingIncident, "viewingIncident should remain false — response goes to watcher pane")
+	assert.True(t, updatedModel.watcherExpanded, "watcher pane should auto-expand on response")
+	assert.Equal(t, 1, updatedModel.watcherBuffer.Len(), "response should be appended to watcher buffer")
 }
 
 func TestClaudeResponse_Error(t *testing.T) {
@@ -276,13 +273,10 @@ func TestClaudePrompt_InputModeKeyMapUpdated(t *testing.T) {
 		"Enter key help description should say 'ask Claude'")
 }
 
-func TestClaudePrompt_WithViewingIncident(t *testing.T) {
-	// When in incident view, entering input mode and submitting should work
-	// by setting viewingIncident to true for the response display
-
+func TestClaudePrompt_AutoExpandsWatcher(t *testing.T) {
 	m := createTestModel()
 	m.incidentCache = make(map[string]*cachedIncidentData)
-	m.viewingIncident = true
+	m.watcherExpanded = false
 	m.selectedIncident = &pagerduty.Incident{
 		APIObject: pagerduty.APIObject{ID: "Q123"},
 	}
@@ -295,6 +289,7 @@ func TestClaudePrompt_WithViewingIncident(t *testing.T) {
 	updatedModel := result.(model)
 
 	assert.True(t, updatedModel.claudeQuerying, "Should start querying")
+	assert.True(t, updatedModel.watcherExpanded, "Watcher pane should auto-expand on query")
 	assert.NotNil(t, cmd, "Should dispatch query command")
 }
 
@@ -304,15 +299,11 @@ func TestNewTextInputWidth(t *testing.T) {
 	assert.Equal(t, 120, input.Width, "Input width should be 120")
 }
 
-func TestClaudeResponse_RendersWithPrefix(t *testing.T) {
-	// When Claude response is rendered in the viewport, it should have
-	// a clear prefix indicating it's from Claude
-
+func TestClaudeResponse_AppendsToWatcherBuffer(t *testing.T) {
 	m := createTestModel()
 	m.incidentCache = make(map[string]*cachedIncidentData)
 	m.claudeQuerying = true
 	m.apiInProgress = true
-	m.incidentViewer = newIncidentViewer()
 
 	msg := claudeResponseMsg{
 		response: "The cluster is experiencing high CPU usage.",
@@ -320,11 +311,11 @@ func TestClaudeResponse_RendersWithPrefix(t *testing.T) {
 	}
 
 	result, _ := m.Update(msg)
-	_ = result.(model)
+	updatedModel := result.(model)
 
-	// The response content is set on the viewport - we can't directly read it back
-	// from viewport.Model in tests, but we verify the model state is correct
-	// The actual prefix is added in the Update handler
+	assert.Equal(t, 1, updatedModel.watcherBuffer.Len())
+	assert.Contains(t, updatedModel.watcherBuffer.Content(), "high CPU usage")
+	assert.Contains(t, updatedModel.watcherBuffer.Content(), emojiAgentMarker, "response should be prefixed with agent marker")
 }
 
 func TestDefaultLookPath_NoPanic(t *testing.T) {
@@ -600,7 +591,7 @@ func TestInputMode_AgentCommand_DispatchesClaude(t *testing.T) {
 	result, cmd := m.keyMsgHandler(keyMsg)
 	updated := result.(model)
 
-	assert.False(t, updated.input.Focused(), "input must be blurred after Enter")
+	assert.True(t, updated.input.Focused(), "input stays focused after /agent dispatch")
 	assert.NotNil(t, cmd, "/agent command must dispatch a command")
 
 	msg := cmd()

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -228,6 +228,36 @@ func aiHealthCheckCmd(provider ai.Provider) tea.Cmd {
 	}
 }
 
+type watcherSynthesisMsg struct {
+	observation string
+	response    string
+	err         error
+}
+
+func watcherSynthesizeCmd(provider ai.Provider, observation string, incidentSummary string) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		systemPrompt := "You are an SRE assistant observing a PagerDuty incident queue. " +
+			"A pattern detector identified the following observation. " +
+			"Provide a brief (1-3 sentence) analysis of what this pattern might indicate " +
+			"and any suggested investigation steps. Be concise."
+
+		userPrompt := fmt.Sprintf("Observation: %s\n\nCurrent incidents:\n%s", observation, incidentSummary)
+
+		log.Debug("watcher.synthesize", "provider", provider.Name(), "observation", observation)
+
+		response, err := provider.Query(ctx, systemPrompt, userPrompt)
+		if err != nil {
+			log.Warn("watcher.synthesize", "error", err)
+			return watcherSynthesisMsg{observation: observation, err: err}
+		}
+
+		return watcherSynthesisMsg{observation: observation, response: response}
+	}
+}
+
 // clearFlashMsg is sent after a flash notification's display duration has elapsed.
 // The status is only cleared if it still matches the original flash message,
 // preventing newer messages from being prematurely dismissed.

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -206,6 +206,36 @@ type aiHealthCheckMsg struct {
 	err     error
 }
 
+type watcherResponseMsg struct {
+	response string
+	err      error
+}
+
+func watcherQueryCmd(provider ai.Provider, userPrompt string, incidentContext string) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+
+		systemPrompt := "You are an SRE assistant with access to PagerDuty incident data and OpenShift cluster information. " +
+			"Provide concise, actionable analysis. Do not suggest destructive commands."
+
+		fullPrompt := userPrompt
+		if incidentContext != "" {
+			fullPrompt = fmt.Sprintf("%s\n\nContext:\n%s", userPrompt, incidentContext)
+		}
+
+		log.Debug("watcher.query", "provider", provider.Name(), "prompt", userPrompt)
+
+		response, err := provider.Query(ctx, systemPrompt, fullPrompt)
+		if err != nil {
+			log.Warn("watcher.query", "error", err)
+			return watcherResponseMsg{err: err}
+		}
+
+		return watcherResponseMsg{response: response}
+	}
+}
+
 func aiHealthCheckCmd(provider ai.Provider) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -216,13 +216,10 @@ type watcherResponseMsg struct {
 	err      error
 }
 
-func watcherQueryCmd(provider ai.Provider, userPrompt string, incidentContext string) tea.Cmd {
+func watcherQueryCmd(provider ai.Provider, systemPrompt string, userPrompt string, incidentContext string) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), watcherQueryTimeout)
 		defer cancel()
-
-		systemPrompt := "You are an SRE assistant with access to PagerDuty incident data and OpenShift cluster information. " +
-			"Provide concise, actionable analysis. Do not suggest destructive commands."
 
 		fullPrompt := userPrompt
 		if incidentContext != "" {
@@ -269,17 +266,15 @@ type watcherSynthesisMsg struct {
 	err         error
 }
 
-func watcherSynthesizeCmd(provider ai.Provider, observation string, incidentSummary string) tea.Cmd {
+func watcherSynthesizeCmd(provider ai.Provider, systemPrompt string, observation string, incidentSummary string) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), watcherSynthesisTimeout)
 		defer cancel()
 
-		systemPrompt := "You are an SRE assistant observing a PagerDuty incident queue. " +
-			"A pattern detector identified the following observation. " +
+		synthesisPrefix := "A pattern detector identified the following observation. " +
 			"Provide a brief (1-3 sentence) analysis of what this pattern might indicate " +
 			"and any suggested investigation steps. Be concise."
-
-		userPrompt := fmt.Sprintf("Observation: %s\n\nCurrent incidents:\n%s", observation, incidentSummary)
+		userPrompt := fmt.Sprintf("%s\n\nObservation: %s\n\nCurrent incidents:\n%s", synthesisPrefix, observation, incidentSummary)
 
 		log.Debug("watcher.synthesize", "provider", provider.Name(), "observation", observation)
 

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -28,6 +28,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const (
+	watcherQueryTimeout     = 60 * time.Second
+	watcherSynthesisTimeout = 30 * time.Second
+)
+
 // This file contains the commands that are used in the Bubble Tea update function.
 // These commands are functions that return a tea.Cmd, which performs I/O with
 // another system, such as the PagerDuty API, the filesystem, or the user's terminal,
@@ -213,7 +218,7 @@ type watcherResponseMsg struct {
 
 func watcherQueryCmd(provider ai.Provider, userPrompt string, incidentContext string) tea.Cmd {
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), watcherQueryTimeout)
 		defer cancel()
 
 		systemPrompt := "You are an SRE assistant with access to PagerDuty incident data and OpenShift cluster information. " +
@@ -266,7 +271,7 @@ type watcherSynthesisMsg struct {
 
 func watcherSynthesizeCmd(provider ai.Provider, observation string, incidentSummary string) tea.Cmd {
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), watcherSynthesisTimeout)
 		defer cancel()
 
 		systemPrompt := "You are an SRE assistant observing a PagerDuty incident queue. " +

--- a/pkg/tui/flag_commands.go
+++ b/pkg/tui/flag_commands.go
@@ -43,12 +43,12 @@ type flagsLoadedMsg struct {
 
 func isFlagCommand(input string) bool {
 	trimmed := strings.TrimSpace(input)
-	return trimmed == "/flags" ||
-		strings.HasPrefix(trimmed, "/flags ") ||
-		strings.HasPrefix(trimmed, "/flag ") ||
-		trimmed == "/flag" ||
-		strings.HasPrefix(trimmed, "/unflag ") ||
-		trimmed == "/unflag"
+	return trimmed == ":flags" ||
+		strings.HasPrefix(trimmed, ":flags ") ||
+		strings.HasPrefix(trimmed, ":flag ") ||
+		trimmed == ":flag" ||
+		strings.HasPrefix(trimmed, ":unflag ") ||
+		trimmed == ":unflag"
 }
 
 func parseFlagCommand(input string) (*parsedFlagCommand, error) {
@@ -60,11 +60,11 @@ func parseFlagCommand(input string) (*parsedFlagCommand, error) {
 	}
 
 	switch parts[0] {
-	case "/flags":
+	case ":flags":
 		return parseFlagsSubcommand(parts[1:])
-	case "/flag":
+	case ":flag":
 		return parseFlagAdd(parts[1:])
-	case "/unflag":
+	case ":unflag":
 		return parseUnflag(parts[1:])
 	default:
 		return nil, fmt.Errorf("unknown command: %s", parts[0])

--- a/pkg/tui/flag_commands_test.go
+++ b/pkg/tui/flag_commands_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestParseFlagCommand_ClusterID(t *testing.T) {
-	t.Run("parses /flag cluster <id>", func(t *testing.T) {
-		cmd, err := parseFlagCommand("/flag cluster 1q2w3e4rfakeidtest9o0p1a2s3d4f5g")
+	t.Run("parses :flag cluster <id>", func(t *testing.T) {
+		cmd, err := parseFlagCommand(":flag cluster 1q2w3e4rfakeidtest9o0p1a2s3d4f5g")
 
 		require.NoError(t, err)
 		require.NotNil(t, cmd)
@@ -26,8 +26,8 @@ func TestParseFlagCommand_ClusterID(t *testing.T) {
 }
 
 func TestParseFlagCommand_OrgName(t *testing.T) {
-	t.Run("parses /flag org <pattern>", func(t *testing.T) {
-		cmd, err := parseFlagCommand("/flag org ^Acme*")
+	t.Run("parses :flag org <pattern>", func(t *testing.T) {
+		cmd, err := parseFlagCommand(":flag org ^Acme*")
 
 		require.NoError(t, err)
 		require.NotNil(t, cmd)
@@ -40,7 +40,7 @@ func TestParseFlagCommand_OrgName(t *testing.T) {
 
 func TestParseFlagCommand_OrgNameMultiWord(t *testing.T) {
 	t.Run("parses org pattern with spaces", func(t *testing.T) {
-		cmd, err := parseFlagCommand("/flag org Red Hat Inc")
+		cmd, err := parseFlagCommand(":flag org Red Hat Inc")
 
 		require.NoError(t, err)
 		assert.Equal(t, FlagOrgName, cmd.condition.Type)
@@ -49,8 +49,8 @@ func TestParseFlagCommand_OrgNameMultiWord(t *testing.T) {
 }
 
 func TestParseFlagCommand_List(t *testing.T) {
-	t.Run("parses /flags as list command", func(t *testing.T) {
-		cmd, err := parseFlagCommand("/flags")
+	t.Run("parses :flags as list command", func(t *testing.T) {
+		cmd, err := parseFlagCommand(":flags")
 
 		require.NoError(t, err)
 		require.NotNil(t, cmd)
@@ -59,8 +59,8 @@ func TestParseFlagCommand_List(t *testing.T) {
 }
 
 func TestParseFlagCommand_Unflag(t *testing.T) {
-	t.Run("parses /unflag <id>", func(t *testing.T) {
-		cmd, err := parseFlagCommand("/unflag 3")
+	t.Run("parses :unflag <id>", func(t *testing.T) {
+		cmd, err := parseFlagCommand(":unflag 3")
 
 		require.NoError(t, err)
 		require.NotNil(t, cmd)
@@ -70,8 +70,8 @@ func TestParseFlagCommand_Unflag(t *testing.T) {
 }
 
 func TestParseFlagCommand_UnflagAll(t *testing.T) {
-	t.Run("parses /unflag all", func(t *testing.T) {
-		cmd, err := parseFlagCommand("/unflag all")
+	t.Run("parses :unflag all", func(t *testing.T) {
+		cmd, err := parseFlagCommand(":unflag all")
 
 		require.NoError(t, err)
 		require.NotNil(t, cmd)
@@ -80,8 +80,8 @@ func TestParseFlagCommand_UnflagAll(t *testing.T) {
 }
 
 func TestParseFlagCommand_FlagsSave(t *testing.T) {
-	t.Run("parses /flags save", func(t *testing.T) {
-		cmd, err := parseFlagCommand("/flags save")
+	t.Run("parses :flags save", func(t *testing.T) {
+		cmd, err := parseFlagCommand(":flags save")
 
 		require.NoError(t, err)
 		require.NotNil(t, cmd)
@@ -91,8 +91,8 @@ func TestParseFlagCommand_FlagsSave(t *testing.T) {
 }
 
 func TestParseFlagCommand_FlagsSavePath(t *testing.T) {
-	t.Run("parses /flags save <path>", func(t *testing.T) {
-		cmd, err := parseFlagCommand("/flags save /tmp/myflags.json")
+	t.Run("parses :flags save <path>", func(t *testing.T) {
+		cmd, err := parseFlagCommand(":flags save /tmp/myflags.json")
 
 		require.NoError(t, err)
 		require.NotNil(t, cmd)
@@ -102,8 +102,8 @@ func TestParseFlagCommand_FlagsSavePath(t *testing.T) {
 }
 
 func TestParseFlagCommand_FlagsLoad(t *testing.T) {
-	t.Run("parses /flags load", func(t *testing.T) {
-		cmd, err := parseFlagCommand("/flags load")
+	t.Run("parses :flags load", func(t *testing.T) {
+		cmd, err := parseFlagCommand(":flags load")
 
 		require.NoError(t, err)
 		require.NotNil(t, cmd)
@@ -112,8 +112,8 @@ func TestParseFlagCommand_FlagsLoad(t *testing.T) {
 }
 
 func TestParseFlagCommand_FlagsLoadPath(t *testing.T) {
-	t.Run("parses /flags load <path>", func(t *testing.T) {
-		cmd, err := parseFlagCommand("/flags load /tmp/myflags.json")
+	t.Run("parses :flags load <path>", func(t *testing.T) {
+		cmd, err := parseFlagCommand(":flags load /tmp/myflags.json")
 
 		require.NoError(t, err)
 		require.NotNil(t, cmd)
@@ -124,7 +124,7 @@ func TestParseFlagCommand_FlagsLoadPath(t *testing.T) {
 
 func TestParseFlagCommand_InvalidType(t *testing.T) {
 	t.Run("returns error for unknown flag type", func(t *testing.T) {
-		_, err := parseFlagCommand("/flag badtype value")
+		_, err := parseFlagCommand(":flag badtype value")
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "unknown flag type")
@@ -132,40 +132,40 @@ func TestParseFlagCommand_InvalidType(t *testing.T) {
 }
 
 func TestParseFlagCommand_MissingValue(t *testing.T) {
-	t.Run("returns error for /flag cluster with no value", func(t *testing.T) {
-		_, err := parseFlagCommand("/flag cluster")
+	t.Run("returns error for :flag cluster with no value", func(t *testing.T) {
+		_, err := parseFlagCommand(":flag cluster")
 
 		assert.Error(t, err)
 	})
 }
 
 func TestParseFlagCommand_MissingOrgValue(t *testing.T) {
-	t.Run("returns error for /flag org with no value", func(t *testing.T) {
-		_, err := parseFlagCommand("/flag org")
+	t.Run("returns error for :flag org with no value", func(t *testing.T) {
+		_, err := parseFlagCommand(":flag org")
 
 		assert.Error(t, err)
 	})
 }
 
 func TestParseFlagCommand_FlagNoArgs(t *testing.T) {
-	t.Run("returns error for bare /flag", func(t *testing.T) {
-		_, err := parseFlagCommand("/flag")
+	t.Run("returns error for bare :flag", func(t *testing.T) {
+		_, err := parseFlagCommand(":flag")
 
 		assert.Error(t, err)
 	})
 }
 
 func TestParseFlagCommand_UnflagInvalidID(t *testing.T) {
-	t.Run("returns error for /unflag with non-numeric id", func(t *testing.T) {
-		_, err := parseFlagCommand("/unflag abc")
+	t.Run("returns error for :unflag with non-numeric id", func(t *testing.T) {
+		_, err := parseFlagCommand(":unflag abc")
 
 		assert.Error(t, err)
 	})
 }
 
 func TestParseFlagCommand_UnflagNoArgs(t *testing.T) {
-	t.Run("returns error for bare /unflag", func(t *testing.T) {
-		_, err := parseFlagCommand("/unflag")
+	t.Run("returns error for bare :unflag", func(t *testing.T) {
+		_, err := parseFlagCommand(":unflag")
 
 		assert.Error(t, err)
 	})
@@ -214,7 +214,7 @@ func TestSaveFlagsCmd_CreatesDirectory(t *testing.T) {
 
 func TestSaveFlagsCmd_InvalidPath(t *testing.T) {
 	t.Run("returns error for invalid path", func(t *testing.T) {
-		cmd := saveFlagsCmd([]FlagCondition{{ID: 1}}, "/dev/null/impossible/flags.json")
+		cmd := saveFlagsCmd([]FlagCondition{{ID: 1}}, "/dev/null/impossible:flags.json")
 		msg := cmd()
 
 		saved := msg.(flagsSavedMsg)
@@ -246,7 +246,7 @@ func TestLoadFlagsCmd_ReadsJSON(t *testing.T) {
 
 func TestLoadFlagsCmd_FileNotFound(t *testing.T) {
 	t.Run("returns error for missing file", func(t *testing.T) {
-		cmd := loadFlagsCmd("/nonexistent/flags.json")
+		cmd := loadFlagsCmd("/nonexistent:flags.json")
 		msg := cmd()
 
 		loaded := msg.(flagsLoadedMsg)
@@ -297,11 +297,11 @@ func TestSaveLoadRoundTrip(t *testing.T) {
 }
 
 func TestDispatchFlagCommand_Add(t *testing.T) {
-	t.Run("dispatches addFlagConditionMsg for /flag cluster", func(t *testing.T) {
+	t.Run("dispatches addFlagConditionMsg for :flag cluster", func(t *testing.T) {
 		m := createTestModel()
 		m.flagMarker = emojiFlagMarker
 
-		cmd := m.dispatchFlagCommand("/flag cluster abc123")
+		cmd := m.dispatchFlagCommand(":flag cluster abc123")
 		require.NotNil(t, cmd)
 
 		msg := cmd()
@@ -313,11 +313,11 @@ func TestDispatchFlagCommand_Add(t *testing.T) {
 }
 
 func TestDispatchFlagCommand_List(t *testing.T) {
-	t.Run("dispatches listFlagConditionsMsg for /flags", func(t *testing.T) {
+	t.Run("dispatches listFlagConditionsMsg for :flags", func(t *testing.T) {
 		m := createTestModel()
 		m.flagMarker = emojiFlagMarker
 
-		cmd := m.dispatchFlagCommand("/flags")
+		cmd := m.dispatchFlagCommand(":flags")
 		require.NotNil(t, cmd)
 
 		msg := cmd()
@@ -331,7 +331,7 @@ func TestDispatchFlagCommand_Invalid(t *testing.T) {
 		m := createTestModel()
 		m.flagMarker = emojiFlagMarker
 
-		cmd := m.dispatchFlagCommand("/flag badtype value")
+		cmd := m.dispatchFlagCommand(":flag badtype value")
 		require.NotNil(t, cmd)
 
 		// The flash notification returns a tea.Cmd that produces setStatusMsg
@@ -349,13 +349,13 @@ func TestIsFlagCommand(t *testing.T) {
 		input string
 		want  bool
 	}{
-		{"flag command", "/flag cluster abc", true},
-		{"flags command", "/flags", true},
-		{"unflag command", "/unflag 3", true},
+		{"flag command", ":flag cluster abc", true},
+		{"flags command", ":flags", true},
+		{"unflag command", ":unflag 3", true},
 		{"not a flag command", "hello world", false},
 		{"claude prompt", "explain this code", false},
-		{"partial match", "/flagged", false},
-		{"flags save", "/flags save", true},
+		{"partial match", ":flagged", false},
+		{"flags save", ":flags save", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/tui/flag_commands_test.go
+++ b/pkg/tui/flag_commands_test.go
@@ -299,7 +299,7 @@ func TestSaveLoadRoundTrip(t *testing.T) {
 func TestDispatchFlagCommand_Add(t *testing.T) {
 	t.Run("dispatches addFlagConditionMsg for /flag cluster", func(t *testing.T) {
 		m := createTestModel()
-		m.flagMarker = defaultFlagMarker
+		m.flagMarker = emojiFlagMarker
 
 		cmd := m.dispatchFlagCommand("/flag cluster abc123")
 		require.NotNil(t, cmd)
@@ -315,7 +315,7 @@ func TestDispatchFlagCommand_Add(t *testing.T) {
 func TestDispatchFlagCommand_List(t *testing.T) {
 	t.Run("dispatches listFlagConditionsMsg for /flags", func(t *testing.T) {
 		m := createTestModel()
-		m.flagMarker = defaultFlagMarker
+		m.flagMarker = emojiFlagMarker
 
 		cmd := m.dispatchFlagCommand("/flags")
 		require.NotNil(t, cmd)
@@ -329,7 +329,7 @@ func TestDispatchFlagCommand_List(t *testing.T) {
 func TestDispatchFlagCommand_Invalid(t *testing.T) {
 	t.Run("returns flash notification for invalid command", func(t *testing.T) {
 		m := createTestModel()
-		m.flagMarker = defaultFlagMarker
+		m.flagMarker = emojiFlagMarker
 
 		cmd := m.dispatchFlagCommand("/flag badtype value")
 		require.NotNil(t, cmd)

--- a/pkg/tui/flags.go
+++ b/pkg/tui/flags.go
@@ -16,7 +16,10 @@ const (
 	FlagOrgName
 )
 
-const defaultFlagMarker = "🚩 "
+const (
+	emojiFlagMarker   = "🚩 "
+	noEmojiFlagMarker = "|► "
+)
 
 // FlagCondition is a user-defined rule that marks matching incidents.
 type FlagCondition struct {

--- a/pkg/tui/flags.go
+++ b/pkg/tui/flags.go
@@ -159,7 +159,7 @@ func (m model) renderFlagConditionsSection() string {
 
 func formatFlagsList(conditions []FlagCondition) string {
 	if len(conditions) == 0 {
-		return "No active flag conditions.\n\nUse `/flag cluster <id>` or `/flag org <pattern>` to add one."
+		return "No active flag conditions.\n\nUse `:flag cluster <id>` or `:flag org <pattern>` to add one."
 	}
 
 	var b strings.Builder

--- a/pkg/tui/flags_test.go
+++ b/pkg/tui/flags_test.go
@@ -267,7 +267,7 @@ func TestEvaluateFlags_NoClusters(t *testing.T) {
 func TestAddFlagConditionMsg(t *testing.T) {
 	t.Run("adds condition and assigns ID", func(t *testing.T) {
 		m := createTestModel()
-		m.flagMarker = defaultFlagMarker
+		m.flagMarker = emojiFlagMarker
 		m.incidentClusterMap = make(map[string][]string)
 		m.clusterCache = make(map[string]*ocm.ClusterInfo)
 
@@ -291,7 +291,7 @@ func TestAddFlagConditionMsg(t *testing.T) {
 func TestAddFlagConditionMsg_IncrementsID(t *testing.T) {
 	t.Run("auto-increments IDs", func(t *testing.T) {
 		m := createTestModel()
-		m.flagMarker = defaultFlagMarker
+		m.flagMarker = emojiFlagMarker
 		m.flagNextID = 5
 		m.flagConditions = []FlagCondition{
 			{ID: 5, Type: FlagClusterID, Pattern: "existing"},
@@ -312,7 +312,7 @@ func TestAddFlagConditionMsg_IncrementsID(t *testing.T) {
 func TestRemoveFlagConditionMsg(t *testing.T) {
 	t.Run("removes condition by ID", func(t *testing.T) {
 		m := createTestModel()
-		m.flagMarker = defaultFlagMarker
+		m.flagMarker = emojiFlagMarker
 		m.flagConditions = []FlagCondition{
 			{ID: 1, Type: FlagClusterID, Pattern: "cluster1"},
 			{ID: 2, Type: FlagOrgName, Pattern: "Acme"},
@@ -333,7 +333,7 @@ func TestRemoveFlagConditionMsg(t *testing.T) {
 func TestRemoveFlagConditionMsg_NotFound(t *testing.T) {
 	t.Run("no-op for unknown ID", func(t *testing.T) {
 		m := createTestModel()
-		m.flagMarker = defaultFlagMarker
+		m.flagMarker = emojiFlagMarker
 		m.flagConditions = []FlagCondition{
 			{ID: 1, Type: FlagClusterID, Pattern: "cluster1"},
 		}
@@ -350,7 +350,7 @@ func TestRemoveFlagConditionMsg_NotFound(t *testing.T) {
 func TestClearFlagConditionsMsg(t *testing.T) {
 	t.Run("removes all conditions", func(t *testing.T) {
 		m := createTestModel()
-		m.flagMarker = defaultFlagMarker
+		m.flagMarker = emojiFlagMarker
 		m.flagConditions = []FlagCondition{
 			{ID: 1, Type: FlagClusterID, Pattern: "a"},
 			{ID: 2, Type: FlagOrgName, Pattern: "b"},
@@ -370,7 +370,7 @@ func TestClearFlagConditionsMsg(t *testing.T) {
 func TestRebuildFlagMatchCache(t *testing.T) {
 	t.Run("rebuilds cache from current state", func(t *testing.T) {
 		m := createTestModel()
-		m.flagMarker = defaultFlagMarker
+		m.flagMarker = emojiFlagMarker
 		m.flagConditions = []FlagCondition{
 			{ID: 1, Type: FlagClusterID, Pattern: "cluster1"},
 		}
@@ -391,7 +391,7 @@ func TestRebuildFlagMatchCache(t *testing.T) {
 func TestRebuildFlagMatchCache_NoConditions(t *testing.T) {
 	t.Run("clears cache when no conditions", func(t *testing.T) {
 		m := createTestModel()
-		m.flagMarker = defaultFlagMarker
+		m.flagMarker = emojiFlagMarker
 		m.flagConditions = nil
 		m.flagMatchCache = map[string][]int{"INC001": {1}}
 
@@ -404,7 +404,7 @@ func TestRebuildFlagMatchCache_NoConditions(t *testing.T) {
 func TestRenderFlagConditionsSection(t *testing.T) {
 	t.Run("renders flag section for flagged incident", func(t *testing.T) {
 		m := createTestModel()
-		m.flagMarker = defaultFlagMarker
+		m.flagMarker = emojiFlagMarker
 		m.flagConditions = []FlagCondition{
 			{ID: 1, Type: FlagClusterID, Pattern: "cluster1", Label: "cluster ID matches \"cluster1\""},
 			{ID: 2, Type: FlagOrgName, Pattern: "Acme", Label: "org name matches \"Acme\""},
@@ -424,7 +424,7 @@ func TestRenderFlagConditionsSection(t *testing.T) {
 func TestRenderFlagConditionsSection_NoFlags(t *testing.T) {
 	t.Run("returns empty when incident not flagged", func(t *testing.T) {
 		m := createTestModel()
-		m.flagMarker = defaultFlagMarker
+		m.flagMarker = emojiFlagMarker
 		m.selectedIncident = &pagerduty.Incident{
 			APIObject: pagerduty.APIObject{ID: "INC001"},
 		}
@@ -437,7 +437,7 @@ func TestRenderFlagConditionsSection_NoFlags(t *testing.T) {
 func TestRenderFlagConditionsSection_NoIncident(t *testing.T) {
 	t.Run("returns empty when no incident selected", func(t *testing.T) {
 		m := createTestModel()
-		m.flagMarker = defaultFlagMarker
+		m.flagMarker = emojiFlagMarker
 
 		content := m.renderFlagConditionsSection()
 		assert.Empty(t, content)

--- a/pkg/tui/keymap.go
+++ b/pkg/tui/keymap.go
@@ -166,8 +166,8 @@ var defaultKeyMap = keymap{
 		key.WithHelp("u", "toggle urgency filter"),
 	),
 	Input: key.NewBinding(
-		key.WithKeys("i", ":"),
-		key.WithHelp("i/:", "command input"),
+		key.WithKeys("i", ":", "/"),
+		key.WithHelp("i/:/", "command input"),
 	),
 	Login: key.NewBinding(
 		key.WithKeys("l"),

--- a/pkg/tui/keymap.go
+++ b/pkg/tui/keymap.go
@@ -19,7 +19,7 @@ func (k keymap) FullHelp() [][]key.Binding {
 		// Column 2: Primary incident actions
 		{k.Ack, k.Note, k.Login, k.Open, k.SOP, k.UnAck, k.Silence, k.Merge, k.Flag},
 		// Column 3: Settings & toggles, Quit at bottom
-		{k.Team, k.Refresh, k.AutoRefresh, k.AutoAck, k.Urgency, k.ViewLog, k.Quit},
+		{k.Team, k.Refresh, k.AutoRefresh, k.AutoAck, k.Urgency, k.Watcher, k.ViewLog, k.Quit},
 		// Column 4: Tab navigation (incident viewer)
 		{k.TabNext, k.TabPrev},
 	}
@@ -58,6 +58,7 @@ type keymap struct {
 	ViewLog     key.Binding
 	Merge       key.Binding
 	Flag        key.Binding
+	Watcher     key.Binding
 	TabNext     key.Binding
 	TabPrev     key.Binding
 }
@@ -191,6 +192,10 @@ var defaultKeyMap = keymap{
 	Flag: key.NewBinding(
 		key.WithKeys("f"),
 		key.WithHelp("f", "flag condition"),
+	),
+	Watcher: key.NewBinding(
+		key.WithKeys("w"),
+		key.WithHelp("w", "toggle watcher"),
 	),
 	TabNext: key.NewBinding(
 		key.WithKeys("tab", "right"),

--- a/pkg/tui/keymap.go
+++ b/pkg/tui/keymap.go
@@ -17,7 +17,7 @@ func (k keymap) FullHelp() [][]key.Binding {
 		// Column 1: Help at top, navigation
 		{k.Help, k.Up, k.Down, k.Top, k.Bottom, k.Enter, k.Back},
 		// Column 2: Primary incident actions
-		{k.Ack, k.Note, k.Login, k.Open, k.SOP, k.UnAck, k.Silence, k.Merge, k.Flag},
+		{k.Ack, k.Note, k.Login, k.Open, k.SOP, k.UnAck, k.Silence, k.Merge, k.Input},
 		// Column 3: Settings & toggles, Quit at bottom
 		{k.Team, k.Refresh, k.AutoRefresh, k.AutoAck, k.Urgency, k.Watcher, k.ViewLog, k.Quit},
 		// Column 4: Tab navigation (incident viewer)
@@ -56,9 +56,8 @@ type keymap struct {
 	Open        key.Binding
 	SOP         key.Binding
 	ViewLog     key.Binding
-	Merge       key.Binding
-	Flag        key.Binding
-	Watcher     key.Binding
+	Merge   key.Binding
+	Watcher key.Binding
 	TabNext     key.Binding
 	TabPrev     key.Binding
 }
@@ -166,8 +165,8 @@ var defaultKeyMap = keymap{
 		key.WithHelp("u", "toggle urgency filter"),
 	),
 	Input: key.NewBinding(
-		key.WithKeys("i", ":", "/"),
-		key.WithHelp("i/:/", "command input"),
+		key.WithKeys(":", "/"),
+		key.WithHelp(":/", "command input"),
 	),
 	Login: key.NewBinding(
 		key.WithKeys("l"),
@@ -188,10 +187,6 @@ var defaultKeyMap = keymap{
 	Merge: key.NewBinding(
 		key.WithKeys("m"),
 		key.WithHelp("m", "merge incident"),
-	),
-	Flag: key.NewBinding(
-		key.WithKeys("f"),
-		key.WithHelp("f", "flag condition"),
 	),
 	Watcher: key.NewBinding(
 		key.WithKeys("w"),

--- a/pkg/tui/keymap.go
+++ b/pkg/tui/keymap.go
@@ -56,8 +56,8 @@ type keymap struct {
 	Open        key.Binding
 	SOP         key.Binding
 	ViewLog     key.Binding
-	Merge   key.Binding
-	Watcher key.Binding
+	Merge       key.Binding
+	Watcher     key.Binding
 	TabNext     key.Binding
 	TabPrev     key.Binding
 }

--- a/pkg/tui/layout.go
+++ b/pkg/tui/layout.go
@@ -25,8 +25,7 @@ const (
 	configFormReserved      = layoutHeaderLines + layoutBottomStatusLines + configFormBottomPadding
 
 	layoutWatcherBorderOverhead = 2
-	layoutWatcherHeaderLines    = 1
-	layoutWatcherOverhead       = layoutWatcherBorderOverhead + layoutWatcherHeaderLines
+	layoutWatcherOverhead       = layoutWatcherBorderOverhead
 
 	layoutMinTableRows       = 10
 	layoutMinWatcherRows     = 5

--- a/pkg/tui/layout.go
+++ b/pkg/tui/layout.go
@@ -24,10 +24,15 @@ const (
 	configFormBottomPadding = 1
 	configFormReserved      = layoutHeaderLines + layoutBottomStatusLines + configFormBottomPadding
 
-	layoutWatcherPaneHeight     = 5
 	layoutWatcherBorderOverhead = 2
 	layoutWatcherHeaderLines    = 1
-	layoutMinWatcherHeight      = 3
+	layoutWatcherOverhead       = layoutWatcherBorderOverhead + layoutWatcherHeaderLines
+
+	layoutMinTableRows       = 10
+	layoutMinWatcherRows     = 5
+	layoutDefaultWatcherRows = 10
+	layoutTableShareNum      = 2
+	layoutTableShareDen      = 3
 
 	layoutMinTableHeight          = 4
 	layoutMinIncidentViewerHeight = 10
@@ -64,7 +69,7 @@ type Layout struct {
 	ClusterSelectServiceWidth   int
 }
 
-func computeLayout(ws tea.WindowSizeMsg, styles Styles, helpView string, watcherLines int) Layout {
+func computeLayout(ws tea.WindowSizeMsg, styles Styles, helpView string, watcherExpanded bool) Layout {
 	mainHOverhead := styles.Main.GetHorizontalMargins() +
 		styles.Main.GetHorizontalPadding() +
 		styles.Main.GetHorizontalBorderSize()
@@ -89,16 +94,40 @@ func computeLayout(ws tea.WindowSizeMsg, styles Styles, helpView string, watcher
 	helpLines := strings.Count(helpView, "\n") + 1
 
 	tableWidth := ws.Width - mainHOverhead - containerHOverhead - cellHOverhead
-	tableHeight := ws.Height - mainVOverhead - containerVOverhead - tableFixedOverhead - helpLines - watcherLines
+	watcherWidth := ws.Width - mainHOverhead - containerHOverhead
+
+	// Total available rows for table + watcher content
+	availableRows := ws.Height - mainVOverhead - containerVOverhead - tableFixedOverhead - helpLines
+
+	var tableHeight, watcherHeight int
+
+	if !watcherExpanded {
+		tableHeight = availableRows
+	} else {
+		// Subtract watcher chrome (header + borders) and its own container border overhead
+		watcherContainerOverhead := styles.WatcherContainer.GetVerticalMargins() +
+			styles.WatcherContainer.GetVerticalPadding() +
+			styles.WatcherContainer.GetVerticalBorderSize()
+		availableForBoth := availableRows - layoutWatcherOverhead - watcherContainerOverhead
+
+		if availableForBoth >= layoutMinTableRows+layoutDefaultWatcherRows {
+			// Enough room: split 2/3 table, 1/3 watcher
+			tableHeight = availableForBoth * layoutTableShareNum / layoutTableShareDen
+			watcherHeight = availableForBoth - tableHeight
+		} else if availableForBoth >= layoutMinTableRows+layoutMinWatcherRows {
+			// Tight: table gets minimum, watcher gets the rest
+			tableHeight = layoutMinTableRows
+			watcherHeight = availableForBoth - tableHeight
+		} else {
+			// Very tight: both get minimums
+			tableHeight = layoutMinTableRows
+			watcherHeight = layoutMinWatcherRows
+		}
+	}
+
 	if tableHeight < layoutMinTableHeight {
 		tableHeight = layoutMinTableHeight
 	}
-
-	watcherHeight := layoutWatcherPaneHeight
-	if watcherHeight < layoutMinWatcherHeight {
-		watcherHeight = layoutMinWatcherHeight
-	}
-	watcherWidth := ws.Width - mainHOverhead - containerHOverhead
 
 	columnWidth := int(math.Ceil(float64(tableWidth-idWidth-dotWidth) / float64(2)))
 
@@ -169,12 +198,7 @@ func (m *model) recomputeLayout() {
 
 	helpView := m.help.View(helpKeyMap)
 
-	watcherLines := 0
-	if m.watcherExpanded {
-		watcherLines = layoutWatcherPaneHeight + layoutWatcherBorderOverhead + layoutWatcherHeaderLines
-	}
-
-	m.layout = computeLayout(windowSize, m.styles, helpView, watcherLines)
+	m.layout = computeLayout(windowSize, m.styles, helpView, m.watcherExpanded)
 	m.table.SetHeight(m.layout.TableHeight)
 
 	if m.watcherExpanded {

--- a/pkg/tui/layout.go
+++ b/pkg/tui/layout.go
@@ -24,6 +24,11 @@ const (
 	configFormBottomPadding = 1
 	configFormReserved      = layoutHeaderLines + layoutBottomStatusLines + configFormBottomPadding
 
+	layoutWatcherPaneHeight     = 5
+	layoutWatcherBorderOverhead = 2
+	layoutWatcherHeaderLines    = 1
+	layoutMinWatcherHeight      = 3
+
 	layoutMinTableHeight          = 4
 	layoutMinIncidentViewerHeight = 10
 	layoutMinFormHeight           = 1
@@ -48,6 +53,9 @@ type Layout struct {
 	IncidentViewerWidth  int
 	IncidentViewerHeight int
 
+	WatcherWidth  int
+	WatcherHeight int
+
 	FormWidth            int
 	FormHeight           int
 	TeamSelectFormHeight int
@@ -56,7 +64,7 @@ type Layout struct {
 	ClusterSelectServiceWidth   int
 }
 
-func computeLayout(ws tea.WindowSizeMsg, styles Styles, helpView string) Layout {
+func computeLayout(ws tea.WindowSizeMsg, styles Styles, helpView string, watcherLines int) Layout {
 	mainHOverhead := styles.Main.GetHorizontalMargins() +
 		styles.Main.GetHorizontalPadding() +
 		styles.Main.GetHorizontalBorderSize()
@@ -81,10 +89,16 @@ func computeLayout(ws tea.WindowSizeMsg, styles Styles, helpView string) Layout 
 	helpLines := strings.Count(helpView, "\n") + 1
 
 	tableWidth := ws.Width - mainHOverhead - containerHOverhead - cellHOverhead
-	tableHeight := ws.Height - mainVOverhead - containerVOverhead - tableFixedOverhead - helpLines
+	tableHeight := ws.Height - mainVOverhead - containerVOverhead - tableFixedOverhead - helpLines - watcherLines
 	if tableHeight < layoutMinTableHeight {
 		tableHeight = layoutMinTableHeight
 	}
+
+	watcherHeight := layoutWatcherPaneHeight
+	if watcherHeight < layoutMinWatcherHeight {
+		watcherHeight = layoutMinWatcherHeight
+	}
+	watcherWidth := ws.Width - mainHOverhead - containerHOverhead
 
 	columnWidth := int(math.Ceil(float64(tableWidth-idWidth-dotWidth) / float64(2)))
 
@@ -131,6 +145,8 @@ func computeLayout(ws tea.WindowSizeMsg, styles Styles, helpView string) Layout 
 		FormWidth:                   formWidth,
 		FormHeight:                  formHeight,
 		TeamSelectFormHeight:        teamSelectFormHeight,
+		WatcherWidth:                watcherWidth,
+		WatcherHeight:               watcherHeight,
 		ClusterSelectClusterIDWidth: clusterIDWidth,
 		ClusterSelectServiceWidth:   serviceWidth,
 	}
@@ -152,6 +168,17 @@ func (m *model) recomputeLayout() {
 	}
 
 	helpView := m.help.View(helpKeyMap)
-	m.layout = computeLayout(windowSize, m.styles, helpView)
+
+	watcherLines := 0
+	if m.watcherExpanded {
+		watcherLines = layoutWatcherPaneHeight + layoutWatcherBorderOverhead + layoutWatcherHeaderLines
+	}
+
+	m.layout = computeLayout(windowSize, m.styles, helpView, watcherLines)
 	m.table.SetHeight(m.layout.TableHeight)
+
+	if m.watcherExpanded {
+		m.watcherViewport.Width = m.layout.WatcherWidth
+		m.watcherViewport.Height = m.layout.WatcherHeight
+	}
 }

--- a/pkg/tui/layout_test.go
+++ b/pkg/tui/layout_test.go
@@ -24,7 +24,7 @@ func longHelp() string {
 func TestComputeLayout_StandardTerminal(t *testing.T) {
 	t.Run("80x24 produces usable dimensions", func(t *testing.T) {
 		ws := tea.WindowSizeMsg{Width: 80, Height: 24}
-		l := computeLayout(ws, defaultStyles(), shortHelp())
+		l := computeLayout(ws, defaultStyles(), shortHelp(), 0)
 
 		assert.Equal(t, 80, l.WindowWidth)
 		assert.Equal(t, 24, l.WindowHeight)
@@ -39,7 +39,7 @@ func TestComputeLayout_StandardTerminal(t *testing.T) {
 func TestComputeLayout_SmallTerminal(t *testing.T) {
 	t.Run("80x10 floors at minimums", func(t *testing.T) {
 		ws := tea.WindowSizeMsg{Width: 80, Height: 10}
-		l := computeLayout(ws, defaultStyles(), shortHelp())
+		l := computeLayout(ws, defaultStyles(), shortHelp(), 0)
 
 		assert.Equal(t, layoutMinTableHeight, l.TableHeight)
 		assert.Equal(t, layoutMinIncidentViewerHeight, l.IncidentViewerHeight)
@@ -49,7 +49,7 @@ func TestComputeLayout_SmallTerminal(t *testing.T) {
 func TestComputeLayout_LargeTerminal(t *testing.T) {
 	t.Run("200x60 scales proportionally", func(t *testing.T) {
 		ws := tea.WindowSizeMsg{Width: 200, Height: 60}
-		l := computeLayout(ws, defaultStyles(), shortHelp())
+		l := computeLayout(ws, defaultStyles(), shortHelp(), 0)
 
 		assert.Greater(t, l.TableHeight, 30)
 		assert.Greater(t, l.ColumnWidth, 50)
@@ -62,8 +62,8 @@ func TestComputeLayout_HelpExpandedReducesHeight(t *testing.T) {
 		ws := tea.WindowSizeMsg{Width: 80, Height: 24}
 		styles := defaultStyles()
 
-		compactLayout := computeLayout(ws, styles, shortHelp())
-		expandedLayout := computeLayout(ws, styles, longHelp())
+		compactLayout := computeLayout(ws, styles, shortHelp(), 0)
+		expandedLayout := computeLayout(ws, styles, longHelp(), 0)
 
 		assert.Greater(t, compactLayout.TableHeight, expandedLayout.TableHeight,
 			"compact help should yield taller table than expanded help")
@@ -73,7 +73,7 @@ func TestComputeLayout_HelpExpandedReducesHeight(t *testing.T) {
 func TestComputeLayout_TableAndIncidentViewerConsistent(t *testing.T) {
 	t.Run("both use named constants and are positive", func(t *testing.T) {
 		ws := tea.WindowSizeMsg{Width: 80, Height: 24}
-		l := computeLayout(ws, defaultStyles(), shortHelp())
+		l := computeLayout(ws, defaultStyles(), shortHelp(), 0)
 
 		assert.Greater(t, l.TableHeight, 0)
 		assert.Greater(t, l.IncidentViewerHeight, 0)
@@ -85,7 +85,7 @@ func TestComputeLayout_TableAndIncidentViewerConsistent(t *testing.T) {
 func TestComputeLayout_FormHeight(t *testing.T) {
 	t.Run("form heights computed from constants", func(t *testing.T) {
 		ws := tea.WindowSizeMsg{Width: 80, Height: 24}
-		l := computeLayout(ws, defaultStyles(), shortHelp())
+		l := computeLayout(ws, defaultStyles(), shortHelp(), 0)
 
 		assert.Equal(t, 24-configFormReserved, l.FormHeight)
 		assert.Equal(t, 24, l.TeamSelectFormHeight)
@@ -96,7 +96,7 @@ func TestComputeLayout_FormHeight(t *testing.T) {
 func TestComputeLayout_ZeroHeight(t *testing.T) {
 	t.Run("zero height floors at minimums", func(t *testing.T) {
 		ws := tea.WindowSizeMsg{Width: 80, Height: 0}
-		l := computeLayout(ws, defaultStyles(), shortHelp())
+		l := computeLayout(ws, defaultStyles(), shortHelp(), 0)
 
 		assert.Equal(t, layoutMinTableHeight, l.TableHeight)
 		assert.Equal(t, layoutMinIncidentViewerHeight, l.IncidentViewerHeight)
@@ -107,7 +107,7 @@ func TestComputeLayout_ZeroHeight(t *testing.T) {
 func TestComputeLayout_ClusterSelectWidthsCapped(t *testing.T) {
 	t.Run("wide terminal caps cluster select widths", func(t *testing.T) {
 		ws := tea.WindowSizeMsg{Width: 200, Height: 40}
-		l := computeLayout(ws, defaultStyles(), shortHelp())
+		l := computeLayout(ws, defaultStyles(), shortHelp(), 0)
 
 		assert.LessOrEqual(t, l.ClusterSelectClusterIDWidth, layoutMaxClusterIDWidth)
 		assert.LessOrEqual(t, l.ClusterSelectServiceWidth, layoutMaxServiceWidth)
@@ -115,7 +115,7 @@ func TestComputeLayout_ClusterSelectWidthsCapped(t *testing.T) {
 
 	t.Run("narrow terminal uses proportional widths", func(t *testing.T) {
 		ws := tea.WindowSizeMsg{Width: 60, Height: 24}
-		l := computeLayout(ws, defaultStyles(), shortHelp())
+		l := computeLayout(ws, defaultStyles(), shortHelp(), 0)
 
 		assert.Less(t, l.ClusterSelectClusterIDWidth, layoutMaxClusterIDWidth)
 		assert.Less(t, l.ClusterSelectServiceWidth, layoutMaxServiceWidth)
@@ -130,7 +130,7 @@ func TestComputeLayout_MatchesOldTableHeight(t *testing.T) {
 		styles := defaultStyles()
 		helpView := shortHelp()
 
-		l := computeLayout(ws, styles, helpView)
+		l := computeLayout(ws, styles, helpView, 0)
 
 		helpLines := strings.Count(helpView, "\n") + 1
 		oldFixedLines := 6
@@ -231,5 +231,47 @@ func TestWindowResize_IncidentViewMode(t *testing.T) {
 
 		assert.Equal(t, updated.layout.IncidentViewerWidth, updated.incidentViewer.Width)
 		assert.Equal(t, updated.layout.IncidentViewerHeight, updated.incidentViewer.Height)
+	})
+}
+
+func TestComputeLayout_WatcherReducesTableHeight(t *testing.T) {
+	t.Run("watcher lines reduce table height", func(t *testing.T) {
+		ws := tea.WindowSizeMsg{Width: 80, Height: 40}
+		styles := defaultStyles()
+		help := shortHelp()
+
+		withoutWatcher := computeLayout(ws, styles, help, 0)
+		watcherLines := layoutWatcherPaneHeight + layoutWatcherBorderOverhead + layoutWatcherHeaderLines
+		withWatcher := computeLayout(ws, styles, help, watcherLines)
+
+		assert.Equal(t, withoutWatcher.TableHeight-watcherLines, withWatcher.TableHeight)
+	})
+
+	t.Run("watcher height is populated when watcher lines > 0", func(t *testing.T) {
+		ws := tea.WindowSizeMsg{Width: 80, Height: 40}
+		watcherLines := layoutWatcherPaneHeight + layoutWatcherBorderOverhead + layoutWatcherHeaderLines
+		l := computeLayout(ws, defaultStyles(), shortHelp(), watcherLines)
+
+		assert.Equal(t, layoutWatcherPaneHeight, l.WatcherHeight)
+		assert.Greater(t, l.WatcherWidth, 0)
+	})
+}
+
+func TestRecomputeLayout_WatcherExpanded(t *testing.T) {
+	t.Run("watcher expanded reduces table height", func(t *testing.T) {
+		m := createTestModel()
+		m.help = newHelp()
+		windowSize = tea.WindowSizeMsg{Width: 80, Height: 40}
+
+		m.watcherExpanded = false
+		m.recomputeLayout()
+		collapsedHeight := m.layout.TableHeight
+
+		m.watcherExpanded = true
+		m.recomputeLayout()
+		expandedHeight := m.layout.TableHeight
+
+		watcherLines := layoutWatcherPaneHeight + layoutWatcherBorderOverhead + layoutWatcherHeaderLines
+		assert.Equal(t, collapsedHeight-watcherLines, expandedHeight)
 	})
 }

--- a/pkg/tui/layout_test.go
+++ b/pkg/tui/layout_test.go
@@ -24,7 +24,7 @@ func longHelp() string {
 func TestComputeLayout_StandardTerminal(t *testing.T) {
 	t.Run("80x24 produces usable dimensions", func(t *testing.T) {
 		ws := tea.WindowSizeMsg{Width: 80, Height: 24}
-		l := computeLayout(ws, defaultStyles(), shortHelp(), 0)
+		l := computeLayout(ws, defaultStyles(), shortHelp(), false)
 
 		assert.Equal(t, 80, l.WindowWidth)
 		assert.Equal(t, 24, l.WindowHeight)
@@ -39,7 +39,7 @@ func TestComputeLayout_StandardTerminal(t *testing.T) {
 func TestComputeLayout_SmallTerminal(t *testing.T) {
 	t.Run("80x10 floors at minimums", func(t *testing.T) {
 		ws := tea.WindowSizeMsg{Width: 80, Height: 10}
-		l := computeLayout(ws, defaultStyles(), shortHelp(), 0)
+		l := computeLayout(ws, defaultStyles(), shortHelp(), false)
 
 		assert.Equal(t, layoutMinTableHeight, l.TableHeight)
 		assert.Equal(t, layoutMinIncidentViewerHeight, l.IncidentViewerHeight)
@@ -49,7 +49,7 @@ func TestComputeLayout_SmallTerminal(t *testing.T) {
 func TestComputeLayout_LargeTerminal(t *testing.T) {
 	t.Run("200x60 scales proportionally", func(t *testing.T) {
 		ws := tea.WindowSizeMsg{Width: 200, Height: 60}
-		l := computeLayout(ws, defaultStyles(), shortHelp(), 0)
+		l := computeLayout(ws, defaultStyles(), shortHelp(), false)
 
 		assert.Greater(t, l.TableHeight, 30)
 		assert.Greater(t, l.ColumnWidth, 50)
@@ -62,8 +62,8 @@ func TestComputeLayout_HelpExpandedReducesHeight(t *testing.T) {
 		ws := tea.WindowSizeMsg{Width: 80, Height: 24}
 		styles := defaultStyles()
 
-		compactLayout := computeLayout(ws, styles, shortHelp(), 0)
-		expandedLayout := computeLayout(ws, styles, longHelp(), 0)
+		compactLayout := computeLayout(ws, styles, shortHelp(), false)
+		expandedLayout := computeLayout(ws, styles, longHelp(), false)
 
 		assert.Greater(t, compactLayout.TableHeight, expandedLayout.TableHeight,
 			"compact help should yield taller table than expanded help")
@@ -73,7 +73,7 @@ func TestComputeLayout_HelpExpandedReducesHeight(t *testing.T) {
 func TestComputeLayout_TableAndIncidentViewerConsistent(t *testing.T) {
 	t.Run("both use named constants and are positive", func(t *testing.T) {
 		ws := tea.WindowSizeMsg{Width: 80, Height: 24}
-		l := computeLayout(ws, defaultStyles(), shortHelp(), 0)
+		l := computeLayout(ws, defaultStyles(), shortHelp(), false)
 
 		assert.Greater(t, l.TableHeight, 0)
 		assert.Greater(t, l.IncidentViewerHeight, 0)
@@ -85,7 +85,7 @@ func TestComputeLayout_TableAndIncidentViewerConsistent(t *testing.T) {
 func TestComputeLayout_FormHeight(t *testing.T) {
 	t.Run("form heights computed from constants", func(t *testing.T) {
 		ws := tea.WindowSizeMsg{Width: 80, Height: 24}
-		l := computeLayout(ws, defaultStyles(), shortHelp(), 0)
+		l := computeLayout(ws, defaultStyles(), shortHelp(), false)
 
 		assert.Equal(t, 24-configFormReserved, l.FormHeight)
 		assert.Equal(t, 24, l.TeamSelectFormHeight)
@@ -96,7 +96,7 @@ func TestComputeLayout_FormHeight(t *testing.T) {
 func TestComputeLayout_ZeroHeight(t *testing.T) {
 	t.Run("zero height floors at minimums", func(t *testing.T) {
 		ws := tea.WindowSizeMsg{Width: 80, Height: 0}
-		l := computeLayout(ws, defaultStyles(), shortHelp(), 0)
+		l := computeLayout(ws, defaultStyles(), shortHelp(), false)
 
 		assert.Equal(t, layoutMinTableHeight, l.TableHeight)
 		assert.Equal(t, layoutMinIncidentViewerHeight, l.IncidentViewerHeight)
@@ -107,7 +107,7 @@ func TestComputeLayout_ZeroHeight(t *testing.T) {
 func TestComputeLayout_ClusterSelectWidthsCapped(t *testing.T) {
 	t.Run("wide terminal caps cluster select widths", func(t *testing.T) {
 		ws := tea.WindowSizeMsg{Width: 200, Height: 40}
-		l := computeLayout(ws, defaultStyles(), shortHelp(), 0)
+		l := computeLayout(ws, defaultStyles(), shortHelp(), false)
 
 		assert.LessOrEqual(t, l.ClusterSelectClusterIDWidth, layoutMaxClusterIDWidth)
 		assert.LessOrEqual(t, l.ClusterSelectServiceWidth, layoutMaxServiceWidth)
@@ -115,7 +115,7 @@ func TestComputeLayout_ClusterSelectWidthsCapped(t *testing.T) {
 
 	t.Run("narrow terminal uses proportional widths", func(t *testing.T) {
 		ws := tea.WindowSizeMsg{Width: 60, Height: 24}
-		l := computeLayout(ws, defaultStyles(), shortHelp(), 0)
+		l := computeLayout(ws, defaultStyles(), shortHelp(), false)
 
 		assert.Less(t, l.ClusterSelectClusterIDWidth, layoutMaxClusterIDWidth)
 		assert.Less(t, l.ClusterSelectServiceWidth, layoutMaxServiceWidth)
@@ -130,7 +130,7 @@ func TestComputeLayout_MatchesOldTableHeight(t *testing.T) {
 		styles := defaultStyles()
 		helpView := shortHelp()
 
-		l := computeLayout(ws, styles, helpView, 0)
+		l := computeLayout(ws, styles, helpView, false)
 
 		helpLines := strings.Count(helpView, "\n") + 1
 		oldFixedLines := 6
@@ -235,25 +235,46 @@ func TestWindowResize_IncidentViewMode(t *testing.T) {
 }
 
 func TestComputeLayout_WatcherReducesTableHeight(t *testing.T) {
-	t.Run("watcher lines reduce table height", func(t *testing.T) {
-		ws := tea.WindowSizeMsg{Width: 80, Height: 40}
+	t.Run("watcher expanded reduces table height", func(t *testing.T) {
+		ws := tea.WindowSizeMsg{Width: 80, Height: 60}
 		styles := defaultStyles()
 		help := shortHelp()
 
-		withoutWatcher := computeLayout(ws, styles, help, 0)
-		watcherLines := layoutWatcherPaneHeight + layoutWatcherBorderOverhead + layoutWatcherHeaderLines
-		withWatcher := computeLayout(ws, styles, help, watcherLines)
+		collapsed := computeLayout(ws, styles, help, false)
+		expanded := computeLayout(ws, styles, help, true)
 
-		assert.Equal(t, withoutWatcher.TableHeight-watcherLines, withWatcher.TableHeight)
+		assert.Greater(t, collapsed.TableHeight, expanded.TableHeight,
+			"table should be shorter when watcher is expanded")
 	})
 
-	t.Run("watcher height is populated when watcher lines > 0", func(t *testing.T) {
-		ws := tea.WindowSizeMsg{Width: 80, Height: 40}
-		watcherLines := layoutWatcherPaneHeight + layoutWatcherBorderOverhead + layoutWatcherHeaderLines
-		l := computeLayout(ws, defaultStyles(), shortHelp(), watcherLines)
+	t.Run("watcher gets height when expanded", func(t *testing.T) {
+		ws := tea.WindowSizeMsg{Width: 80, Height: 60}
+		l := computeLayout(ws, defaultStyles(), shortHelp(), true)
 
-		assert.Equal(t, layoutWatcherPaneHeight, l.WatcherHeight)
+		assert.GreaterOrEqual(t, l.WatcherHeight, layoutMinWatcherRows)
 		assert.Greater(t, l.WatcherWidth, 0)
+	})
+
+	t.Run("table always gets at least minimum rows", func(t *testing.T) {
+		ws := tea.WindowSizeMsg{Width: 80, Height: 60}
+		l := computeLayout(ws, defaultStyles(), shortHelp(), true)
+
+		assert.GreaterOrEqual(t, l.TableHeight, layoutMinTableRows)
+	})
+
+	t.Run("large terminal splits 2/3 table 1/3 watcher", func(t *testing.T) {
+		ws := tea.WindowSizeMsg{Width: 80, Height: 80}
+		l := computeLayout(ws, defaultStyles(), shortHelp(), true)
+
+		assert.Greater(t, l.TableHeight, l.WatcherHeight,
+			"table should be larger than watcher in 2/3 split")
+	})
+
+	t.Run("collapsed watcher gives zero height", func(t *testing.T) {
+		ws := tea.WindowSizeMsg{Width: 80, Height: 60}
+		l := computeLayout(ws, defaultStyles(), shortHelp(), false)
+
+		assert.Equal(t, 0, l.WatcherHeight)
 	})
 }
 
@@ -261,7 +282,7 @@ func TestRecomputeLayout_WatcherExpanded(t *testing.T) {
 	t.Run("watcher expanded reduces table height", func(t *testing.T) {
 		m := createTestModel()
 		m.help = newHelp()
-		windowSize = tea.WindowSizeMsg{Width: 80, Height: 40}
+		windowSize = tea.WindowSizeMsg{Width: 80, Height: 60}
 
 		m.watcherExpanded = false
 		m.recomputeLayout()
@@ -271,7 +292,7 @@ func TestRecomputeLayout_WatcherExpanded(t *testing.T) {
 		m.recomputeLayout()
 		expandedHeight := m.layout.TableHeight
 
-		watcherLines := layoutWatcherPaneHeight + layoutWatcherBorderOverhead + layoutWatcherHeaderLines
-		assert.Equal(t, collapsedHeight-watcherLines, expandedHeight)
+		assert.Greater(t, collapsedHeight, expandedHeight)
+		assert.GreaterOrEqual(t, expandedHeight, layoutMinTableRows)
 	})
 }

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -133,8 +133,9 @@ type model struct {
 	watcherBuffer   *watcherBuffer
 	watcherMarker   string
 	agentMarker     string
-	watcherDedup      *watcherDedup
-	watcherAnalyzing  bool
+	watcherDedup       *watcherDedup
+	watcherAnalyzing   bool
+	watcherQueryStart  time.Time
 	typewriter        *typewriterState
 
 	// Incident viewer tab state

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -135,6 +135,7 @@ type model struct {
 	agentMarker     string
 	watcherDedup      *watcherDedup
 	watcherAnalyzing  bool
+	typewriter        *typewriterState
 
 	// Incident viewer tab state
 	activeTab int // 0=details, 1=alerts, 2=notes

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -126,6 +126,10 @@ type model struct {
 	// aiHealthy tracks whether the last LLM provider health check succeeded
 	aiHealthy bool
 
+	// watcherExpanded is true when the AI watcher pane is visible below the table
+	watcherExpanded bool
+	watcherViewport viewport.Model
+
 	// Incident viewer tab state
 	activeTab int // 0=details, 1=alerts, 2=notes
 
@@ -265,6 +269,7 @@ func InitialModel(
 		configModeRequested:   configMode,
 		aiProvider:            aiProvider,
 		agentCLICommand:       agentCLICommand,
+		watcherViewport:       newWatcherViewport(),
 	}
 
 	if aiProvider != nil {
@@ -359,6 +364,7 @@ func InitialModelWithConfig(
 		styles:                styles,
 		aiProvider:            aiProvider,
 		agentCLICommand:       agentCLICommand,
+		watcherViewport:       newWatcherViewport(),
 	}
 
 	if aiProvider != nil {
@@ -611,7 +617,11 @@ func newIncidentViewer() viewport.Model {
 
 func newLogViewer() viewport.Model {
 	vp := viewport.New(100, 100)
-	// Viewport uses container border from View(), no style needed here
+	return vp
+}
+
+func newWatcherViewport() viewport.Model {
+	vp := viewport.New(100, layoutWatcherPaneHeight)
 	return vp
 }
 

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -133,6 +133,7 @@ type model struct {
 	watcherBuffer   *watcherBuffer
 	watcherMarker   string
 	agentMarker     string
+	watcherDedup    *watcherDedup
 
 	// Incident viewer tab state
 	activeTab int // 0=details, 1=alerts, 2=notes
@@ -280,6 +281,7 @@ func InitialModel(
 	m.flagMarker = mk.flag
 	m.watcherMarker = mk.watcher
 	m.agentMarker = mk.agent
+	m.watcherDedup = newWatcherDedup(5 * time.Minute)
 
 	if aiProvider != nil {
 		m.scheduledJobs = append(m.scheduledJobs, &scheduledJob{
@@ -380,6 +382,7 @@ func InitialModelWithConfig(
 	m.flagMarker = mk2.flag
 	m.watcherMarker = mk2.watcher
 	m.agentMarker = mk2.agent
+	m.watcherDedup = newWatcherDedup(5 * time.Minute)
 
 	if aiProvider != nil {
 		m.scheduledJobs = append(m.scheduledJobs, &scheduledJob{

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -119,9 +119,9 @@ type model struct {
 	chordHelpActive bool
 
 	// claudeQuerying is true while a Claude CLI query is in progress
-	claudeQuerying     bool
-	agentCLICommand    string
-	agentSystemPrompt  string
+	claudeQuerying      bool
+	agentCLICommand     string
+	agentSystemPrompt   string
 	watcherSystemPrompt string
 
 	// aiProvider is the configured LLM API provider, or nil when unconfigured
@@ -130,16 +130,16 @@ type model struct {
 	aiHealthy bool
 
 	// watcherExpanded is true when the AI watcher pane is visible below the table
-	watcherExpanded bool
-	watcherViewport viewport.Model
-	watcherBuffer   *watcherBuffer
-	watcherMarker   string
-	agentMarker     string
-	watcherDedup       *watcherDedup
-	watcherAnalyzing      bool
-	watcherQueryStart     time.Time
-	watcherQueryTimeout   time.Duration
-	typewriter        *typewriterState
+	watcherExpanded     bool
+	watcherViewport     viewport.Model
+	watcherBuffer       *watcherBuffer
+	watcherMarker       string
+	agentMarker         string
+	watcherDedup        *watcherDedup
+	watcherAnalyzing    bool
+	watcherQueryStart   time.Time
+	watcherQueryTimeout time.Duration
+	typewriter          *typewriterState
 
 	// Incident viewer tab state
 	activeTab int // 0=details, 1=alerts, 2=notes

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -119,8 +119,10 @@ type model struct {
 	chordHelpActive bool
 
 	// claudeQuerying is true while a Claude CLI query is in progress
-	claudeQuerying  bool
-	agentCLICommand string
+	claudeQuerying     bool
+	agentCLICommand    string
+	agentSystemPrompt  string
+	watcherSystemPrompt string
 
 	// aiProvider is the configured LLM API provider, or nil when unconfigured
 	aiProvider ai.Provider
@@ -286,6 +288,8 @@ func InitialModel(
 	m.watcherMarker = mk.watcher
 	m.agentMarker = mk.agent
 	m.watcherDedup = newWatcherDedup(5 * time.Minute)
+	m.agentSystemPrompt = viper.GetString("agent_system_prompt")
+	m.watcherSystemPrompt = viper.GetString("watcher_system_prompt")
 
 	if aiProvider != nil {
 		m.scheduledJobs = append(m.scheduledJobs, &scheduledJob{
@@ -387,6 +391,8 @@ func InitialModelWithConfig(
 	m.watcherMarker = mk2.watcher
 	m.agentMarker = mk2.agent
 	m.watcherDedup = newWatcherDedup(5 * time.Minute)
+	m.agentSystemPrompt = viper.GetString("agent_system_prompt")
+	m.watcherSystemPrompt = viper.GetString("watcher_system_prompt")
 
 	if aiProvider != nil {
 		m.scheduledJobs = append(m.scheduledJobs, &scheduledJob{

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -639,7 +639,7 @@ func newLogViewer() viewport.Model {
 }
 
 func newWatcherViewport() viewport.Model {
-	vp := viewport.New(100, layoutWatcherPaneHeight)
+	vp := viewport.New(100, layoutDefaultWatcherRows)
 	return vp
 }
 

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -23,6 +23,7 @@ import (
 	"github.com/clcollins/srepd/pkg/launcher"
 	"github.com/clcollins/srepd/pkg/ocm"
 	"github.com/clcollins/srepd/pkg/pd"
+	"github.com/spf13/viper"
 )
 
 // cachedIncidentData stores fetched incident data for reuse
@@ -129,6 +130,9 @@ type model struct {
 	// watcherExpanded is true when the AI watcher pane is visible below the table
 	watcherExpanded bool
 	watcherViewport viewport.Model
+	watcherBuffer   *watcherBuffer
+	watcherMarker   string
+	agentMarker     string
 
 	// Incident viewer tab state
 	activeTab int // 0=details, 1=alerts, 2=notes
@@ -262,7 +266,6 @@ func InitialModel(
 		clusterCache:          make(map[string]*ocm.ClusterInfo),
 		serviceLogCache:       make(map[string][]ocm.ServiceLog),
 		limitedSupportCache:   make(map[string][]ocm.LimitedSupportReason),
-		flagMarker:            defaultFlagMarker,
 		chordPrefix:           "ctrl+x",
 		theme:                 theme,
 		styles:                styles,
@@ -270,7 +273,13 @@ func InitialModel(
 		aiProvider:            aiProvider,
 		agentCLICommand:       agentCLICommand,
 		watcherViewport:       newWatcherViewport(),
+		watcherBuffer:         newWatcherBuffer(50),
 	}
+
+	mk := resolveMarkers(viper.GetBool("emoji"))
+	m.flagMarker = mk.flag
+	m.watcherMarker = mk.watcher
+	m.agentMarker = mk.agent
 
 	if aiProvider != nil {
 		m.scheduledJobs = append(m.scheduledJobs, &scheduledJob{
@@ -359,13 +368,18 @@ func InitialModelWithConfig(
 		clusterCache:          make(map[string]*ocm.ClusterInfo),
 		serviceLogCache:       make(map[string][]ocm.ServiceLog),
 		limitedSupportCache:   make(map[string][]ocm.LimitedSupportReason),
-		flagMarker:            defaultFlagMarker,
 		theme:                 theme,
 		styles:                styles,
 		aiProvider:            aiProvider,
 		agentCLICommand:       agentCLICommand,
 		watcherViewport:       newWatcherViewport(),
+		watcherBuffer:         newWatcherBuffer(50),
 	}
+
+	mk2 := resolveMarkers(viper.GetBool("emoji"))
+	m.flagMarker = mk2.flag
+	m.watcherMarker = mk2.watcher
+	m.agentMarker = mk2.agent
 
 	if aiProvider != nil {
 		m.scheduledJobs = append(m.scheduledJobs, &scheduledJob{

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -134,8 +134,9 @@ type model struct {
 	watcherMarker   string
 	agentMarker     string
 	watcherDedup       *watcherDedup
-	watcherAnalyzing   bool
-	watcherQueryStart  time.Time
+	watcherAnalyzing      bool
+	watcherQueryStart     time.Time
+	watcherQueryTimeout   time.Duration
 	typewriter        *typewriterState
 
 	// Incident viewer tab state

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -133,7 +133,8 @@ type model struct {
 	watcherBuffer   *watcherBuffer
 	watcherMarker   string
 	agentMarker     string
-	watcherDedup    *watcherDedup
+	watcherDedup      *watcherDedup
+	watcherAnalyzing  bool
 
 	// Incident viewer tab state
 	activeTab int // 0=details, 1=alerts, 2=notes

--- a/pkg/tui/model_test.go
+++ b/pkg/tui/model_test.go
@@ -26,11 +26,16 @@ func createTestModel() model {
 	t := table.New()
 	t.SetStyles(styles.Table)
 	return model{
-		table:         t,
-		incidentCache: make(map[string]*cachedIncidentData),
-		incidentList:  []pagerduty.Incident{},
-		theme:         theme,
-		styles:        styles,
+		table:           t,
+		incidentCache:   make(map[string]*cachedIncidentData),
+		incidentList:    []pagerduty.Incident{},
+		theme:           theme,
+		styles:          styles,
+		watcherBuffer:   newWatcherBuffer(50),
+		watcherViewport: newWatcherViewport(),
+		watcherMarker:   emojiWatcherMarker,
+		agentMarker:     emojiAgentMarker,
+		flagMarker:      emojiFlagMarker,
 	}
 }
 

--- a/pkg/tui/model_test.go
+++ b/pkg/tui/model_test.go
@@ -36,6 +36,7 @@ func createTestModel() model {
 		watcherMarker:   emojiWatcherMarker,
 		agentMarker:     emojiAgentMarker,
 		flagMarker:      emojiFlagMarker,
+		watcherDedup:    newWatcherDedup(5 * time.Minute),
 	}
 }
 

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -168,6 +168,10 @@ func (m model) keyMsgHandler(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	// Commands for any focus mode
 	if key.Matches(msg.(tea.KeyMsg), defaultKeyMap.Input) {
+		if msg.(tea.KeyMsg).String() == "/" {
+			m.input.SetValue("/")
+			m.input.SetCursor(1)
+		}
 		return m, tea.Sequence(
 			m.input.Focus(),
 		)

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -718,13 +718,16 @@ func switchInputFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 
+			m.input.Reset()
+			m.input.Blur()
+			m.table.Focus()
+
 			if isAgentCommand(prompt) {
 				query := parseAgentQuery(prompt)
 				if query == "" {
 					m.setStatus("usage: :agent <query>")
 					return m, nil
 				}
-				m.input.Reset()
 				return m, func() tea.Msg {
 					return claudePromptMsg{prompt: query}
 				}
@@ -736,15 +739,10 @@ func switchInputFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.setStatus("usage: :watcher <query>")
 					return m, nil
 				}
-				m.input.Reset()
 				return m, func() tea.Msg {
 					return watcherPromptMsg{prompt: query}
 				}
 			}
-
-			m.input.Reset()
-			m.input.Blur()
-			m.table.Focus()
 
 			if isFlagCommand(prompt) {
 				log.Debug("switchInputFocusMode", "msg", "dispatching flag command", "prompt", prompt)

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -168,18 +168,11 @@ func (m model) keyMsgHandler(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	// Commands for any focus mode
 	if key.Matches(msg.(tea.KeyMsg), defaultKeyMap.Input) {
-		if msg.(tea.KeyMsg).String() == "/" {
-			m.input.SetValue("/")
+		keyStr := msg.(tea.KeyMsg).String()
+		if keyStr == ":" || keyStr == "/" {
+			m.input.SetValue(keyStr)
 			m.input.SetCursor(1)
 		}
-		return m, tea.Sequence(
-			m.input.Focus(),
-		)
-	}
-
-	if key.Matches(msg.(tea.KeyMsg), defaultKeyMap.Flag) {
-		m.input.SetValue("/flag ")
-		m.input.SetCursor(len("/flag "))
 		return m, tea.Sequence(
 			m.input.Focus(),
 		)
@@ -728,7 +721,7 @@ func switchInputFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 			if isAgentCommand(prompt) {
 				query := parseAgentQuery(prompt)
 				if query == "" {
-					m.setStatus("usage: /agent <query>")
+					m.setStatus("usage: :agent <query>")
 					return m, nil
 				}
 				m.input.Reset()
@@ -745,7 +738,7 @@ func switchInputFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, m.dispatchFlagCommand(prompt)
 			}
 
-			m.setStatus("unknown command — try /agent <query> or /flag <type> <value>")
+			m.setStatus("unknown command — try :agent <query> or :flag <type> <value>")
 			return m, nil
 
 		default:

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -735,9 +735,11 @@ func switchInputFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.table.Focus()
 
 			if isFlagCommand(prompt) {
+				log.Debug("switchInputFocusMode", "msg", "dispatching flag command", "prompt", prompt)
 				return m, m.dispatchFlagCommand(prompt)
 			}
 
+			log.Debug("switchInputFocusMode", "msg", "unknown command", "prompt", prompt)
 			m.setStatus("unknown command — try :agent <query> or :flag <type> <value>")
 			return m, nil
 

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -730,6 +730,18 @@ func switchInputFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 
+			if isWatcherCommand(prompt) {
+				query := parseWatcherQuery(prompt)
+				if query == "" {
+					m.setStatus("usage: :watcher <query>")
+					return m, nil
+				}
+				m.input.Reset()
+				return m, func() tea.Msg {
+					return watcherPromptMsg{prompt: query}
+				}
+			}
+
 			m.input.Reset()
 			m.input.Blur()
 			m.table.Focus()
@@ -740,7 +752,7 @@ func switchInputFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 			log.Debug("switchInputFocusMode", "msg", "unknown command", "prompt", prompt)
-			m.setStatus("unknown command — try :agent <query> or :flag <type> <value>")
+			m.setStatus("unknown command — try :agent, :watcher, or :flag")
 			return m, nil
 
 		default:

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -714,16 +714,11 @@ func switchInputFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case key.Matches(msg, defaultKeyMap.Enter):
 			prompt := m.input.Value()
-			m.input.Reset()
-			m.input.Blur()
-			m.table.Focus()
 
 			if prompt == "" {
+				m.input.Blur()
+				m.table.Focus()
 				return m, nil
-			}
-
-			if isFlagCommand(prompt) {
-				return m, m.dispatchFlagCommand(prompt)
 			}
 
 			if isAgentCommand(prompt) {
@@ -732,9 +727,18 @@ func switchInputFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.setStatus("usage: /agent <query>")
 					return m, nil
 				}
+				m.input.Reset()
 				return m, func() tea.Msg {
 					return claudePromptMsg{prompt: query}
 				}
+			}
+
+			m.input.Reset()
+			m.input.Blur()
+			m.table.Focus()
+
+			if isFlagCommand(prompt) {
+				return m, m.dispatchFlagCommand(prompt)
 			}
 
 			m.setStatus("unknown command — try /agent <query> or /flag <type> <value>")

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -54,6 +54,11 @@ func (m model) windowSizeMsgHandler(msg tea.Msg) (tea.Model, tea.Cmd) {
 	m.logViewer.Width = m.layout.IncidentViewerWidth
 	m.logViewer.Height = m.layout.IncidentViewerHeight
 
+	if m.watcherExpanded {
+		m.watcherViewport.Width = m.layout.WatcherWidth
+		m.watcherViewport.Height = m.layout.WatcherHeight
+	}
+
 	if m.configMode && m.configForm != nil {
 		m.configForm.WithWidth(m.layout.FormWidth).WithHeight(m.layout.FormHeight)
 		form, cmd := m.configForm.Update(msg)
@@ -153,6 +158,12 @@ func (m model) keyMsgHandler(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if key.Matches(msg.(tea.KeyMsg), defaultKeyMap.Urgency) {
 		m.showLowUrgency = !m.showLowUrgency
 		return m, func() tea.Msg { return updatedIncidentListMsg{m.incidentList, nil} }
+	}
+
+	if key.Matches(msg.(tea.KeyMsg), defaultKeyMap.Watcher) {
+		m.watcherExpanded = !m.watcherExpanded
+		m.recomputeLayout()
+		return m, nil
 	}
 
 	// Commands for any focus mode

--- a/pkg/tui/msgHandlers_test.go
+++ b/pkg/tui/msgHandlers_test.go
@@ -1073,7 +1073,7 @@ func TestInputMode_Enter_StillDispatchesPrompt(t *testing.T) {
 	result, cmd := m.keyMsgHandler(keyMsg)
 	updated := result.(model)
 
-	assert.False(t, updated.input.Focused(), "Enter must blur the input")
+	assert.True(t, updated.input.Focused(), "agent dispatch keeps input focused for follow-up queries")
 	assert.Empty(t, updated.input.Value(), "Enter must reset the input value")
 	assert.NotNil(t, cmd, "Enter must dispatch a command")
 

--- a/pkg/tui/msgHandlers_test.go
+++ b/pkg/tui/msgHandlers_test.go
@@ -1067,7 +1067,7 @@ func TestInputMode_Escape_StillExitsInput(t *testing.T) {
 }
 
 func TestInputMode_Enter_StillDispatchesPrompt(t *testing.T) {
-	m := createInputFocusedModel("/agent investigate this alert")
+	m := createInputFocusedModel(":agent investigate this alert")
 
 	keyMsg := tea.KeyMsg{Type: tea.KeyEnter}
 	result, cmd := m.keyMsgHandler(keyMsg)

--- a/pkg/tui/msgHandlers_test.go
+++ b/pkg/tui/msgHandlers_test.go
@@ -1073,7 +1073,7 @@ func TestInputMode_Enter_StillDispatchesPrompt(t *testing.T) {
 	result, cmd := m.keyMsgHandler(keyMsg)
 	updated := result.(model)
 
-	assert.True(t, updated.input.Focused(), "agent dispatch keeps input focused for follow-up queries")
+	assert.False(t, updated.input.Focused(), "input should blur after agent dispatch")
 	assert.Empty(t, updated.input.Value(), "Enter must reset the input value")
 	assert.NotNil(t, cmd, "Enter must dispatch a command")
 

--- a/pkg/tui/theme.go
+++ b/pkg/tui/theme.go
@@ -28,17 +28,18 @@ type Theme struct {
 }
 
 type Styles struct {
-	Main           lipgloss.Style
-	Padded         lipgloss.Style
-	Muted          lipgloss.Style
-	Warning        lipgloss.Style
-	Error          lipgloss.Style
-	TableContainer lipgloss.Style
-	Table          table.Styles
-	ActiveTab      lipgloss.Style
-	InactiveTab    lipgloss.Style
-	TabWindow      lipgloss.Style
-	GlamourStyle   ansi.StyleConfig
+	Main             lipgloss.Style
+	Padded           lipgloss.Style
+	Muted            lipgloss.Style
+	Warning          lipgloss.Style
+	Error            lipgloss.Style
+	TableContainer   lipgloss.Style
+	Table            table.Styles
+	ActiveTab        lipgloss.Style
+	InactiveTab      lipgloss.Style
+	TabWindow        lipgloss.Style
+	WatcherContainer lipgloss.Style
+	GlamourStyle     ansi.StyleConfig
 }
 
 func DefaultTheme() Theme {
@@ -117,6 +118,11 @@ func BuildStyles(theme Theme) Styles {
 		BorderForeground(theme.Border).
 		Foreground(theme.Text)
 
+	watcherContainer := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder(), true).
+		BorderForeground(theme.Border).
+		Foreground(theme.Text)
+
 	tableCell := lipgloss.NewStyle().Padding(0, 1)
 	tableHeader := lipgloss.NewStyle().
 		Padding(0, 1).
@@ -145,7 +151,8 @@ func BuildStyles(theme Theme) Styles {
 			Background(theme.Error).
 			BorderForeground(theme.Border).
 			Padding(1, 3, 1, 3),
-		TableContainer: tableContainer,
+		TableContainer:   tableContainer,
+		WatcherContainer: watcherContainer,
 		Table: table.Styles{
 			Cell:     tableCell,
 			Selected: tableSelected,

--- a/pkg/tui/theme.go
+++ b/pkg/tui/theme.go
@@ -9,6 +9,11 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
+const (
+	cellPaddingV = 0
+	cellPaddingH = 1
+)
+
 var hexColorPattern = regexp.MustCompile(`^#[0-9a-fA-F]{3}([0-9a-fA-F]{3})?$`)
 
 func isValidHexColor(s string) bool {
@@ -122,11 +127,11 @@ func BuildStyles(theme Theme) Styles {
 		Border(lipgloss.RoundedBorder(), true).
 		BorderForeground(theme.Border).
 		Foreground(theme.Text).
-		Padding(0, 1)
+		Padding(cellPaddingV, cellPaddingH)
 
-	tableCell := lipgloss.NewStyle().Padding(0, 1)
+	tableCell := lipgloss.NewStyle().Padding(cellPaddingV, cellPaddingH)
 	tableHeader := lipgloss.NewStyle().
-		Padding(0, 1).
+		Padding(cellPaddingV, cellPaddingH).
 		Border(lipgloss.RoundedBorder(), false, false, true).
 		BorderForeground(theme.Border).
 		Foreground(theme.Highlight).

--- a/pkg/tui/theme.go
+++ b/pkg/tui/theme.go
@@ -121,7 +121,8 @@ func BuildStyles(theme Theme) Styles {
 	watcherContainer := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder(), true).
 		BorderForeground(theme.Border).
-		Foreground(theme.Text)
+		Foreground(theme.Text).
+		Padding(0, 1)
 
 	tableCell := lipgloss.NewStyle().Padding(0, 1)
 	tableHeader := lipgloss.NewStyle().

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -464,12 +464,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case watcherPromptMsg:
 		if m.aiProvider == nil {
-			m.setStatus("LLM provider not configured — add llm_api section to config")
-			return m, nil
+			return m, m.flashNotification("LLM provider not configured — add llm_api section to config")
 		}
 		if !m.aiHealthy {
-			m.setStatus("LLM provider offline")
-			return m, nil
+			return m, m.flashNotification("LLM provider offline")
 		}
 
 		log.Info("watcher query initiated", "prompt", truncatePrompt(msg.prompt, 80))
@@ -493,8 +491,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.apiInProgress = false
 
 		if msg.err != nil {
-			m.setStatus(fmt.Sprintf("watcher query failed: %s", msg.err))
-			return m, nil
+			return m, m.flashNotification(fmt.Sprintf("watcher query failed: %s", msg.err))
 		}
 
 		m.watcherBuffer.Append(prefixLines(m.watcherMarker, msg.response))

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -128,7 +128,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// Skip logging for very frequent messages
 	switch msgType {
 	case reflect.TypeOf(TickMsg{}),
-		reflect.TypeOf(spinner.TickMsg{}):
+		reflect.TypeOf(spinner.TickMsg{}),
+		reflect.TypeOf(tea.MouseMsg{}):
 		shouldLog = false
 	}
 

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -129,7 +129,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msgType {
 	case reflect.TypeOf(TickMsg{}),
 		reflect.TypeOf(spinner.TickMsg{}),
-		reflect.TypeOf(tea.MouseMsg{}):
+		reflect.TypeOf(tea.MouseMsg{}),
+		reflect.TypeOf(ocmServiceLogsMsg{}),
+		reflect.TypeOf(limitedSupportMsg{}):
 		shouldLog = false
 	}
 

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -477,6 +477,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.setStatus(fmt.Sprintf("querying watcher: %s", truncatePrompt(msg.prompt, 40)))
 		m.watcherAnalyzing = true
 		m.apiInProgress = true
+		m.watcherQueryStart = time.Now()
 
 		if !m.watcherExpanded {
 			m.watcherExpanded = true

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -491,7 +491,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		incidentContext := buildWatcherContext(&m)
 		return m, tea.Batch(
 			m.spinner.Tick,
-			watcherQueryCmd(m.aiProvider, msg.prompt, incidentContext),
+			watcherQueryCmd(m.aiProvider, m.watcherSystemPrompt, msg.prompt, incidentContext),
 		)
 
 	case watcherResponseMsg:

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -462,6 +462,50 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.aiHealthy = msg.healthy
 		return m, nil
 
+	case watcherPromptMsg:
+		if m.aiProvider == nil {
+			m.setStatus("LLM provider not configured — add llm_api section to config")
+			return m, nil
+		}
+		if !m.aiHealthy {
+			m.setStatus("LLM provider offline")
+			return m, nil
+		}
+
+		log.Info("watcher query initiated", "prompt", truncatePrompt(msg.prompt, 80))
+		m.setStatus(fmt.Sprintf("querying watcher: %s", truncatePrompt(msg.prompt, 40)))
+		m.watcherAnalyzing = true
+		m.apiInProgress = true
+
+		if !m.watcherExpanded {
+			m.watcherExpanded = true
+			m.recomputeLayout()
+		}
+
+		incidentContext := buildWatcherContext(&m)
+		return m, tea.Batch(
+			m.spinner.Tick,
+			watcherQueryCmd(m.aiProvider, msg.prompt, incidentContext),
+		)
+
+	case watcherResponseMsg:
+		m.watcherAnalyzing = false
+		m.apiInProgress = false
+
+		if msg.err != nil {
+			m.setStatus(fmt.Sprintf("watcher query failed: %s", msg.err))
+			return m, nil
+		}
+
+		m.watcherBuffer.Append(prefixLines(m.watcherMarker, msg.response))
+		if !m.watcherExpanded {
+			m.watcherExpanded = true
+			m.recomputeLayout()
+		}
+		m.updateWatcherViewport()
+		m.setStatus("watcher response received")
+		return m, nil
+
 	case watcherSynthesisMsg:
 		m.watcherAnalyzing = false
 		if msg.err != nil {

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -444,6 +444,14 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		return m.windowSizeMsgHandler(msg)
 
+	case tea.MouseMsg:
+		if m.watcherExpanded {
+			var cmd tea.Cmd
+			m.watcherViewport, cmd = m.watcherViewport.Update(msg)
+			return m, cmd
+		}
+		return m, nil
+
 	case tea.KeyMsg:
 		return m.keyMsgHandler(msg)
 

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -458,6 +458,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case TickMsg:
 		return m, tea.Batch(runScheduledJobs(&m)...)
 
+	case typewriterTickMsg:
+		return m, m.advanceTypewriter()
+
 	case aiHealthCheckMsg:
 		m.aiHealthy = msg.healthy
 		return m, nil
@@ -494,28 +497,27 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, m.flashNotification(fmt.Sprintf("watcher query failed: %s", msg.err))
 		}
 
-		m.watcherBuffer.Append(prefixLines(m.watcherMarker, msg.response))
 		if !m.watcherExpanded {
 			m.watcherExpanded = true
 			m.recomputeLayout()
 		}
-		m.updateWatcherViewport()
 		m.setStatus("watcher response received")
-		return m, nil
+		m.watcherBuffer.Append("")
+		return m, m.startTypewriter(m.watcherMarker, msg.response)
 
 	case watcherSynthesisMsg:
 		m.watcherAnalyzing = false
-		if msg.err != nil {
-			m.watcherBuffer.Append(prefixLines(m.watcherMarker, msg.observation))
-		} else {
-			m.watcherBuffer.Append(prefixLines(m.watcherMarker, msg.response))
-		}
 		if !m.watcherExpanded {
 			m.watcherExpanded = true
 			m.recomputeLayout()
 		}
-		m.updateWatcherViewport()
-		return m, nil
+		if msg.err != nil {
+			m.watcherBuffer.Append(prefixLines(m.watcherMarker, msg.observation))
+			m.updateWatcherViewport()
+			return m, nil
+		}
+		m.watcherBuffer.Append("")
+		return m, m.startTypewriter(m.watcherMarker, msg.response)
 
 	case tea.WindowSizeMsg:
 		return m.windowSizeMsgHandler(msg)

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -379,6 +379,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		msg.condition.ID = m.flagNextID
 		m.flagConditions = append(m.flagConditions, msg.condition)
 		m.rebuildFlagMatchCache()
+		m.runDetectors()
 		return m, m.flashNotification(fmt.Sprintf("flag #%d added: %s", msg.condition.ID, msg.condition.Label))
 
 	case removeFlagConditionMsg:
@@ -389,6 +390,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		m.rebuildFlagMatchCache()
+		m.runDetectors()
 		return m, m.flashNotification(fmt.Sprintf("flag #%d removed", msg.id))
 
 	case clearFlagConditionsMsg:
@@ -852,6 +854,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if cmd := m.syncSelectedIncidentToHighlightedRow(); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
+
+		m.runDetectors()
 
 	case parseTemplateForNoteMsg:
 		if m.selectedIncident == nil {

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -379,8 +379,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		msg.condition.ID = m.flagNextID
 		m.flagConditions = append(m.flagConditions, msg.condition)
 		m.rebuildFlagMatchCache()
-		m.runDetectors()
-		return m, m.flashNotification(fmt.Sprintf("flag #%d added: %s", msg.condition.ID, msg.condition.Label))
+		watcherCmds := m.runDetectors()
+		flashCmd := m.flashNotification(fmt.Sprintf("flag #%d added: %s", msg.condition.ID, msg.condition.Label))
+		return m, tea.Batch(append(watcherCmds, flashCmd)...)
 
 	case removeFlagConditionMsg:
 		for i, c := range m.flagConditions {
@@ -390,8 +391,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		m.rebuildFlagMatchCache()
-		m.runDetectors()
-		return m, m.flashNotification(fmt.Sprintf("flag #%d removed", msg.id))
+		watcherCmds := m.runDetectors()
+		flashCmd := m.flashNotification(fmt.Sprintf("flag #%d removed", msg.id))
+		return m, tea.Batch(append(watcherCmds, flashCmd)...)
 
 	case clearFlagConditionsMsg:
 		m.flagConditions = nil
@@ -441,6 +443,20 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case aiHealthCheckMsg:
 		m.aiHealthy = msg.healthy
+		return m, nil
+
+	case watcherSynthesisMsg:
+		m.watcherAnalyzing = false
+		if msg.err != nil {
+			m.watcherBuffer.Append(prefixLines(m.watcherMarker, msg.observation))
+		} else {
+			m.watcherBuffer.Append(prefixLines(m.watcherMarker, msg.response))
+		}
+		if !m.watcherExpanded {
+			m.watcherExpanded = true
+			m.recomputeLayout()
+		}
+		m.updateWatcherViewport()
 		return m, nil
 
 	case tea.WindowSizeMsg:
@@ -855,7 +871,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, cmd)
 		}
 
-		m.runDetectors()
+		cmds = append(cmds, m.runDetectors()...)
 
 	case parseTemplateForNoteMsg:
 		if m.selectedIncident == nil {

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -478,6 +478,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.watcherAnalyzing = true
 		m.apiInProgress = true
 		m.watcherQueryStart = time.Now()
+		m.watcherQueryTimeout = watcherQueryTimeout
 
 		if !m.watcherExpanded {
 			m.watcherExpanded = true

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -381,7 +381,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.rebuildFlagMatchCache()
 		watcherCmds := m.runDetectors()
 		flashCmd := m.flashNotification(fmt.Sprintf("flag #%d added: %s", msg.condition.ID, msg.condition.Label))
-		return m, tea.Batch(append(watcherCmds, flashCmd)...)
+		rebuildCmd := func() tea.Msg { return updatedIncidentListMsg{m.incidentList, nil} }
+		return m, tea.Batch(append(watcherCmds, flashCmd, rebuildCmd)...)
 
 	case removeFlagConditionMsg:
 		for i, c := range m.flagConditions {
@@ -393,12 +394,16 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.rebuildFlagMatchCache()
 		watcherCmds := m.runDetectors()
 		flashCmd := m.flashNotification(fmt.Sprintf("flag #%d removed", msg.id))
-		return m, tea.Batch(append(watcherCmds, flashCmd)...)
+		rebuildCmd := func() tea.Msg { return updatedIncidentListMsg{m.incidentList, nil} }
+		return m, tea.Batch(append(watcherCmds, flashCmd, rebuildCmd)...)
 
 	case clearFlagConditionsMsg:
 		m.flagConditions = nil
 		m.rebuildFlagMatchCache()
-		return m, m.flashNotification("all flags cleared")
+		return m, tea.Batch(
+			m.flashNotification("all flags cleared"),
+			func() tea.Msg { return updatedIncidentListMsg{m.incidentList, nil} },
+		)
 
 	case listFlagConditionsMsg:
 		content := formatFlagsList(m.flagConditions)
@@ -431,7 +436,19 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.flagNextID = maxID
 		m.rebuildFlagMatchCache()
-		return m, m.flashNotification(fmt.Sprintf("flags loaded (%d conditions)", len(m.flagConditions)))
+
+		enrichCmds := []tea.Cmd{
+			m.flashNotification(fmt.Sprintf("flags loaded (%d conditions)", len(m.flagConditions))),
+			func() tea.Msg { return updatedIncidentListMsg{m.incidentList, nil} },
+		}
+		for _, inc := range m.incidentList {
+			if _, ok := m.incidentClusterMap[inc.ID]; !ok {
+				if m.config != nil {
+					enrichCmds = append(enrichCmds, getIncidentAlerts(m.config, inc.ID))
+				}
+			}
+		}
+		return m, tea.Batch(enrichCmds...)
 
 	case spinner.TickMsg:
 		var cmd tea.Cmd
@@ -1400,6 +1417,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.clusterCache[msg.clusterID] = msg.info
 		log.Debug("ocm.GetCluster cached", "cluster_id", msg.clusterID)
+
+		m.rebuildFlagMatchCache()
 
 		// Phase 2: dispatch service logs and limited support using the
 		// OCM internal ID for the API call but the PD cluster ID as cache key.

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -960,9 +960,12 @@ func (m model) renderWatcherStatus() string {
 	}
 
 	if m.claudeQuerying || m.watcherAnalyzing {
-		elapsed := time.Since(m.watcherQueryStart).Truncate(time.Second)
+		remaining := m.watcherQueryTimeout - time.Since(m.watcherQueryStart).Truncate(time.Second)
+		if remaining < 0 {
+			remaining = 0
+		}
 		highlight := lipgloss.NewStyle().Foreground(m.theme.Highlight)
-		parts = append(parts, m.spinner.View()+" "+highlight.Render(fmt.Sprintf("analyzing... %s", elapsed)))
+		parts = append(parts, m.spinner.View()+" "+highlight.Render(fmt.Sprintf("analyzing... %s", remaining)))
 	} else {
 		parts = append(parts, "idle")
 	}

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -148,13 +148,14 @@ func (m model) renderFooter() string {
 	}
 
 	right := m.renderWatcherStatus()
-	leftWidth := windowSize.Width * layoutTableShareNum / layoutTableShareDen
-	rightWidth := windowSize.Width - leftWidth
+	renderedRight := m.styles.Muted.Render(right)
+	rightWidth := lipgloss.Width(renderedRight)
+	leftWidth := windowSize.Width - rightWidth - m.styles.Padded.GetHorizontalPadding() - m.styles.Padded.GetHorizontalBorderSize()
 
 	return lipgloss.JoinHorizontal(
 		0.2,
-		m.styles.Padded.Width(leftWidth).MaxWidth(leftWidth).Render(left),
-		m.styles.Muted.Width(rightWidth).MaxWidth(rightWidth).Align(lipgloss.Right).Padding(0, 1, 0, 0).Render(right),
+		m.styles.Padded.Width(leftWidth).Render(left),
+		renderedRight,
 	)
 }
 

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -153,8 +153,8 @@ func (m model) renderFooter() string {
 
 	return lipgloss.JoinHorizontal(
 		0.2,
-		m.styles.Padded.Width(leftWidth).Render(left),
-		m.styles.Muted.Width(rightWidth).Align(lipgloss.Right).Padding(0, 1, 0, 0).Render(right),
+		m.styles.Padded.Width(leftWidth).MaxWidth(leftWidth).Render(left),
+		m.styles.Muted.Width(rightWidth).MaxWidth(rightWidth).Align(lipgloss.Right).Padding(0, 1, 0, 0).Render(right),
 	)
 }
 
@@ -958,13 +958,11 @@ func (m model) renderWatcherStatus() string {
 	}
 
 	analyzingLabel := "analyzing..."
-	spinnerWidth := lipgloss.Width(m.spinner.View()) + 1
 	if m.claudeQuerying || m.watcherAnalyzing {
-		bold := lipgloss.NewStyle().Bold(true)
-		parts = append(parts, m.spinner.View()+" "+bold.Render(analyzingLabel))
+		highlight := lipgloss.NewStyle().Foreground(m.theme.Highlight)
+		parts = append(parts, m.spinner.View()+" "+highlight.Render(analyzingLabel))
 	} else {
-		padded := fmt.Sprintf("%-*s", len(analyzingLabel)+spinnerWidth, "idle")
-		parts = append(parts, padded)
+		parts = append(parts, "idle")
 	}
 
 	return strings.Join(parts, " | ")

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -956,7 +956,7 @@ func (m model) renderWatcherHeader() string {
 		}
 	}
 
-	if m.claudeQuerying {
+	if m.claudeQuerying || m.watcherAnalyzing {
 		parts = append(parts, m.spinner.View()+" analyzing...")
 	} else {
 		parts = append(parts, "idle")

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -957,10 +957,14 @@ func (m model) renderWatcherStatus() string {
 		}
 	}
 
+	analyzingLabel := "analyzing..."
+	spinnerWidth := lipgloss.Width(m.spinner.View()) + 1
 	if m.claudeQuerying || m.watcherAnalyzing {
-		parts = append(parts, m.spinner.View()+" analyzing...")
+		bold := lipgloss.NewStyle().Bold(true)
+		parts = append(parts, m.spinner.View()+" "+bold.Render(analyzingLabel))
 	} else {
-		parts = append(parts, "idle")
+		padded := fmt.Sprintf("%-*s", len(analyzingLabel)+spinnerWidth, "idle")
+		parts = append(parts, padded)
 	}
 
 	return strings.Join(parts, " | ")

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -86,14 +86,13 @@ func (m model) View() string {
 	default:
 		s.WriteString(m.styles.TableContainer.Render(m.table.View()))
 		s.WriteString("\n")
-		// Render refresh status line immediately below main table
 		s.WriteString(m.renderFooter())
 		s.WriteString("\n")
-		// Input field always reserves a line (empty if not focused)
+		s.WriteString(m.renderWatcherPane())
 		if m.input.Focused() {
 			s.WriteString(m.input.View())
 		} else {
-			s.WriteString("") // Preserve empty line when input not focused
+			s.WriteString("")
 		}
 	}
 
@@ -931,3 +930,37 @@ const noteTemplate = `
 # Service: {{ .Service }}
 #
 `
+
+func (m model) renderWatcherPane() string {
+	if !m.watcherExpanded {
+		return ""
+	}
+
+	var s strings.Builder
+	s.WriteString(m.renderWatcherHeader())
+	s.WriteString("\n")
+	s.WriteString(m.styles.WatcherContainer.Render(m.watcherViewport.View()))
+	s.WriteString("\n")
+	return s.String()
+}
+
+func (m model) renderWatcherHeader() string {
+	parts := []string{"[AI Watcher]"}
+
+	if m.aiProvider != nil {
+		parts = append(parts, m.aiProvider.Name())
+		if m.aiHealthy {
+			parts = append(parts, "healthy")
+		} else {
+			parts = append(parts, "offline")
+		}
+	}
+
+	if m.claudeQuerying {
+		parts = append(parts, m.spinner.View()+" analyzing...")
+	} else {
+		parts = append(parts, "idle")
+	}
+
+	return m.styles.Muted.Render("  " + strings.Join(parts, " | "))
+}

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -6,6 +6,7 @@ import (
 	"html/template"
 	"slices"
 	"strings"
+	"time"
 
 	"charm.land/glamour/v2"
 	"github.com/PagerDuty/go-pagerduty"
@@ -958,10 +959,10 @@ func (m model) renderWatcherStatus() string {
 		}
 	}
 
-	analyzingLabel := "analyzing..."
 	if m.claudeQuerying || m.watcherAnalyzing {
+		elapsed := time.Since(m.watcherQueryStart).Truncate(time.Second)
 		highlight := lipgloss.NewStyle().Foreground(m.theme.Highlight)
-		parts = append(parts, m.spinner.View()+" "+highlight.Render(analyzingLabel))
+		parts = append(parts, m.spinner.View()+" "+highlight.Render(fmt.Sprintf("analyzing... %s", elapsed)))
 	} else {
 		parts = append(parts, "idle")
 	}

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -141,15 +141,21 @@ func (m model) View() string {
 }
 
 func (m model) renderFooter() string {
-	var s strings.Builder
-	s.WriteString(
-		lipgloss.JoinHorizontal(
-			0.2,
-			m.styles.Padded.Render(refreshArea(m.autoRefresh, m.autoAcknowledge, m.showLowUrgency)),
-		),
-	)
+	left := refreshArea(m.autoRefresh, m.autoAcknowledge, m.showLowUrgency)
 
-	return s.String()
+	if !m.watcherExpanded {
+		return m.styles.Padded.Render(left)
+	}
+
+	right := m.renderWatcherStatus()
+	leftWidth := windowSize.Width * layoutTableShareNum / layoutTableShareDen
+	rightWidth := windowSize.Width - leftWidth
+
+	return lipgloss.JoinHorizontal(
+		0.2,
+		m.styles.Padded.Width(leftWidth).Render(left),
+		m.styles.Muted.Width(rightWidth).Align(lipgloss.Right).Padding(0, 1, 0, 0).Render(right),
+	)
 }
 
 func (m model) renderHeader() string {
@@ -936,15 +942,10 @@ func (m model) renderWatcherPane() string {
 		return ""
 	}
 
-	var s strings.Builder
-	s.WriteString(m.renderWatcherHeader())
-	s.WriteString("\n")
-	s.WriteString(m.styles.WatcherContainer.Render(m.watcherViewport.View()))
-	s.WriteString("\n")
-	return s.String()
+	return m.styles.WatcherContainer.Render(m.watcherViewport.View()) + "\n"
 }
 
-func (m model) renderWatcherHeader() string {
+func (m model) renderWatcherStatus() string {
 	parts := []string{"[AI Watcher]"}
 
 	if m.aiProvider != nil {
@@ -962,5 +963,5 @@ func (m model) renderWatcherHeader() string {
 		parts = append(parts, "idle")
 	}
 
-	return m.styles.Muted.Render("  " + strings.Join(parts, " | "))
+	return strings.Join(parts, " | ")
 }

--- a/pkg/tui/watcher.go
+++ b/pkg/tui/watcher.go
@@ -1,9 +1,14 @@
 package tui
 
 import (
+	"crypto/sha256"
+	"fmt"
 	"strings"
+	"time"
 
+	"github.com/PagerDuty/go-pagerduty"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/log"
 )
 
 const (
@@ -72,6 +77,111 @@ func (m *model) updateWatcherViewport() {
 	}
 	m.watcherViewport.SetContent(content)
 	m.watcherViewport.GotoBottom()
+}
+
+type watcherObservation struct {
+	Summary string
+}
+
+type watcherDedup struct {
+	seen    map[string]time.Time
+	cooldown time.Duration
+}
+
+func newWatcherDedup(cooldown time.Duration) *watcherDedup {
+	return &watcherDedup{
+		seen:    make(map[string]time.Time),
+		cooldown: cooldown,
+	}
+}
+
+func (d *watcherDedup) IsNew(observation string) bool {
+	h := fmt.Sprintf("%x", sha256.Sum256([]byte(observation)))
+	if last, ok := d.seen[h]; ok && time.Since(last) < d.cooldown {
+		return false
+	}
+	d.seen[h] = time.Now()
+	return true
+}
+
+func (m *model) runDetectors() {
+	if len(m.incidentList) < 2 {
+		return
+	}
+
+	observations := detectAll(m.incidentList, m.incidentClusterMap)
+
+	for _, obs := range observations {
+		if m.watcherDedup.IsNew(obs.Summary) {
+			log.Debug("watcher.runDetectors", "observation", obs.Summary)
+			m.watcherBuffer.Append(prefixLines(m.watcherMarker, obs.Summary))
+			m.updateWatcherViewport()
+		}
+	}
+}
+
+func detectAll(incidents []pagerduty.Incident, clusterMap map[string][]string) []watcherObservation {
+	var observations []watcherObservation
+	observations = append(observations, detectServiceStorm(incidents)...)
+	observations = append(observations, detectClusterStorm(incidents, clusterMap)...)
+	observations = append(observations, detectUrgencyShift(incidents)...)
+	return observations
+}
+
+func detectServiceStorm(incidents []pagerduty.Incident) []watcherObservation {
+	serviceCounts := make(map[string]int)
+	for _, inc := range incidents {
+		serviceCounts[inc.Service.Summary]++
+	}
+
+	var observations []watcherObservation
+	for svc, count := range serviceCounts {
+		if count >= 3 {
+			observations = append(observations, watcherObservation{
+				Summary: fmt.Sprintf("Service storm: %d incidents on %s", count, svc),
+			})
+		}
+	}
+	return observations
+}
+
+func detectClusterStorm(incidents []pagerduty.Incident, clusterMap map[string][]string) []watcherObservation {
+	if clusterMap == nil {
+		return nil
+	}
+
+	clusterCounts := make(map[string]int)
+	for _, inc := range incidents {
+		for _, clusterID := range clusterMap[inc.ID] {
+			clusterCounts[clusterID]++
+		}
+	}
+
+	var observations []watcherObservation
+	for cluster, count := range clusterCounts {
+		if count >= 2 {
+			observations = append(observations, watcherObservation{
+				Summary: fmt.Sprintf("Cluster storm: %d incidents on cluster %s", count, cluster),
+			})
+		}
+	}
+	return observations
+}
+
+func detectUrgencyShift(incidents []pagerduty.Incident) []watcherObservation {
+	highCount := 0
+	for _, inc := range incidents {
+		if inc.Urgency == "high" {
+			highCount++
+		}
+	}
+
+	if highCount >= 3 {
+		return []watcherObservation{{
+			Summary: fmt.Sprintf("High urgency cluster: %d/%d incidents are high urgency", highCount, len(incidents)),
+		}}
+	}
+	return nil
 }
 
 func prefixLines(marker string, text string) string {

--- a/pkg/tui/watcher.go
+++ b/pkg/tui/watcher.go
@@ -111,12 +111,21 @@ func (m *model) runDetectors() {
 
 	observations := detectAll(m.incidentList, m.incidentClusterMap)
 
+	added := false
 	for _, obs := range observations {
 		if m.watcherDedup.IsNew(obs.Summary) {
 			log.Debug("watcher.runDetectors", "observation", obs.Summary)
 			m.watcherBuffer.Append(prefixLines(m.watcherMarker, obs.Summary))
-			m.updateWatcherViewport()
+			added = true
 		}
+	}
+
+	if added {
+		if !m.watcherExpanded {
+			m.watcherExpanded = true
+			m.recomputeLayout()
+		}
+		m.updateWatcherViewport()
 	}
 }
 

--- a/pkg/tui/watcher.go
+++ b/pkg/tui/watcher.go
@@ -191,6 +191,7 @@ func (m *model) runDetectors() []tea.Cmd {
 
 		if m.aiProvider != nil && m.aiHealthy && !m.watcherAnalyzing {
 			m.watcherAnalyzing = true
+			m.watcherQueryStart = time.Now()
 			summary := buildIncidentSummary(m.incidentList)
 			cmds = append(cmds, watcherSynthesizeCmd(m.aiProvider, obs.Summary, summary))
 		} else {

--- a/pkg/tui/watcher.go
+++ b/pkg/tui/watcher.go
@@ -59,6 +59,14 @@ func (b *watcherBuffer) Append(entry string) {
 	b.entries = append(b.entries, entry)
 }
 
+func (b *watcherBuffer) SetLast(entry string) {
+	if len(b.entries) == 0 {
+		b.Append(entry)
+		return
+	}
+	b.entries[len(b.entries)-1] = entry
+}
+
 func (b *watcherBuffer) Content() string {
 	return strings.Join(b.entries, "\n---\n")
 }
@@ -78,6 +86,66 @@ func (m *model) updateWatcherViewport() {
 	}
 	m.watcherViewport.SetContent(content)
 	m.watcherViewport.GotoBottom()
+}
+
+const (
+	typewriterWordsPerTick = 3
+	typewriterTickInterval = 30 * time.Millisecond
+)
+
+type typewriterState struct {
+	words   []string
+	index   int
+	marker  string
+	partial string
+}
+
+type typewriterTickMsg struct{}
+
+func (m *model) startTypewriter(marker string, text string) tea.Cmd {
+	words := strings.Fields(text)
+	if len(words) == 0 {
+		return nil
+	}
+	m.typewriter = &typewriterState{
+		words:  words,
+		marker: marker,
+	}
+	return tea.Tick(typewriterTickInterval, func(time.Time) tea.Msg {
+		return typewriterTickMsg{}
+	})
+}
+
+func (m *model) advanceTypewriter() tea.Cmd {
+	tw := m.typewriter
+	if tw == nil {
+		return nil
+	}
+
+	end := tw.index + typewriterWordsPerTick
+	if end > len(tw.words) {
+		end = len(tw.words)
+	}
+
+	chunk := strings.Join(tw.words[tw.index:end], " ")
+	if tw.partial != "" {
+		tw.partial += " " + chunk
+	} else {
+		tw.partial = chunk
+	}
+	tw.index = end
+
+	m.watcherBuffer.SetLast(prefixLines(tw.marker, tw.partial))
+	m.updateWatcherViewport()
+
+	if tw.index >= len(tw.words) {
+		m.typewriter = nil
+		return nil
+	}
+
+	return tea.Tick(typewriterTickInterval, func(time.Time) tea.Msg {
+		return typewriterTickMsg{}
+	})
 }
 
 type watcherObservation struct {

--- a/pkg/tui/watcher.go
+++ b/pkg/tui/watcher.go
@@ -102,8 +102,21 @@ type typewriterState struct {
 
 type typewriterTickMsg struct{}
 
+func splitKeepingNewlines(text string) []string {
+	var tokens []string
+	for _, line := range strings.Split(text, "\n") {
+		words := strings.Fields(line)
+		tokens = append(tokens, words...)
+		tokens = append(tokens, "\n")
+	}
+	if len(tokens) > 0 {
+		tokens = tokens[:len(tokens)-1]
+	}
+	return tokens
+}
+
 func (m *model) startTypewriter(marker string, text string) tea.Cmd {
-	words := strings.Fields(text)
+	words := splitKeepingNewlines(text)
 	if len(words) == 0 {
 		return nil
 	}
@@ -127,11 +140,15 @@ func (m *model) advanceTypewriter() tea.Cmd {
 		end = len(tw.words)
 	}
 
-	chunk := strings.Join(tw.words[tw.index:end], " ")
-	if tw.partial != "" {
-		tw.partial += " " + chunk
-	} else {
-		tw.partial = chunk
+	for i := tw.index; i < end; i++ {
+		word := tw.words[i]
+		if word == "\n" {
+			tw.partial += "\n"
+		} else if tw.partial == "" || strings.HasSuffix(tw.partial, "\n") {
+			tw.partial += word
+		} else {
+			tw.partial += " " + word
+		}
 	}
 	tw.index = end
 

--- a/pkg/tui/watcher.go
+++ b/pkg/tui/watcher.go
@@ -194,7 +194,7 @@ func (m *model) runDetectors() []tea.Cmd {
 			m.watcherQueryStart = time.Now()
 			m.watcherQueryTimeout = watcherSynthesisTimeout
 			summary := buildIncidentSummary(m.incidentList)
-			cmds = append(cmds, watcherSynthesizeCmd(m.aiProvider, obs.Summary, summary))
+			cmds = append(cmds, watcherSynthesizeCmd(m.aiProvider, m.watcherSystemPrompt, obs.Summary, summary))
 		} else {
 			m.watcherBuffer.Append(prefixLines(m.watcherMarker, obs.Summary))
 			added = true

--- a/pkg/tui/watcher.go
+++ b/pkg/tui/watcher.go
@@ -170,13 +170,13 @@ type watcherObservation struct {
 }
 
 type watcherDedup struct {
-	seen    map[string]time.Time
+	seen     map[string]time.Time
 	cooldown time.Duration
 }
 
 func newWatcherDedup(cooldown time.Duration) *watcherDedup {
 	return &watcherDedup{
-		seen:    make(map[string]time.Time),
+		seen:     make(map[string]time.Time),
 		cooldown: cooldown,
 	}
 }

--- a/pkg/tui/watcher.go
+++ b/pkg/tui/watcher.go
@@ -192,6 +192,7 @@ func (m *model) runDetectors() []tea.Cmd {
 		if m.aiProvider != nil && m.aiHealthy && !m.watcherAnalyzing {
 			m.watcherAnalyzing = true
 			m.watcherQueryStart = time.Now()
+			m.watcherQueryTimeout = watcherSynthesisTimeout
 			summary := buildIncidentSummary(m.incidentList)
 			cmds = append(cmds, watcherSynthesizeCmd(m.aiProvider, obs.Summary, summary))
 		} else {

--- a/pkg/tui/watcher.go
+++ b/pkg/tui/watcher.go
@@ -236,46 +236,46 @@ func buildWatcherContext(m *model) string {
 		parts = append(parts, fmt.Sprintf("Service: %s", inc.Service.Summary))
 		parts = append(parts, fmt.Sprintf("Status: %s, Urgency: %s", inc.Status, inc.Urgency))
 
-		for _, alert := range m.selectedIncidentAlerts {
+		// Pull alerts from cache (populated by OCM enrichment pipeline)
+		var alerts []pagerduty.IncidentAlert
+		if cached, ok := m.incidentCache[inc.ID]; ok && cached.alertsLoaded {
+			alerts = cached.alerts
+		} else if len(m.selectedIncidentAlerts) > 0 {
+			alerts = m.selectedIncidentAlerts
+		}
+
+		for _, alert := range alerts {
 			if details, ok := alert.Body["details"].(map[string]interface{}); ok {
 				if name, ok := details["alert_name"].(string); ok {
 					parts = append(parts, fmt.Sprintf("Alert: %s", name))
 				}
+				if sopURL, ok := details["firing"].(string); ok && sopURL != "" {
+					parts = append(parts, fmt.Sprintf("SOP: %s", sopURL))
+				}
 				if cluster, ok := details["cluster_id"].(string); ok {
 					parts = append(parts, fmt.Sprintf("Cluster: %s", cluster))
-
-					if info, ok := m.clusterCache[cluster]; ok {
-						parts = append(parts, fmt.Sprintf("Cluster name: %s", info.DisplayName))
-						parts = append(parts, fmt.Sprintf("State: %s, Region: %s, Version: %s", info.State, info.Region, info.Version))
-					}
-					if logs, ok := m.serviceLogCache[cluster]; ok && len(logs) > 0 {
-						parts = append(parts, fmt.Sprintf("Recent service logs: %d", len(logs)))
-						for i, sl := range logs {
-							if i >= 3 {
-								break
-							}
-							parts = append(parts, fmt.Sprintf("  - [%s] %s: %s", sl.Severity, sl.ServiceName, sl.Summary))
-						}
-					}
-					if reasons, ok := m.limitedSupportCache[cluster]; ok && len(reasons) > 0 {
-						parts = append(parts, fmt.Sprintf("Limited support reasons: %d", len(reasons)))
-						for _, r := range reasons {
-							parts = append(parts, fmt.Sprintf("  - %s", r.Summary))
-						}
-					}
+					parts = append(parts, buildClusterContext(m, cluster)...)
 				}
 			}
 		}
 
-		if len(m.selectedIncidentNotes) > 0 {
-			parts = append(parts, fmt.Sprintf("Notes: %d", len(m.selectedIncidentNotes)))
-			for i, n := range m.selectedIncidentNotes {
-				if i >= 3 {
+		// Pull notes from cache
+		var notes []pagerduty.IncidentNote
+		if cached, ok := m.incidentCache[inc.ID]; ok && cached.notesLoaded {
+			notes = cached.notes
+		} else if len(m.selectedIncidentNotes) > 0 {
+			notes = m.selectedIncidentNotes
+		}
+
+		if len(notes) > 0 {
+			parts = append(parts, fmt.Sprintf("Notes: %d", len(notes)))
+			for i, n := range notes {
+				if i >= 5 {
 					break
 				}
 				content := n.Content
-				if len(content) > 200 {
-					content = content[:200] + "..."
+				if len(content) > 300 {
+					content = content[:300] + "..."
 				}
 				parts = append(parts, fmt.Sprintf("  - %s", content))
 			}
@@ -288,6 +288,35 @@ func buildWatcherContext(m *model) string {
 	}
 
 	return strings.Join(parts, "\n")
+}
+
+func buildClusterContext(m *model, clusterID string) []string {
+	var parts []string
+
+	if info, ok := m.clusterCache[clusterID]; ok {
+		parts = append(parts, fmt.Sprintf("Cluster name: %s", info.DisplayName))
+		parts = append(parts, fmt.Sprintf("State: %s, Region: %s, Provider: %s, Version: %s",
+			info.State, info.Region, info.CloudProvider, info.Version))
+	}
+
+	if logs, ok := m.serviceLogCache[clusterID]; ok && len(logs) > 0 {
+		parts = append(parts, fmt.Sprintf("Recent service logs: %d", len(logs)))
+		for i, sl := range logs {
+			if i >= 5 {
+				break
+			}
+			parts = append(parts, fmt.Sprintf("  - [%s] %s: %s", sl.Severity, sl.ServiceName, sl.Summary))
+		}
+	}
+
+	if reasons, ok := m.limitedSupportCache[clusterID]; ok && len(reasons) > 0 {
+		parts = append(parts, fmt.Sprintf("Limited support reasons: %d", len(reasons)))
+		for _, r := range reasons {
+			parts = append(parts, fmt.Sprintf("  - %s", r.Summary))
+		}
+	}
+
+	return parts
 }
 
 func prefixLines(marker string, text string) string {

--- a/pkg/tui/watcher.go
+++ b/pkg/tui/watcher.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/PagerDuty/go-pagerduty"
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/log"
 )
@@ -104,17 +105,27 @@ func (d *watcherDedup) IsNew(observation string) bool {
 	return true
 }
 
-func (m *model) runDetectors() {
+func (m *model) runDetectors() []tea.Cmd {
 	if len(m.incidentList) < 2 {
-		return
+		return nil
 	}
 
 	observations := detectAll(m.incidentList, m.incidentClusterMap)
 
+	var cmds []tea.Cmd
 	added := false
 	for _, obs := range observations {
-		if m.watcherDedup.IsNew(obs.Summary) {
-			log.Debug("watcher.runDetectors", "observation", obs.Summary)
+		if !m.watcherDedup.IsNew(obs.Summary) {
+			continue
+		}
+
+		log.Debug("watcher.runDetectors", "observation", obs.Summary)
+
+		if m.aiProvider != nil && m.aiHealthy && !m.watcherAnalyzing {
+			m.watcherAnalyzing = true
+			summary := buildIncidentSummary(m.incidentList)
+			cmds = append(cmds, watcherSynthesizeCmd(m.aiProvider, obs.Summary, summary))
+		} else {
 			m.watcherBuffer.Append(prefixLines(m.watcherMarker, obs.Summary))
 			added = true
 		}
@@ -127,6 +138,16 @@ func (m *model) runDetectors() {
 		}
 		m.updateWatcherViewport()
 	}
+
+	return cmds
+}
+
+func buildIncidentSummary(incidents []pagerduty.Incident) string {
+	var lines []string
+	for _, inc := range incidents {
+		lines = append(lines, fmt.Sprintf("- [%s] %s (%s, %s)", inc.ID, inc.Title, inc.Service.Summary, inc.Urgency))
+	}
+	return strings.Join(lines, "\n")
 }
 
 func detectAll(incidents []pagerduty.Incident, clusterMap map[string][]string) []watcherObservation {

--- a/pkg/tui/watcher.go
+++ b/pkg/tui/watcher.go
@@ -214,6 +214,82 @@ func detectUrgencyShift(incidents []pagerduty.Incident) []watcherObservation {
 	return nil
 }
 
+type watcherPromptMsg struct {
+	prompt string
+}
+
+func isWatcherCommand(input string) bool {
+	trimmed := strings.TrimSpace(input)
+	return strings.HasPrefix(trimmed, ":watcher ") || trimmed == ":watcher"
+}
+
+func parseWatcherQuery(input string) string {
+	return strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(input), ":watcher"))
+}
+
+func buildWatcherContext(m *model) string {
+	var parts []string
+
+	if m.selectedIncident != nil {
+		inc := m.selectedIncident
+		parts = append(parts, fmt.Sprintf("Selected incident: %s (%s)", inc.Title, inc.ID))
+		parts = append(parts, fmt.Sprintf("Service: %s", inc.Service.Summary))
+		parts = append(parts, fmt.Sprintf("Status: %s, Urgency: %s", inc.Status, inc.Urgency))
+
+		for _, alert := range m.selectedIncidentAlerts {
+			if details, ok := alert.Body["details"].(map[string]interface{}); ok {
+				if name, ok := details["alert_name"].(string); ok {
+					parts = append(parts, fmt.Sprintf("Alert: %s", name))
+				}
+				if cluster, ok := details["cluster_id"].(string); ok {
+					parts = append(parts, fmt.Sprintf("Cluster: %s", cluster))
+
+					if info, ok := m.clusterCache[cluster]; ok {
+						parts = append(parts, fmt.Sprintf("Cluster name: %s", info.DisplayName))
+						parts = append(parts, fmt.Sprintf("State: %s, Region: %s, Version: %s", info.State, info.Region, info.Version))
+					}
+					if logs, ok := m.serviceLogCache[cluster]; ok && len(logs) > 0 {
+						parts = append(parts, fmt.Sprintf("Recent service logs: %d", len(logs)))
+						for i, sl := range logs {
+							if i >= 3 {
+								break
+							}
+							parts = append(parts, fmt.Sprintf("  - [%s] %s: %s", sl.Severity, sl.ServiceName, sl.Summary))
+						}
+					}
+					if reasons, ok := m.limitedSupportCache[cluster]; ok && len(reasons) > 0 {
+						parts = append(parts, fmt.Sprintf("Limited support reasons: %d", len(reasons)))
+						for _, r := range reasons {
+							parts = append(parts, fmt.Sprintf("  - %s", r.Summary))
+						}
+					}
+				}
+			}
+		}
+
+		if len(m.selectedIncidentNotes) > 0 {
+			parts = append(parts, fmt.Sprintf("Notes: %d", len(m.selectedIncidentNotes)))
+			for i, n := range m.selectedIncidentNotes {
+				if i >= 3 {
+					break
+				}
+				content := n.Content
+				if len(content) > 200 {
+					content = content[:200] + "..."
+				}
+				parts = append(parts, fmt.Sprintf("  - %s", content))
+			}
+		}
+	}
+
+	if len(m.incidentList) > 0 {
+		parts = append(parts, fmt.Sprintf("\nFull incident queue (%d incidents):", len(m.incidentList)))
+		parts = append(parts, buildIncidentSummary(m.incidentList))
+	}
+
+	return strings.Join(parts, "\n")
+}
+
 func prefixLines(marker string, text string) string {
 	lines := strings.Split(text, "\n")
 	var result []string

--- a/pkg/tui/watcher.go
+++ b/pkg/tui/watcher.go
@@ -1,0 +1,88 @@
+package tui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+const (
+	emojiWatcherMarker   = "📡 "
+	emojiAgentMarker     = "🤖 "
+	noEmojiWatcherMarker = "☺ "
+	noEmojiAgentMarker   = "☻ "
+)
+
+type markers struct {
+	flag    string
+	watcher string
+	agent   string
+}
+
+func resolveMarkers(useEmoji bool) markers {
+	if useEmoji {
+		return markers{
+			flag:    emojiFlagMarker,
+			watcher: emojiWatcherMarker,
+			agent:   emojiAgentMarker,
+		}
+	}
+	return markers{
+		flag:    noEmojiFlagMarker,
+		watcher: noEmojiWatcherMarker,
+		agent:   noEmojiAgentMarker,
+	}
+}
+
+type watcherBuffer struct {
+	entries  []string
+	capacity int
+}
+
+func newWatcherBuffer(capacity int) *watcherBuffer {
+	return &watcherBuffer{
+		entries:  make([]string, 0, capacity),
+		capacity: capacity,
+	}
+}
+
+func (b *watcherBuffer) Append(entry string) {
+	if len(b.entries) >= b.capacity {
+		b.entries = b.entries[1:]
+	}
+	b.entries = append(b.entries, entry)
+}
+
+func (b *watcherBuffer) Content() string {
+	return strings.Join(b.entries, "\n---\n")
+}
+
+func (b *watcherBuffer) Len() int {
+	return len(b.entries)
+}
+
+func (b *watcherBuffer) Clear() {
+	b.entries = b.entries[:0]
+}
+
+func (m *model) updateWatcherViewport() {
+	content := m.watcherBuffer.Content()
+	if m.watcherViewport.Width > 0 {
+		content = lipgloss.NewStyle().Width(m.watcherViewport.Width).Render(content)
+	}
+	m.watcherViewport.SetContent(content)
+	m.watcherViewport.GotoBottom()
+}
+
+func prefixLines(marker string, text string) string {
+	lines := strings.Split(text, "\n")
+	var result []string
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			result = append(result, "")
+		} else {
+			result = append(result, marker+line)
+		}
+	}
+	return strings.Join(result, "\n")
+}

--- a/pkg/tui/watcher_integration_test.go
+++ b/pkg/tui/watcher_integration_test.go
@@ -1,0 +1,357 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/PagerDuty/go-pagerduty"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/clcollins/srepd/pkg/ai"
+	"github.com/clcollins/srepd/pkg/ocm"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWatcherToggle(t *testing.T) {
+	t.Run("w key toggles watcherExpanded", func(t *testing.T) {
+		m := createTestModel()
+		m.help = newHelp()
+		windowSize = tea.WindowSizeMsg{Width: 80, Height: 60}
+		m.table.Focus()
+
+		assert.False(t, m.watcherExpanded)
+
+		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'w'}}
+		result, _ := m.Update(msg)
+		updated := result.(model)
+
+		assert.True(t, updated.watcherExpanded)
+	})
+}
+
+func TestWatcherPromptMsg_NoProvider(t *testing.T) {
+	m := createTestModel()
+	m.aiProvider = nil
+	m.table.Focus()
+
+	result, cmd := m.Update(watcherPromptMsg{prompt: "test"})
+	updated := result.(model)
+
+	assert.False(t, updated.watcherAnalyzing)
+	assert.NotNil(t, cmd, "should return flash notification")
+}
+
+func TestWatcherPromptMsg_ProviderOffline(t *testing.T) {
+	m := createTestModel()
+	m.aiProvider = ai.NewMockProvider("test")
+	m.aiHealthy = false
+	m.table.Focus()
+
+	result, cmd := m.Update(watcherPromptMsg{prompt: "test"})
+	updated := result.(model)
+
+	assert.False(t, updated.watcherAnalyzing)
+	assert.NotNil(t, cmd, "should return flash notification")
+}
+
+func TestWatcherPromptMsg_Success(t *testing.T) {
+	m := createTestModel()
+	m.aiProvider = ai.NewMockProvider("test")
+	m.aiHealthy = true
+	m.table.Focus()
+	windowSize = tea.WindowSizeMsg{Width: 80, Height: 60}
+
+	result, cmd := m.Update(watcherPromptMsg{prompt: "what happened"})
+	updated := result.(model)
+
+	assert.True(t, updated.watcherAnalyzing)
+	assert.True(t, updated.apiInProgress)
+	assert.True(t, updated.watcherExpanded)
+	assert.NotNil(t, cmd)
+}
+
+func TestWatcherResponseMsg_Success(t *testing.T) {
+	m := createTestModel()
+	m.watcherAnalyzing = true
+	m.apiInProgress = true
+	windowSize = tea.WindowSizeMsg{Width: 80, Height: 60}
+
+	result, cmd := m.Update(watcherResponseMsg{response: "analysis result"})
+	updated := result.(model)
+
+	assert.False(t, updated.watcherAnalyzing)
+	assert.False(t, updated.apiInProgress)
+	assert.True(t, updated.watcherExpanded)
+	assert.NotNil(t, cmd, "should return typewriter tick")
+	assert.NotNil(t, updated.typewriter)
+}
+
+func TestWatcherResponseMsg_Error(t *testing.T) {
+	m := createTestModel()
+	m.watcherAnalyzing = true
+	m.apiInProgress = true
+
+	result, cmd := m.Update(watcherResponseMsg{err: assert.AnError})
+	updated := result.(model)
+
+	assert.False(t, updated.watcherAnalyzing)
+	assert.False(t, updated.apiInProgress)
+	assert.NotNil(t, cmd, "should return flash notification")
+}
+
+func TestWatcherSynthesisMsg_Success(t *testing.T) {
+	m := createTestModel()
+	m.watcherAnalyzing = true
+	windowSize = tea.WindowSizeMsg{Width: 80, Height: 60}
+
+	result, cmd := m.Update(watcherSynthesisMsg{
+		observation: "service storm detected",
+		response:    "Multiple incidents suggest a platform-wide issue.",
+	})
+	updated := result.(model)
+
+	assert.False(t, updated.watcherAnalyzing)
+	assert.True(t, updated.watcherExpanded)
+	assert.NotNil(t, cmd, "should return typewriter tick")
+}
+
+func TestWatcherSynthesisMsg_Error(t *testing.T) {
+	m := createTestModel()
+	m.watcherAnalyzing = true
+	windowSize = tea.WindowSizeMsg{Width: 80, Height: 60}
+
+	result, _ := m.Update(watcherSynthesisMsg{
+		observation: "service storm detected",
+		err:         assert.AnError,
+	})
+	updated := result.(model)
+
+	assert.False(t, updated.watcherAnalyzing)
+	assert.Equal(t, 1, updated.watcherBuffer.Len(), "raw observation should be appended on error")
+}
+
+func TestTypewriterTickMsg(t *testing.T) {
+	m := createTestModel()
+	m.typewriter = &typewriterState{
+		words:  []string{"hello", "world", "foo"},
+		marker: "🤖 ",
+	}
+	m.watcherBuffer.Append("")
+
+	result, cmd := m.Update(typewriterTickMsg{})
+	updated := result.(model)
+
+	assert.Contains(t, updated.watcherBuffer.Content(), "hello")
+	if updated.typewriter == nil {
+		assert.Nil(t, cmd, "no more ticks when done")
+	} else {
+		assert.NotNil(t, cmd, "more ticks when words remain")
+	}
+}
+
+func TestMouseMsg_WatcherExpanded(t *testing.T) {
+	m := createTestModel()
+	m.watcherExpanded = true
+	windowSize = tea.WindowSizeMsg{Width: 80, Height: 60}
+	m.recomputeLayout()
+	m.watcherViewport.Width = m.layout.WatcherWidth
+	m.watcherViewport.Height = m.layout.WatcherHeight
+	m.watcherViewport.SetContent("some content\nto scroll\nthrough")
+
+	mouseMsg := tea.MouseMsg{Type: tea.MouseWheelDown}
+	result, _ := m.Update(mouseMsg)
+	_ = result.(model)
+}
+
+func TestMouseMsg_WatcherCollapsed(t *testing.T) {
+	m := createTestModel()
+	m.watcherExpanded = false
+
+	mouseMsg := tea.MouseMsg{Type: tea.MouseWheelDown}
+	_, cmd := m.Update(mouseMsg)
+
+	assert.Nil(t, cmd)
+}
+
+func TestInputMode_WatcherCommand(t *testing.T) {
+	m := createTestModel()
+	m.input = newTextInput()
+	m.input.Focus()
+	m.input.SetValue(":watcher what happened")
+	m.table.Focus()
+
+	enterMsg := tea.KeyMsg{Type: tea.KeyEnter}
+	result, cmd := switchInputFocusMode(m, enterMsg)
+	updated := result.(model)
+
+	assert.False(t, updated.input.Focused())
+	assert.NotNil(t, cmd)
+
+	msg := cmd()
+	promptMsg, ok := msg.(watcherPromptMsg)
+	assert.True(t, ok)
+	assert.Equal(t, "what happened", promptMsg.prompt)
+}
+
+func TestInputMode_WatcherCommandEmpty(t *testing.T) {
+	m := createTestModel()
+	m.input = newTextInput()
+	m.input.Focus()
+	m.input.SetValue(":watcher")
+
+	enterMsg := tea.KeyMsg{Type: tea.KeyEnter}
+	result, cmd := switchInputFocusMode(m, enterMsg)
+	updated := result.(model)
+
+	assert.Contains(t, updated.status, "usage")
+	assert.Nil(t, cmd)
+}
+
+func TestRenderWatcherPane_Collapsed(t *testing.T) {
+	m := createTestModel()
+	m.watcherExpanded = false
+
+	result := m.renderWatcherPane()
+	assert.Equal(t, "", result)
+}
+
+func TestRenderWatcherPane_Expanded(t *testing.T) {
+	m := createTestModel()
+	m.watcherExpanded = true
+	m.watcherViewport.Width = 80
+	m.watcherViewport.Height = 10
+
+	result := m.renderWatcherPane()
+	assert.NotEmpty(t, result)
+}
+
+func TestRenderWatcherStatus_NoProvider(t *testing.T) {
+	m := createTestModel()
+	m.aiProvider = nil
+
+	status := m.renderWatcherStatus()
+	assert.Contains(t, status, "[AI Watcher]")
+	assert.Contains(t, status, "idle")
+}
+
+func TestRenderWatcherStatus_Healthy(t *testing.T) {
+	m := createTestModel()
+	m.aiProvider = ai.NewMockProvider("ollama")
+	m.aiHealthy = true
+
+	status := m.renderWatcherStatus()
+	assert.Contains(t, status, "ollama")
+	assert.Contains(t, status, "healthy")
+}
+
+func TestRenderWatcherStatus_Offline(t *testing.T) {
+	m := createTestModel()
+	m.aiProvider = ai.NewMockProvider("ollama")
+	m.aiHealthy = false
+
+	status := m.renderWatcherStatus()
+	assert.Contains(t, status, "offline")
+}
+
+func TestRenderFooter_WatcherCollapsed(t *testing.T) {
+	m := createTestModel()
+	m.watcherExpanded = false
+
+	footer := m.renderFooter()
+	assert.Contains(t, footer, "Watching")
+	assert.NotContains(t, footer, "[AI Watcher]")
+}
+
+func TestRenderFooter_WatcherExpanded(t *testing.T) {
+	m := createTestModel()
+	m.watcherExpanded = true
+	m.aiProvider = ai.NewMockProvider("ollama")
+	m.aiHealthy = true
+	windowSize = tea.WindowSizeMsg{Width: 120, Height: 60}
+
+	footer := m.renderFooter()
+	assert.Contains(t, footer, "Watching")
+}
+
+func TestBuildClusterContext(t *testing.T) {
+	m := createTestModel()
+	m.clusterCache = map[string]*ocm.ClusterInfo{
+		"cluster-abc": {
+			DisplayName:   "test-cluster.example.org",
+			State:         "ready",
+			Region:        "us-east-1",
+			CloudProvider: "aws",
+			Version:       "4.16.5",
+		},
+	}
+
+	parts := buildClusterContext(&m, "cluster-abc")
+
+	assert.NotEmpty(t, parts)
+	found := false
+	for _, p := range parts {
+		if assert.ObjectsAreEqual("test-cluster.example.org", p) || len(p) > 0 {
+			found = true
+		}
+	}
+	assert.True(t, found)
+}
+
+func TestAdvanceTypewriter(t *testing.T) {
+	m := createTestModel()
+	m.watcherBuffer.Append("")
+	m.typewriter = &typewriterState{
+		words:  []string{"one", "two", "three", "four", "five"},
+		marker: "📡 ",
+	}
+
+	cmd := m.advanceTypewriter()
+	assert.NotNil(t, cmd, "should return tick for remaining words")
+	assert.Contains(t, m.watcherBuffer.Content(), "one")
+
+	cmd = m.advanceTypewriter()
+	if m.typewriter == nil {
+		assert.Nil(t, cmd, "nil when done")
+	}
+}
+
+func TestAdvanceTypewriter_Nil(t *testing.T) {
+	m := createTestModel()
+	m.typewriter = nil
+
+	cmd := m.advanceTypewriter()
+	assert.Nil(t, cmd)
+}
+
+func TestBuildWatcherContext_WithCachedAlerts(t *testing.T) {
+	m := createTestModel()
+	inc := &pagerduty.Incident{
+		APIObject: pagerduty.APIObject{ID: "P123"},
+		Title:     "Test Alert",
+		Status:    "triggered",
+		Urgency:   "high",
+		Service:   pagerduty.APIObject{Summary: "test-service"},
+	}
+	m.selectedIncident = inc
+	m.incidentCache["P123"] = &cachedIncidentData{
+		alertsLoaded: true,
+		alerts: []pagerduty.IncidentAlert{
+			{
+				Body: map[string]interface{}{
+					"details": map[string]interface{}{
+						"alert_name": "ClusterOperatorDown",
+						"cluster_id": "cluster-abc",
+					},
+				},
+			},
+		},
+		notesLoaded: true,
+		notes: []pagerduty.IncidentNote{
+			{Content: "Investigated — worker node OOM."},
+		},
+	}
+
+	ctx := buildWatcherContext(&m)
+
+	assert.Contains(t, ctx, "ClusterOperatorDown")
+	assert.Contains(t, ctx, "cluster-abc")
+	assert.Contains(t, ctx, "Investigated")
+}

--- a/pkg/tui/watcher_integration_test.go
+++ b/pkg/tui/watcher_integration_test.go
@@ -156,7 +156,7 @@ func TestMouseMsg_WatcherExpanded(t *testing.T) {
 	m.watcherViewport.Height = m.layout.WatcherHeight
 	m.watcherViewport.SetContent("some content\nto scroll\nthrough")
 
-	mouseMsg := tea.MouseMsg{Type: tea.MouseWheelDown}
+	mouseMsg := tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonWheelDown}
 	result, _ := m.Update(mouseMsg)
 	_ = result.(model)
 }
@@ -165,7 +165,7 @@ func TestMouseMsg_WatcherCollapsed(t *testing.T) {
 	m := createTestModel()
 	m.watcherExpanded = false
 
-	mouseMsg := tea.MouseMsg{Type: tea.MouseWheelDown}
+	mouseMsg := tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonWheelDown}
 	_, cmd := m.Update(mouseMsg)
 
 	assert.Nil(t, cmd)

--- a/pkg/tui/watcher_test.go
+++ b/pkg/tui/watcher_test.go
@@ -252,3 +252,109 @@ func TestDetectAll(t *testing.T) {
 		assert.GreaterOrEqual(t, len(obs), 2)
 	})
 }
+
+func TestWatcherBuffer_SetLast(t *testing.T) {
+	t.Run("replaces last entry", func(t *testing.T) {
+		buf := newWatcherBuffer(5)
+		buf.Append("first")
+		buf.Append("second")
+		buf.SetLast("replaced")
+
+		assert.Equal(t, 2, buf.Len())
+		assert.Contains(t, buf.Content(), "replaced")
+		assert.NotContains(t, buf.Content(), "second")
+	})
+
+	t.Run("appends when empty", func(t *testing.T) {
+		buf := newWatcherBuffer(5)
+		buf.SetLast("only")
+
+		assert.Equal(t, 1, buf.Len())
+		assert.Equal(t, "only", buf.Content())
+	})
+}
+
+func TestBuildIncidentSummary(t *testing.T) {
+	incidents := []pagerduty.Incident{
+		makeIncident("P1", "svc-a", "high"),
+		makeIncident("P2", "svc-b", "low"),
+	}
+
+	summary := buildIncidentSummary(incidents)
+
+	assert.Contains(t, summary, "P1")
+	assert.Contains(t, summary, "svc-a")
+	assert.Contains(t, summary, "high")
+	assert.Contains(t, summary, "P2")
+	assert.Contains(t, summary, "svc-b")
+	assert.Contains(t, summary, "low")
+}
+
+func TestIsWatcherCommand(t *testing.T) {
+	assert.True(t, isWatcherCommand(":watcher what happened"))
+	assert.True(t, isWatcherCommand(":watcher"))
+	assert.True(t, isWatcherCommand("  :watcher query"))
+	assert.False(t, isWatcherCommand("watcher"))
+	assert.False(t, isWatcherCommand(":agent query"))
+	assert.False(t, isWatcherCommand(""))
+}
+
+func TestParseWatcherQuery(t *testing.T) {
+	assert.Equal(t, "what happened", parseWatcherQuery(":watcher what happened"))
+	assert.Equal(t, "", parseWatcherQuery(":watcher"))
+	assert.Equal(t, "multi word query", parseWatcherQuery(":watcher multi word query"))
+}
+
+func TestSplitKeepingNewlines(t *testing.T) {
+	t.Run("preserves newlines as tokens", func(t *testing.T) {
+		tokens := splitKeepingNewlines("hello world\nfoo bar")
+		assert.Equal(t, []string{"hello", "world", "\n", "foo", "bar"}, tokens)
+	})
+
+	t.Run("handles blank lines", func(t *testing.T) {
+		tokens := splitKeepingNewlines("hello\n\nworld")
+		assert.Equal(t, []string{"hello", "\n", "\n", "world"}, tokens)
+	})
+
+	t.Run("single line", func(t *testing.T) {
+		tokens := splitKeepingNewlines("hello world")
+		assert.Equal(t, []string{"hello", "world"}, tokens)
+	})
+
+	t.Run("empty string", func(t *testing.T) {
+		tokens := splitKeepingNewlines("")
+		assert.Empty(t, tokens)
+	})
+}
+
+func TestBuildWatcherContext_NoIncident(t *testing.T) {
+	m := createTestModel()
+	m.incidentList = []pagerduty.Incident{
+		makeIncident("P1", "svc-a", "high"),
+	}
+
+	ctx := buildWatcherContext(&m)
+
+	assert.Contains(t, ctx, "P1")
+	assert.Contains(t, ctx, "svc-a")
+}
+
+func TestBuildWatcherContext_WithIncident(t *testing.T) {
+	m := createTestModel()
+	m.selectedIncident = &pagerduty.Incident{
+		APIObject: pagerduty.APIObject{ID: "P123"},
+		Title:     "Test Alert",
+		Status:    "triggered",
+		Urgency:   "high",
+		Service:   pagerduty.APIObject{Summary: "test-service"},
+	}
+	m.incidentList = []pagerduty.Incident{*m.selectedIncident}
+
+	ctx := buildWatcherContext(&m)
+
+	assert.Contains(t, ctx, "Test Alert")
+	assert.Contains(t, ctx, "P123")
+	assert.Contains(t, ctx, "test-service")
+	assert.Contains(t, ctx, "triggered")
+	assert.Contains(t, ctx, "high")
+}

--- a/pkg/tui/watcher_test.go
+++ b/pkg/tui/watcher_test.go
@@ -2,7 +2,9 @@ package tui
 
 import (
 	"testing"
+	"time"
 
+	"github.com/PagerDuty/go-pagerduty"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -119,4 +121,134 @@ func TestResolveMarkers_NoEmoji(t *testing.T) {
 	assert.Equal(t, noEmojiFlagMarker, mk.flag)
 	assert.Equal(t, noEmojiWatcherMarker, mk.watcher)
 	assert.Equal(t, noEmojiAgentMarker, mk.agent)
+}
+
+func makeIncident(id, service, urgency string) pagerduty.Incident {
+	return pagerduty.Incident{
+		APIObject: pagerduty.APIObject{ID: id},
+		Service:   pagerduty.APIObject{Summary: service},
+		Urgency:   urgency,
+		Status:    "triggered",
+	}
+}
+
+func TestDetectServiceStorm(t *testing.T) {
+	t.Run("detects 3+ incidents on same service", func(t *testing.T) {
+		incidents := []pagerduty.Incident{
+			makeIncident("P1", "osd-cluster-a", "high"),
+			makeIncident("P2", "osd-cluster-a", "high"),
+			makeIncident("P3", "osd-cluster-a", "low"),
+		}
+		obs := detectServiceStorm(incidents)
+		assert.Len(t, obs, 1)
+		assert.Contains(t, obs[0].Summary, "osd-cluster-a")
+		assert.Contains(t, obs[0].Summary, "3")
+	})
+
+	t.Run("no storm with 2 incidents", func(t *testing.T) {
+		incidents := []pagerduty.Incident{
+			makeIncident("P1", "svc-a", "high"),
+			makeIncident("P2", "svc-a", "high"),
+		}
+		obs := detectServiceStorm(incidents)
+		assert.Empty(t, obs)
+	})
+
+	t.Run("multiple services each below threshold", func(t *testing.T) {
+		incidents := []pagerduty.Incident{
+			makeIncident("P1", "svc-a", "high"),
+			makeIncident("P2", "svc-b", "high"),
+			makeIncident("P3", "svc-c", "high"),
+		}
+		obs := detectServiceStorm(incidents)
+		assert.Empty(t, obs)
+	})
+}
+
+func TestDetectClusterStorm(t *testing.T) {
+	t.Run("detects 2+ incidents on same cluster", func(t *testing.T) {
+		incidents := []pagerduty.Incident{
+			makeIncident("P1", "svc-a", "high"),
+			makeIncident("P2", "svc-b", "high"),
+		}
+		clusterMap := map[string][]string{
+			"P1": {"cluster-abc"},
+			"P2": {"cluster-abc"},
+		}
+		obs := detectClusterStorm(incidents, clusterMap)
+		assert.Len(t, obs, 1)
+		assert.Contains(t, obs[0].Summary, "cluster-abc")
+	})
+
+	t.Run("no storm with different clusters", func(t *testing.T) {
+		incidents := []pagerduty.Incident{
+			makeIncident("P1", "svc-a", "high"),
+			makeIncident("P2", "svc-b", "high"),
+		}
+		clusterMap := map[string][]string{
+			"P1": {"cluster-abc"},
+			"P2": {"cluster-def"},
+		}
+		obs := detectClusterStorm(incidents, clusterMap)
+		assert.Empty(t, obs)
+	})
+
+	t.Run("nil cluster map returns nil", func(t *testing.T) {
+		incidents := []pagerduty.Incident{makeIncident("P1", "svc", "high")}
+		obs := detectClusterStorm(incidents, nil)
+		assert.Nil(t, obs)
+	})
+}
+
+func TestDetectUrgencyShift(t *testing.T) {
+	t.Run("detects 3+ high urgency incidents", func(t *testing.T) {
+		incidents := []pagerduty.Incident{
+			makeIncident("P1", "svc-a", "high"),
+			makeIncident("P2", "svc-b", "high"),
+			makeIncident("P3", "svc-c", "high"),
+		}
+		obs := detectUrgencyShift(incidents)
+		assert.Len(t, obs, 1)
+		assert.Contains(t, obs[0].Summary, "3/3")
+	})
+
+	t.Run("no alert with fewer than 3 high", func(t *testing.T) {
+		incidents := []pagerduty.Incident{
+			makeIncident("P1", "svc-a", "high"),
+			makeIncident("P2", "svc-b", "low"),
+		}
+		obs := detectUrgencyShift(incidents)
+		assert.Nil(t, obs)
+	})
+}
+
+func TestWatcherDedup(t *testing.T) {
+	t.Run("first observation is new", func(t *testing.T) {
+		d := newWatcherDedup(5 * time.Minute)
+		assert.True(t, d.IsNew("something happened"))
+	})
+
+	t.Run("duplicate within cooldown is not new", func(t *testing.T) {
+		d := newWatcherDedup(5 * time.Minute)
+		d.IsNew("something happened")
+		assert.False(t, d.IsNew("something happened"))
+	})
+
+	t.Run("different observation is new", func(t *testing.T) {
+		d := newWatcherDedup(5 * time.Minute)
+		d.IsNew("first thing")
+		assert.True(t, d.IsNew("second thing"))
+	})
+}
+
+func TestDetectAll(t *testing.T) {
+	t.Run("returns combined observations from all detectors", func(t *testing.T) {
+		incidents := []pagerduty.Incident{
+			makeIncident("P1", "svc-a", "high"),
+			makeIncident("P2", "svc-a", "high"),
+			makeIncident("P3", "svc-a", "high"),
+		}
+		obs := detectAll(incidents, nil)
+		assert.GreaterOrEqual(t, len(obs), 2)
+	})
 }

--- a/pkg/tui/watcher_test.go
+++ b/pkg/tui/watcher_test.go
@@ -1,0 +1,122 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWatcherBuffer_Append(t *testing.T) {
+	buf := newWatcherBuffer(5)
+	buf.Append("first")
+	buf.Append("second")
+
+	assert.Equal(t, 2, buf.Len())
+	assert.Contains(t, buf.Content(), "first")
+	assert.Contains(t, buf.Content(), "second")
+}
+
+func TestWatcherBuffer_ContentJoinsWithSeparator(t *testing.T) {
+	buf := newWatcherBuffer(5)
+	buf.Append("one")
+	buf.Append("two")
+	buf.Append("three")
+
+	assert.Equal(t, "one\n---\ntwo\n---\nthree", buf.Content())
+}
+
+func TestWatcherBuffer_CapacityOverflow(t *testing.T) {
+	buf := newWatcherBuffer(3)
+	buf.Append("a")
+	buf.Append("b")
+	buf.Append("c")
+	buf.Append("d")
+
+	assert.Equal(t, 3, buf.Len())
+	assert.NotContains(t, buf.Content(), "a")
+	assert.Contains(t, buf.Content(), "b")
+	assert.Contains(t, buf.Content(), "d")
+}
+
+func TestWatcherBuffer_Clear(t *testing.T) {
+	buf := newWatcherBuffer(5)
+	buf.Append("something")
+	buf.Clear()
+
+	assert.Equal(t, 0, buf.Len())
+	assert.Equal(t, "", buf.Content())
+}
+
+func TestWatcherBuffer_SingleEntry(t *testing.T) {
+	buf := newWatcherBuffer(5)
+	buf.Append("only entry")
+
+	assert.Equal(t, "only entry", buf.Content())
+}
+
+func TestWatcherBuffer_EmptyContent(t *testing.T) {
+	buf := newWatcherBuffer(5)
+	assert.Equal(t, "", buf.Content())
+	assert.Equal(t, 0, buf.Len())
+}
+
+func TestPrefixLines(t *testing.T) {
+	tests := []struct {
+		name     string
+		marker   string
+		text     string
+		expected string
+	}{
+		{
+			name:     "single line",
+			marker:   "🤖 ",
+			text:     "hello",
+			expected: "🤖 hello",
+		},
+		{
+			name:     "multi line",
+			marker:   "🤖 ",
+			text:     "line one\nline two\nline three",
+			expected: "🤖 line one\n🤖 line two\n🤖 line three",
+		},
+		{
+			name:     "blank lines preserved without marker",
+			marker:   "📡 ",
+			text:     "first\n\nsecond\n\nthird",
+			expected: "📡 first\n\n📡 second\n\n📡 third",
+		},
+		{
+			name:     "whitespace-only lines treated as blank",
+			marker:   "☻ ",
+			text:     "hello\n   \nworld",
+			expected: "☻ hello\n\n☻ world",
+		},
+		{
+			name:     "empty string",
+			marker:   "🤖 ",
+			text:     "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := prefixLines(tt.marker, tt.text)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestResolveMarkers_Emoji(t *testing.T) {
+	mk := resolveMarkers(true)
+	assert.Equal(t, emojiFlagMarker, mk.flag)
+	assert.Equal(t, emojiWatcherMarker, mk.watcher)
+	assert.Equal(t, emojiAgentMarker, mk.agent)
+}
+
+func TestResolveMarkers_NoEmoji(t *testing.T) {
+	mk := resolveMarkers(false)
+	assert.Equal(t, noEmojiFlagMarker, mk.flag)
+	assert.Equal(t, noEmojiWatcherMarker, mk.watcher)
+	assert.Equal(t, noEmojiAgentMarker, mk.agent)
+}


### PR DESCRIPTION
## Summary

- Add collapsible watcher pane below incident table with dynamic 2/3-1/3 height split, mouse scrolling, and typewriter response display
- Add `:agent` command (CLI subprocess) and `:watcher` command (LLM API) with shared rich incident context (alerts, OCM cluster info, service logs, limited support, notes)
- Add ambient heuristic pattern detectors: service storm, cluster storm, urgency shift — with LLM synthesis when provider is healthy
- Add configurable system prompts (`agent_system_prompt`, `watcher_system_prompt`), emoji toggle, and `agent_cli_command`
- Switch command prefix from `/` to `:` (vim-style), add `/` key for future search, remove `f` and `i` key bindings
- Fix flag markers not appearing until manual refresh — all flag operations now trigger immediate table rebuild
- Add elapsed countdown timer and provider health status to footer
- Suppress noisy mouse/OCM log messages from journal
- Full documentation: docs/ai-agents.md, docs/configuration.md, updated flag-conditions.md, llm-providers.md, README

Closes #305
Closes #312
Closes #315

## Test plan

- [x] `make test-all` passes (fmt-check, vet, lint, test, test-race)
- [x] golangci-lint clean
- [x] Watcher pane toggles with `w`, resizes dynamically, scrolls with mouse wheel
- [x] `:agent` queries dispatch to CLI agent with full incident context, responses typewrite into watcher pane
- [x] `:watcher` queries dispatch to LLM provider with full context, responses typewrite into watcher pane
- [x] Ambient detectors fire on incident list updates, synthesize via LLM when healthy
- [x] Health check status and countdown timer visible in footer
- [x] `:flag`/`:flags`/`:unflag` commands work with new `:` prefix
- [x] Flag markers appear immediately on add/remove/load
- [x] `emoji: false` switches all markers to text fallbacks
- [x] Dev mode (`srepd --dev`) works with watcher features

🤖 Generated with [Claude Code](https://claude.com/claude-code)