### PR TITLE
Add color palette documentation with Nord and Catppuccin Latte presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ See [docs/configuration.md](docs/configuration.md) for the full reference includ
 
 ### Colors
 
-All color keys are optional. Unspecified keys use defaults. Values must be hex colors (e.g., `#778da9`).
+All color keys are optional. Unspecified keys use defaults. Values must be hex colors (e.g., `#778da9`). See [docs/colors.md](docs/colors.md) for color key descriptions and pre-built palettes (Nord, Catppuccin Latte).
 
 ```yaml
 colors:

--- a/docs/colors.md
+++ b/docs/colors.md
@@ -1,0 +1,64 @@
+# Color Palettes
+
+SREPD supports custom color themes via the `colors` key in `~/.config/srepd/srepd.yaml`. All keys are optional — unspecified keys fall back to defaults. Values must be valid hex colors (`#rgb` or `#rrggbb`, case-insensitive). Invalid values are silently ignored.
+
+## Color Keys
+
+| Key | Controls |
+|-----|----------|
+| `text` | Normal text, table rows, document body |
+| `border` | Borders, tab outlines, separators, horizontal rules |
+| `highlight` | Table headers, selected row text, active tab text, headings |
+| `selected` | Selected row background |
+| `warning` | Warning and confirmation prompt background |
+| `error` | Error modal background |
+| `muted` | De-emphasized text (version string, incident IDs) |
+| `tab` | Tab accent color |
+
+## Default
+
+The built-in palette uses blue-gray tones from the [Coolors "Quantum Harmony"](https://coolors.co/palette/0d1b2a-1b263b-415a77-778da9-e0e1dd) palette. Designed for dark terminal backgrounds.
+
+```yaml
+colors:
+  text: "#778da9"
+  border: "#415a77"
+  highlight: "#ffffff"
+  selected: "#415a77"
+  warning: "#a4133c"
+  error: "#0d1b2a"
+  muted: "#5C5C5C"
+  tab: "#7D56F4"
+```
+
+## Nord
+
+Arctic, blue-tinted palette with muted accents. Works well on dark terminal backgrounds. From the [Nord](https://www.nordtheme.com) theme (MIT license).
+
+```yaml
+colors:
+  text: "#D8DEE9"
+  border: "#4C566A"
+  highlight: "#88C0D0"
+  selected: "#434C5E"
+  warning: "#EBCB8B"
+  error: "#BF616A"
+  muted: "#4C566A"
+  tab: "#5E81AC"
+```
+
+## Catppuccin Latte
+
+Pastel palette designed for light terminal backgrounds. From the [Catppuccin](https://catppuccin.com) theme (MIT license).
+
+```yaml
+colors:
+  text: "#4c4f69"
+  border: "#bcc0cc"
+  highlight: "#7287fd"
+  selected: "#ccd0da"
+  warning: "#df8e1d"
+  error: "#d20f39"
+  muted: "#acb0be"
+  tab: "#8839ef"
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,7 +83,7 @@ See [LLM Providers](llm-providers.md) for provider-specific setup.
 |-----|------|---------|-------------|
 | `colors` | `map[string]string` | (defaults) | Custom color scheme with hex values |
 
-Available color keys: `text`, `border`, `highlight`, `selected`, `warning`, `error`, `muted`, `tab`.
+Available color keys: `text`, `border`, `highlight`, `selected`, `warning`, `error`, `muted`, `tab`. See [Colors](colors.md) for color key descriptions and pre-built palettes.
 
 ```yaml
 colors:

--- a/docs/plans/add-colors-docs.md
+++ b/docs/plans/add-colors-docs.md
@@ -1,0 +1,10 @@
+# Plan: Add color palette documentation
+
+## Context
+
+SREPD's color system is configurable but the README only shows the default values without explaining what each key controls or offering alternative palettes. Users who want to customize colors need to read the source code.
+
+## Changes
+
+- Add `docs/colors.md` documenting all 8 color keys, the default palette, and two pre-built alternatives (Nord for dark terminals, Catppuccin Latte for light terminals)
+- Add cross-reference from README Colors section to the new doc


### PR DESCRIPTION
## Summary

- Add `docs/colors.md` documenting all 8 color keys, the default palette, and two pre-built alternatives:
  - **Nord** (MIT) — arctic blue-gray for dark terminals
  - **Catppuccin Latte** (MIT) — pastel palette for light terminals
- Cross-reference from `README.md` and `docs/configuration.md` Colors sections

## Test plan

- [ ] Verify markdown renders correctly on GitHub
- [ ] Confirm hex values match Nord and Catppuccin official palettes
- [ ] Docs-only change — no code impact

Created with assistance from Claude 🤖 <claude@anthropic.com>