### PR TITLE
Add cluster reports tab via backplane API

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ A PagerDuty terminal user interface focused on common SRE tasks.
 * [Flag conditions](docs/flag-conditions.md): mark incidents matching cluster ID or organization name patterns
 * [AI agents](docs/ai-agents.md): `:agent` CLI queries and `:watcher` LLM analysis with ambient incident pattern detection
 * OCM integration: cluster enrichment with display names, service logs, limited support history
-* 6-tab incident viewer: Details, Alerts, Notes, Cluster, SLs, LS History
+* Backplane integration: CORA cluster diagnostic reports via backplane API
+* 7-tab incident viewer: Details, Alerts, Notes, Cluster, SLs, LS History, Reports
 * Auto-update notification and `srepd update` self-update command
 * Full [configuration reference](docs/configuration.md)
 
@@ -130,9 +131,12 @@ Enriched data includes:
 * **Cluster tab** shows OCM cluster details: name, ID, state, region, provider, version, CCS, Hypershift
 * **Service Logs tab** shows recent service logs per cluster
 * **Limited Support History tab** shows LS reasons per cluster
+* **Reports tab** shows CORA cluster diagnostic reports from the backplane API
 * Multi-cluster incidents show `(+N)` in the service column
 
 OCM features are optional — if OCM is not configured, the remaining TUI functions normally.
+
+The Reports tab requires `~/.config/backplane/config.json` (standard backplane-cli config). The backplane URL is resolved from OCM environment metadata. If the config file is missing, the tab shows a message indicating backplane is not enabled.
 
 ## LLM Integration
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -107,6 +107,8 @@ func launchTUIWithConfig() {
 		ocmAuthPending,
 		nil, // aiProvider — not needed in config mode
 		"",  // agentCLICommand — not needed in config mode
+		nil, // backplaneClient — not needed in config mode
+		nil, // backplaneConfig — not needed in config mode
 	)
 
 	p := tea.NewProgram(m, tea.WithAltScreen())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,6 +36,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/log"
 	"github.com/clcollins/srepd/pkg/ai"
+	"github.com/clcollins/srepd/pkg/backplane"
 	pkgconfig "github.com/clcollins/srepd/pkg/config"
 	"github.com/clcollins/srepd/pkg/launcher"
 	"github.com/clcollins/srepd/pkg/ocm"
@@ -186,6 +187,34 @@ func launchTUI() {
 		}
 	}
 
+	var bpClient backplane.BackplaneClient
+	var bpConfig *backplane.Config
+	bpCfg, bpErr := backplane.LoadConfig()
+	if bpErr != nil {
+		log.Info("Backplane config not available", "error", bpErr)
+	} else {
+		bpConfig = bpCfg
+		if ocmClient != nil {
+			if bpCfg.URL == "" {
+				resolvedURL, urlErr := ocmClient.GetBackplaneURL()
+				if urlErr != nil {
+					log.Warn("Backplane URL resolution from OCM failed", "error", urlErr)
+				} else {
+					bpCfg.URL = resolvedURL
+					log.Info("Backplane URL resolved from OCM", "url", resolvedURL)
+				}
+			}
+			if bpCfg.URL != "" {
+				bpClient = backplane.NewClient(bpCfg, ocmClient.GetAccessToken)
+				log.Info("Backplane client initialized")
+			} else {
+				log.Warn("Backplane client not created: no URL available")
+			}
+		} else {
+			log.Info("Backplane config loaded, client deferred until OCM auth completes")
+		}
+	}
+
 	m, _ := tui.InitialModel(
 		viper.GetString("token"),
 		viper.GetStringSlice("teams"),
@@ -202,6 +231,8 @@ func launchTUI() {
 		ocmAuthPending,
 		aiProvider,
 		viper.GetString("agent_cli_command"),
+		bpClient,
+		bpConfig,
 	)
 
 	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion())
@@ -376,6 +407,12 @@ func runDevMode() {
 		log.Warn("Dev mode: OCM fixtures not loaded", "error", ocmErr)
 	}
 
+	// Load backplane mock client with fixture data for dev mode
+	bpMock, bpErr := backplane.LoadMockClientFromFixtures(fixturesDir)
+	if bpErr != nil {
+		log.Warn("Dev mode: backplane fixtures not loaded", "error", bpErr)
+	}
+
 	m, _ := tui.InitialModelWithConfig(
 		config,
 		viper.GetStringSlice("editor"),
@@ -384,6 +421,7 @@ func runDevMode() {
 		ocmMock,
 		nil, // aiProvider — not used in dev mode
 		"",  // agentCLICommand — uses default in dev mode
+		bpMock,
 	)
 
 	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion())

--- a/docs/plans/316-cluster-reports-tab.md
+++ b/docs/plans/316-cluster-reports-tab.md
@@ -1,0 +1,60 @@
+# Plan: Add cluster reports tab via backplane API (#316)
+
+**Status:** Complete
+**Issue:** #316
+**PR:** #325
+
+## Problem
+
+CORA (Cluster Observability and Remediation Agent) generates diagnostic
+reports stored via the backplane API. SREs need to view these reports
+during incident triage alongside existing service logs and cluster info.
+
+## Solution
+
+Add a new "Reports" tab (tab 6) that fetches cluster reports from the
+backplane API using direct HTTP calls. No `backplane-cli` dependency —
+reads `~/.config/backplane/config.json` for proxy config and resolves
+the backplane URL from OCM environment metadata.
+
+### Key design decisions
+
+- **Direct HTTP over backplane-cli imports**: The API surface is simple
+  (GET with Bearer token), and avoiding the dependency keeps the binary
+  lean and avoids transitive dependency bloat.
+- **URL resolution from OCM**: The standard backplane config has an empty
+  `url` field. The URL is resolved at runtime from the OCM environment
+  metadata via `conn.ClustersMgmt().V1().Environment().Get().Send()`.
+- **Token freshness via closure**: The backplane client takes a
+  `tokenFunc func() (string, error)` that calls `ocmClient.GetAccessToken()`
+  at request time, ensuring the OCM SDK handles token refresh.
+- **Deferred client creation**: When OCM auth is pending (async browser
+  flow), the backplane config is stored and the client is created when
+  `OCMClientReadyMsg` arrives.
+
+## Files changed
+
+- `pkg/backplane/backplane.go` — types and BackplaneClient interface
+- `pkg/backplane/config.go` — config loader for ~/.config/backplane/config.json
+- `pkg/backplane/client.go` — HTTP client with Bearer auth and proxy support
+- `pkg/backplane/mock.go` — mock client for dev mode and testing
+- `pkg/backplane/client_test.go` — 8 tests (92% coverage)
+- `pkg/backplane/config_test.go` — 4 tests
+- `pkg/backplane/mock_test.go` — 5 tests
+- `pkg/ocm/ocm.go` — added GetAccessToken() and GetBackplaneURL() to interface
+- `pkg/ocm/client.go` — implemented GetAccessToken() and GetBackplaneURL()
+- `pkg/ocm/mock.go` — mock implementations
+- `pkg/tui/model.go` — backplane fields, updated constructors, cache cleanup
+- `pkg/tui/ocm_enrichment.go` — clusterReportsMsg type and getClusterReports()
+- `pkg/tui/views.go` — tabReports constant, renderClusterReportsTab(), tab bar
+- `pkg/tui/tui.go` — message handler, phase 2 dispatch, deferred client creation
+- `cmd/root.go` — backplane client initialization with URL resolution
+- `cmd/config.go` — nil backplane params for config mode
+- `testdata/fixtures/clusterreports.json` — dev mode fixture data
+
+## Post-mortem / lessons learned
+
+- The backplane config file commonly has `"url": ""` — the URL is resolved
+  from OCM environment metadata, not from the config. Initial implementation
+  rejected empty URLs, which broke on real-world configs. Lesson: always
+  test with real config files early.

--- a/pkg/backplane/backplane.go
+++ b/pkg/backplane/backplane.go
@@ -1,0 +1,24 @@
+package backplane
+
+import "context"
+
+// ReportSummary is a summary of a single cluster report from the backplane API.
+type ReportSummary struct {
+	ReportID  string `json:"report_id"`
+	Summary   string `json:"summary"`
+	CreatedAt string `json:"created_at"`
+}
+
+// Report is the full content of a single cluster report.
+type Report struct {
+	ReportID  string `json:"report_id"`
+	Summary   string `json:"summary"`
+	CreatedAt string `json:"created_at"`
+	Data      string `json:"data"`
+}
+
+// BackplaneClient defines the interface for backplane API operations.
+type BackplaneClient interface {
+	ListReports(ctx context.Context, clusterID string) ([]ReportSummary, error)
+	GetReport(ctx context.Context, clusterID, reportID string) (*Report, error)
+}

--- a/pkg/backplane/client.go
+++ b/pkg/backplane/client.go
@@ -1,0 +1,128 @@
+package backplane
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/charmbracelet/log"
+)
+
+const defaultTimeout = 30 * time.Second
+
+type listReportsResponse struct {
+	Reports []ReportSummary `json:"reports"`
+}
+
+// Client is the HTTP-based backplane client.
+type Client struct {
+	config     *Config
+	tokenFunc  func() (string, error)
+	httpClient *http.Client
+}
+
+// NewClient creates a BackplaneClient from config and a token provider function.
+func NewClient(cfg *Config, tokenFunc func() (string, error)) BackplaneClient {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+
+	if cfg.ProxyURL != nil && *cfg.ProxyURL != "" && !cfg.Govcloud {
+		proxyURL, err := url.Parse(*cfg.ProxyURL)
+		if err == nil {
+			transport.Proxy = http.ProxyURL(proxyURL)
+			log.Debug("backplane.NewClient", "proxy", "configured")
+		} else {
+			log.Warn("backplane.NewClient", "msg", "invalid proxy URL, proceeding without proxy", "error", err)
+		}
+	}
+
+	log.Debug("backplane.NewClient", "url", cfg.URL, "govcloud", cfg.Govcloud)
+
+	return &Client{
+		config:    cfg,
+		tokenFunc: tokenFunc,
+		httpClient: &http.Client{
+			Timeout:   defaultTimeout,
+			Transport: transport,
+		},
+	}
+}
+
+func (c *Client) ListReports(ctx context.Context, clusterID string) ([]ReportSummary, error) {
+	endpoint := fmt.Sprintf("%s/backplane/cluster/%s/reports?last=10", c.config.URL, clusterID)
+	log.Debug("backplane.ListReports", "cluster_id", clusterID)
+
+	body, err := c.doRequest(ctx, endpoint)
+	if err != nil {
+		log.Warn("backplane.ListReports failed", "cluster_id", clusterID, "error", err)
+		return nil, fmt.Errorf("list reports for %s: %w", clusterID, err)
+	}
+
+	var resp listReportsResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		log.Warn("backplane.ListReports decode failed", "cluster_id", clusterID, "error", err)
+		return nil, fmt.Errorf("decode reports response for %s: %w", clusterID, err)
+	}
+
+	log.Debug("backplane.ListReports", "cluster_id", clusterID, "count", len(resp.Reports))
+	return resp.Reports, nil
+}
+
+func (c *Client) GetReport(ctx context.Context, clusterID, reportID string) (*Report, error) {
+	endpoint := fmt.Sprintf("%s/backplane/cluster/%s/reports/%s", c.config.URL, clusterID, reportID)
+	log.Debug("backplane.GetReport", "cluster_id", clusterID, "report_id", reportID)
+
+	body, err := c.doRequest(ctx, endpoint)
+	if err != nil {
+		log.Warn("backplane.GetReport failed", "cluster_id", clusterID, "report_id", reportID, "error", err)
+		return nil, fmt.Errorf("get report %s for %s: %w", reportID, clusterID, err)
+	}
+
+	var report Report
+	if err := json.Unmarshal(body, &report); err != nil {
+		log.Warn("backplane.GetReport decode failed", "cluster_id", clusterID, "report_id", reportID, "error", err)
+		return nil, fmt.Errorf("decode report %s: %w", reportID, err)
+	}
+
+	log.Debug("backplane.GetReport", "cluster_id", clusterID, "report_id", reportID, "summary", report.Summary)
+	return &report, nil
+}
+
+func (c *Client) doRequest(ctx context.Context, endpoint string) ([]byte, error) {
+	token, err := c.tokenFunc()
+	if err != nil {
+		log.Warn("backplane.doRequest", "msg", "token acquisition failed", "error", err)
+		return nil, fmt.Errorf("get access token: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	log.Debug("backplane.doRequest", "endpoint", endpoint)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		log.Warn("backplane.doRequest", "msg", "request failed", "endpoint", endpoint, "error", err)
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response body: %w", err)
+	}
+
+	log.Debug("backplane.doRequest", "endpoint", endpoint, "status", resp.StatusCode, "body_bytes", len(body))
+
+	if resp.StatusCode != http.StatusOK {
+		log.Warn("backplane.doRequest", "msg", "unexpected status", "endpoint", endpoint, "status", resp.StatusCode)
+		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return body, nil
+}

--- a/pkg/backplane/client_test.go
+++ b/pkg/backplane/client_test.go
@@ -1,0 +1,186 @@
+package backplane
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_ListReports(t *testing.T) {
+	reports := listReportsResponse{
+		Reports: []ReportSummary{
+			{ReportID: "rpt-1", Summary: "test report", CreatedAt: "2026-06-01T00:00:00Z"},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/backplane/cluster/test-cluster/reports", r.URL.Path)
+		assert.Equal(t, "10", r.URL.Query().Get("last"))
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(reports)
+	}))
+	defer server.Close()
+
+	cfg := &Config{URL: server.URL}
+	client := NewClient(cfg, func() (string, error) { return "test-token", nil })
+
+	result, err := client.ListReports(context.Background(), "test-cluster")
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, "rpt-1", result[0].ReportID)
+	assert.Equal(t, "test report", result[0].Summary)
+}
+
+func TestClient_GetReport(t *testing.T) {
+	report := Report{
+		ReportID:  "rpt-1",
+		Summary:   "test report",
+		CreatedAt: "2026-06-01T00:00:00Z",
+		Data:      "dGVzdCBkYXRh",
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/backplane/cluster/test-cluster/reports/rpt-1", r.URL.Path)
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(report)
+	}))
+	defer server.Close()
+
+	cfg := &Config{URL: server.URL}
+	client := NewClient(cfg, func() (string, error) { return "test-token", nil })
+
+	result, err := client.GetReport(context.Background(), "test-cluster", "rpt-1")
+	require.NoError(t, err)
+	assert.Equal(t, "rpt-1", result.ReportID)
+	assert.Equal(t, "dGVzdCBkYXRh", result.Data)
+}
+
+func TestClient_ListReports_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("server error"))
+	}))
+	defer server.Close()
+
+	cfg := &Config{URL: server.URL}
+	client := NewClient(cfg, func() (string, error) { return "test-token", nil })
+
+	result, err := client.ListReports(context.Background(), "test-cluster")
+	assert.Nil(t, result)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected status 500")
+}
+
+func TestClient_EmptyReports(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(listReportsResponse{Reports: []ReportSummary{}})
+	}))
+	defer server.Close()
+
+	cfg := &Config{URL: server.URL}
+	client := NewClient(cfg, func() (string, error) { return "test-token", nil })
+
+	result, err := client.ListReports(context.Background(), "test-cluster")
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestClient_TokenError(t *testing.T) {
+	cfg := &Config{URL: "https://unused.example.com"}
+	client := NewClient(cfg, func() (string, error) {
+		return "", fmt.Errorf("token expired")
+	})
+
+	result, err := client.ListReports(context.Background(), "test-cluster")
+	assert.Nil(t, result)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "token expired")
+}
+
+func TestClient_InvalidJSON_ListReports(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer server.Close()
+
+	cfg := &Config{URL: server.URL}
+	client := NewClient(cfg, func() (string, error) { return "test-token", nil })
+
+	result, err := client.ListReports(context.Background(), "test-cluster")
+	assert.Nil(t, result)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "decode reports response")
+}
+
+func TestClient_InvalidJSON_GetReport(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer server.Close()
+
+	cfg := &Config{URL: server.URL}
+	client := NewClient(cfg, func() (string, error) { return "test-token", nil })
+
+	result, err := client.GetReport(context.Background(), "test-cluster", "rpt-1")
+	assert.Nil(t, result)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "decode report")
+}
+
+func TestNewClient_WithProxy(t *testing.T) {
+	proxyURL := "http://proxy.example.com:3128"
+	cfg := &Config{
+		URL:      "https://backplane.example.com",
+		ProxyURL: &proxyURL,
+		Govcloud: false,
+	}
+	client := NewClient(cfg, func() (string, error) { return "token", nil })
+	assert.NotNil(t, client)
+}
+
+func TestNewClient_GovcloudSkipsProxy(t *testing.T) {
+	proxyURL := "http://proxy.example.com:3128"
+	cfg := &Config{
+		URL:      "https://backplane.example.com",
+		ProxyURL: &proxyURL,
+		Govcloud: true,
+	}
+	client := NewClient(cfg, func() (string, error) { return "token", nil })
+	assert.NotNil(t, client)
+}
+
+func TestNewClient_NilProxy(t *testing.T) {
+	cfg := &Config{
+		URL:      "https://backplane.example.com",
+		ProxyURL: nil,
+	}
+	client := NewClient(cfg, func() (string, error) { return "token", nil })
+	assert.NotNil(t, client)
+}
+
+func TestClient_GetReport_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("not found"))
+	}))
+	defer server.Close()
+
+	cfg := &Config{URL: server.URL}
+	client := NewClient(cfg, func() (string, error) { return "test-token", nil })
+
+	result, err := client.GetReport(context.Background(), "test-cluster", "rpt-missing")
+	assert.Nil(t, result)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected status 404")
+}

--- a/pkg/backplane/config.go
+++ b/pkg/backplane/config.go
@@ -1,0 +1,52 @@
+package backplane
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/charmbracelet/log"
+)
+
+const (
+	configDir  = ".config/backplane"
+	configFile = "config.json"
+)
+
+// Config holds the backplane configuration loaded from config.json.
+type Config struct {
+	URL      string  `json:"url"`
+	ProxyURL *string `json:"proxy-url"`
+	Govcloud bool    `json:"govcloud"`
+}
+
+// LoadConfig reads the backplane configuration from ~/.config/backplane/config.json.
+func LoadConfig() (*Config, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("unable to determine home directory: %w", err)
+	}
+
+	path := filepath.Join(home, configDir, configFile)
+	log.Debug("backplane.LoadConfig", "path", path)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		log.Debug("backplane.LoadConfig", "msg", "config file not found", "path", path)
+		return nil, fmt.Errorf("backplane config not found at %s: %w", path, err)
+	}
+
+	var cfg Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		log.Warn("backplane.LoadConfig", "msg", "invalid JSON in config file", "path", path, "error", err)
+		return nil, fmt.Errorf("invalid backplane config at %s: %w", path, err)
+	}
+
+	hasProxy := cfg.ProxyURL != nil && *cfg.ProxyURL != ""
+	if cfg.URL == "" {
+		log.Debug("backplane.LoadConfig", "msg", "config file has no url field, will resolve from OCM", "path", path)
+	}
+	log.Info("backplane.LoadConfig", "path", path, "url_set", cfg.URL != "", "has_proxy", hasProxy, "govcloud", cfg.Govcloud)
+	return &cfg, nil
+}

--- a/pkg/backplane/config_test.go
+++ b/pkg/backplane/config_test.go
@@ -1,0 +1,72 @@
+package backplane
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadConfig_MissingFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	cfg, err := LoadConfig()
+	assert.Nil(t, cfg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "backplane config not found")
+}
+
+func TestLoadConfig_ValidFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	cfgDir := filepath.Join(tmpDir, configDir)
+	require.NoError(t, os.MkdirAll(cfgDir, 0o755))
+
+	proxyURL := "http://proxy.example.com:8080"
+	data, _ := json.Marshal(Config{
+		URL:      "https://backplane.example.com",
+		ProxyURL: &proxyURL,
+		Govcloud: false,
+	})
+	require.NoError(t, os.WriteFile(filepath.Join(cfgDir, configFile), data, 0o644))
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "https://backplane.example.com", cfg.URL)
+	assert.Equal(t, "http://proxy.example.com:8080", *cfg.ProxyURL)
+	assert.False(t, cfg.Govcloud)
+}
+
+func TestLoadConfig_MalformedJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	cfgDir := filepath.Join(tmpDir, configDir)
+	require.NoError(t, os.MkdirAll(cfgDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(cfgDir, configFile), []byte("{invalid}"), 0o644))
+
+	cfg, err := LoadConfig()
+	assert.Nil(t, cfg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid backplane config")
+}
+
+func TestLoadConfig_EmptyURL(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	cfgDir := filepath.Join(tmpDir, configDir)
+	require.NoError(t, os.MkdirAll(cfgDir, 0o755))
+
+	data, _ := json.Marshal(Config{URL: ""})
+	require.NoError(t, os.WriteFile(filepath.Join(cfgDir, configFile), data, 0o644))
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "", cfg.URL)
+}

--- a/pkg/backplane/mock.go
+++ b/pkg/backplane/mock.go
@@ -1,0 +1,82 @@
+package backplane
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// MockClient implements BackplaneClient for testing and dev mode.
+type MockClient struct {
+	Reports map[string][]ReportSummary
+}
+
+// NewMockClient creates a MockClient with initialized maps.
+func NewMockClient() *MockClient {
+	return &MockClient{
+		Reports: make(map[string][]ReportSummary),
+	}
+}
+
+func (m *MockClient) ListReports(_ context.Context, clusterID string) ([]ReportSummary, error) {
+	reports, ok := m.Reports[clusterID]
+	if !ok {
+		return []ReportSummary{}, nil
+	}
+	return reports, nil
+}
+
+func (m *MockClient) GetReport(_ context.Context, clusterID, reportID string) (*Report, error) {
+	reports, ok := m.Reports[clusterID]
+	if !ok {
+		return nil, fmt.Errorf("cluster %q not found", clusterID)
+	}
+	for _, r := range reports {
+		if r.ReportID == reportID {
+			return &Report{
+				ReportID:  r.ReportID,
+				Summary:   r.Summary,
+				CreatedAt: r.CreatedAt,
+				Data:      "mock report data",
+			}, nil
+		}
+	}
+	return nil, fmt.Errorf("report %q not found for cluster %q", reportID, clusterID)
+}
+
+type fixtureReport struct {
+	ReportID  string `json:"report_id"`
+	Summary   string `json:"summary"`
+	CreatedAt string `json:"created_at"`
+}
+
+// LoadMockClientFromFixtures creates a MockClient populated with fixture data.
+func LoadMockClientFromFixtures(dir string) (*MockClient, error) {
+	mock := NewMockClient()
+
+	path := filepath.Join(dir, "clusterreports.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return mock, nil
+		}
+		return mock, fmt.Errorf("loading cluster report fixtures: %w", err)
+	}
+
+	var reports map[string][]fixtureReport
+	if err := json.Unmarshal(data, &reports); err != nil {
+		return mock, fmt.Errorf("parsing cluster report fixtures: %w", err)
+	}
+
+	for id, frs := range reports {
+		var summaries []ReportSummary
+		for _, fr := range frs {
+			summaries = append(summaries, ReportSummary(fr))
+		}
+		mock.Reports[id] = summaries
+	}
+
+	return mock, nil
+}

--- a/pkg/backplane/mock_test.go
+++ b/pkg/backplane/mock_test.go
@@ -1,0 +1,64 @@
+package backplane
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockClient_ImplementsInterface(t *testing.T) {
+	var _ BackplaneClient = &MockClient{}
+}
+
+func TestMockClient_ListReports(t *testing.T) {
+	mock := NewMockClient()
+	mock.Reports["cluster-1"] = []ReportSummary{
+		{ReportID: "rpt-1", Summary: "test", CreatedAt: "2026-06-01T00:00:00Z"},
+	}
+
+	reports, err := mock.ListReports(context.Background(), "cluster-1")
+	require.NoError(t, err)
+	assert.Len(t, reports, 1)
+	assert.Equal(t, "rpt-1", reports[0].ReportID)
+
+	empty, err := mock.ListReports(context.Background(), "nonexistent")
+	require.NoError(t, err)
+	assert.Empty(t, empty)
+}
+
+func TestMockClient_GetReport(t *testing.T) {
+	mock := NewMockClient()
+	mock.Reports["cluster-1"] = []ReportSummary{
+		{ReportID: "rpt-1", Summary: "test", CreatedAt: "2026-06-01T00:00:00Z"},
+	}
+
+	report, err := mock.GetReport(context.Background(), "cluster-1", "rpt-1")
+	require.NoError(t, err)
+	assert.Equal(t, "rpt-1", report.ReportID)
+
+	_, err = mock.GetReport(context.Background(), "cluster-1", "nonexistent")
+	assert.Error(t, err)
+
+	_, err = mock.GetReport(context.Background(), "nonexistent", "rpt-1")
+	assert.Error(t, err)
+}
+
+func TestLoadMockClientFromFixtures(t *testing.T) {
+	fixturesDir := filepath.Join("..", "..", "testdata", "fixtures")
+	mock, err := LoadMockClientFromFixtures(fixturesDir)
+	require.NoError(t, err)
+
+	reports, err := mock.ListReports(context.Background(), "cluster-osd-001")
+	require.NoError(t, err)
+	assert.Len(t, reports, 2)
+	assert.Equal(t, "rpt-cora-001", reports[0].ReportID)
+}
+
+func TestLoadMockClientFromFixtures_MissingFile(t *testing.T) {
+	mock, err := LoadMockClientFromFixtures(t.TempDir())
+	require.NoError(t, err)
+	assert.Empty(t, mock.Reports)
+}

--- a/pkg/ocm/client.go
+++ b/pkg/ocm/client.go
@@ -313,6 +313,27 @@ func (c *Client) GetLimitedSupportHistory(ctx context.Context, clusterID string)
 	return reasons, nil
 }
 
+func (c *Client) GetBackplaneURL() (string, error) {
+	resp, err := c.conn.ClustersMgmt().V1().Environment().Get().Send()
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch OCM environment: %w", err)
+	}
+	url, ok := resp.Body().GetBackplaneURL()
+	if !ok || url == "" {
+		return "", fmt.Errorf("backplane URL not available in OCM environment %q", resp.Body().Name())
+	}
+	log.Debug("ocm.GetBackplaneURL", "url", url, "environment", resp.Body().Name())
+	return url, nil
+}
+
+func (c *Client) GetAccessToken() (string, error) {
+	accessToken, _, err := c.conn.Tokens()
+	if err != nil {
+		return "", fmt.Errorf("failed to get OCM access token: %w", err)
+	}
+	return accessToken, nil
+}
+
 func (c *Client) Close() {
 	if c.conn != nil {
 		c.conn.Close() //nolint:errcheck

--- a/pkg/ocm/mock.go
+++ b/pkg/ocm/mock.go
@@ -45,4 +45,12 @@ func (m *MockClient) GetLimitedSupportHistory(_ context.Context, clusterID strin
 	return reasons, nil
 }
 
+func (m *MockClient) GetAccessToken() (string, error) {
+	return "mock-access-token", nil
+}
+
+func (m *MockClient) GetBackplaneURL() (string, error) {
+	return "https://mock-backplane.example.com", nil
+}
+
 func (m *MockClient) Close() {}

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -43,5 +43,7 @@ type OCMClient interface {
 	GetCluster(ctx context.Context, clusterID string) (*ClusterInfo, error)
 	GetServiceLogs(ctx context.Context, clusterID, externalID string) ([]ServiceLog, error)
 	GetLimitedSupportHistory(ctx context.Context, clusterID string) ([]LimitedSupportReason, error)
+	GetAccessToken() (string, error)
+	GetBackplaneURL() (string, error)
 	Close()
 }

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -19,6 +19,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/log"
 	"github.com/clcollins/srepd/pkg/ai"
+	"github.com/clcollins/srepd/pkg/backplane"
 	pkgconfig "github.com/clcollins/srepd/pkg/config"
 	"github.com/clcollins/srepd/pkg/launcher"
 	"github.com/clcollins/srepd/pkg/ocm"
@@ -183,6 +184,11 @@ type model struct {
 	serviceLogCache       map[string][]ocm.ServiceLog
 	limitedSupportCache   map[string][]ocm.LimitedSupportReason
 
+	// Backplane enrichment state
+	backplaneClient    backplane.BackplaneClient
+	backplaneConfig    *backplane.Config
+	clusterReportCache map[string][]backplane.ReportSummary
+
 	// Flag conditions state
 	flagConditions []FlagCondition
 	flagNextID     int
@@ -223,6 +229,8 @@ func InitialModel(
 	ocmAuthPending bool,
 	aiProvider ai.Provider,
 	agentCLICommand string,
+	backplaneClient backplane.BackplaneClient,
+	backplaneConfig *backplane.Config,
 ) (tea.Model, tea.Cmd) {
 	var err error
 
@@ -273,6 +281,9 @@ func InitialModel(
 		clusterCache:          make(map[string]*ocm.ClusterInfo),
 		serviceLogCache:       make(map[string][]ocm.ServiceLog),
 		limitedSupportCache:   make(map[string][]ocm.LimitedSupportReason),
+		backplaneClient:       backplaneClient,
+		backplaneConfig:       backplaneConfig,
+		clusterReportCache:    make(map[string][]backplane.ReportSummary),
 		chordPrefix:           "ctrl+x",
 		theme:                 theme,
 		styles:                styles,
@@ -330,6 +341,7 @@ func InitialModelWithConfig(
 	ocmClient ocm.OCMClient,
 	aiProvider ai.Provider,
 	agentCLICommand string,
+	backplaneClient backplane.BackplaneClient,
 ) (tea.Model, tea.Cmd) {
 
 	theme := DefaultTheme()
@@ -378,6 +390,8 @@ func InitialModelWithConfig(
 		clusterCache:          make(map[string]*ocm.ClusterInfo),
 		serviceLogCache:       make(map[string][]ocm.ServiceLog),
 		limitedSupportCache:   make(map[string][]ocm.LimitedSupportReason),
+		backplaneClient:       backplaneClient,
+		clusterReportCache:    make(map[string][]backplane.ReportSummary),
 		theme:                 theme,
 		styles:                styles,
 		aiProvider:            aiProvider,
@@ -457,6 +471,7 @@ func (m *model) clearOCMCacheForIncident(incidentID string) {
 			delete(m.clusterCache, cid)
 			delete(m.serviceLogCache, cid)
 			delete(m.limitedSupportCache, cid)
+			delete(m.clusterReportCache, cid)
 			delete(m.clusterEnrichInFlight, cid)
 		}
 	}

--- a/pkg/tui/model_test.go
+++ b/pkg/tui/model_test.go
@@ -1236,16 +1236,22 @@ func TestTabSwitch_TabKey(t *testing.T) {
 			expectedTab: tabCluster,
 		},
 		{
-			name:        "Tab wraps from LimitedSupport to Details",
+			name:        "Tab from LimitedSupport goes to Reports",
 			initialTab:  tabLimitedSupport,
+			keyMsg:      tea.KeyMsg{Type: tea.KeyTab},
+			expectedTab: tabReports,
+		},
+		{
+			name:        "Tab wraps from Reports to Details",
+			initialTab:  tabReports,
 			keyMsg:      tea.KeyMsg{Type: tea.KeyTab},
 			expectedTab: tabDetails,
 		},
 		{
-			name:        "Shift+Tab from Details goes to LimitedSupport",
+			name:        "Shift+Tab from Details goes to Reports",
 			initialTab:  tabDetails,
 			keyMsg:      tea.KeyMsg{Type: tea.KeyShiftTab},
-			expectedTab: tabLimitedSupport,
+			expectedTab: tabReports,
 		},
 		{
 			name:        "Shift+Tab from Alerts goes to Details",
@@ -1450,7 +1456,7 @@ func TestInitialModel_ValidConfig(t *testing.T) {
 			},
 		}
 
-		teaModel, cmd := InitialModelWithConfig(config, editor, l, false, nil, nil, "")
+		teaModel, cmd := InitialModelWithConfig(config, editor, l, false, nil, nil, "", nil)
 		assert.NotNil(t, teaModel, "InitialModelWithConfig should return a non-nil model")
 		assert.NotNil(t, cmd, "InitialModelWithConfig should return a non-nil cmd")
 
@@ -1477,7 +1483,7 @@ func TestInitialModel_DebugFlag(t *testing.T) {
 			},
 		}
 
-		teaModel, _ := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, true, nil, nil, "")
+		teaModel, _ := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, true, nil, nil, "", nil)
 		m := teaModel.(model)
 
 		assert.True(t, m.debug, "debug should be true when passed as true")
@@ -1486,7 +1492,7 @@ func TestInitialModel_DebugFlag(t *testing.T) {
 
 func TestInitialModelWithConfig_NilConfig(t *testing.T) {
 	t.Run("nil config sets m.err", func(t *testing.T) {
-		teaModel, cmd := InitialModelWithConfig(nil, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil, "")
+		teaModel, cmd := InitialModelWithConfig(nil, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil, "", nil)
 		m := teaModel.(model)
 
 		assert.NotNil(t, m.err, "m.err should be set when config is nil")
@@ -1504,7 +1510,7 @@ func TestInitialModelWithConfig_SetsConfig(t *testing.T) {
 			},
 		}
 
-		teaModel, _ := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil, "")
+		teaModel, _ := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil, "", nil)
 		m := teaModel.(model)
 
 		assert.Equal(t, config, m.config, "config should be stored on the model")
@@ -1521,7 +1527,7 @@ func TestInitialModelWithConfig_CmdReturnsErrMsg(t *testing.T) {
 			},
 		}
 
-		_, cmd := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil, "")
+		_, cmd := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil, "", nil)
 		assert.NotNil(t, cmd, "cmd should be non-nil")
 
 		msg := cmd()
@@ -1533,7 +1539,7 @@ func TestInitialModelWithConfig_CmdReturnsErrMsg(t *testing.T) {
 
 func TestInitialModelWithConfig_CmdReturnsErrMsgForNilConfig(t *testing.T) {
 	t.Run("cmd produces errMsg with non-nil error for nil config", func(t *testing.T) {
-		_, cmd := InitialModelWithConfig(nil, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil, "")
+		_, cmd := InitialModelWithConfig(nil, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil, "", nil)
 		assert.NotNil(t, cmd, "cmd should be non-nil")
 
 		msg := cmd()
@@ -1552,7 +1558,7 @@ func TestInitialModel_ScheduledJobsInitialized(t *testing.T) {
 			},
 		}
 
-		teaModel, _ := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil, "")
+		teaModel, _ := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil, "", nil)
 		m := teaModel.(model)
 
 		assert.GreaterOrEqual(t, len(m.scheduledJobs), 1, "should have at least one scheduled job (PollIncidents)")
@@ -1568,7 +1574,7 @@ func TestInitialModel_MarkdownRenderer(t *testing.T) {
 			},
 		}
 
-		teaModel, _ := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil, "")
+		teaModel, _ := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil, "", nil)
 		m := teaModel.(model)
 
 		// markdownRenderer should be non-nil (created by NewTermRenderer)
@@ -1753,7 +1759,7 @@ func TestInitialModelWithConfig_FieldInitialization(t *testing.T) {
 	launcher := launcher.ClusterLauncher{}
 	debug := true
 
-	result, cmd := InitialModelWithConfig(mockConfig, editor, launcher, debug, nil, nil, "")
+	result, cmd := InitialModelWithConfig(mockConfig, editor, launcher, debug, nil, nil, "", nil)
 
 	assert.NotNil(t, result, "model should not be nil")
 	assert.NotNil(t, cmd, "cmd should not be nil")

--- a/pkg/tui/ocm_enrichment.go
+++ b/pkg/tui/ocm_enrichment.go
@@ -6,6 +6,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/log"
+	"github.com/clcollins/srepd/pkg/backplane"
 	"github.com/clcollins/srepd/pkg/ocm"
 )
 
@@ -26,6 +27,12 @@ type ocmServiceLogsMsg struct {
 type limitedSupportMsg struct {
 	clusterID string
 	reasons   []ocm.LimitedSupportReason
+	err       error
+}
+
+type clusterReportsMsg struct {
+	clusterID string
+	reports   []backplane.ReportSummary
 	err       error
 }
 
@@ -85,5 +92,16 @@ func getLimitedSupportHistory(client ocm.OCMClient, clusterID, cacheKey string) 
 		reasons, err := client.GetLimitedSupportHistory(ctx, clusterID)
 		log.Debug("ocm.GetLimitedSupportHistory", "cluster_id", clusterID, "count", len(reasons))
 		return limitedSupportMsg{clusterID: cacheKey, reasons: reasons, err: err}
+	}
+}
+
+func getClusterReports(client backplane.BackplaneClient, clusterID, cacheKey string) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), ocmAPITimeout)
+		defer cancel()
+		log.Debug("backplane.ListReports", "cluster_id", clusterID)
+		reports, err := client.ListReports(ctx, clusterID)
+		log.Debug("backplane.ListReports", "cluster_id", clusterID, "count", len(reports))
+		return clusterReportsMsg{clusterID: cacheKey, reports: reports, err: err}
 	}
 }

--- a/pkg/tui/ocm_enrichment_test.go
+++ b/pkg/tui/ocm_enrichment_test.go
@@ -293,7 +293,7 @@ func TestInitialModelWithConfig_MapsInitialized(t *testing.T) {
 			Client: &pd.MockPagerDutyClient{},
 		}
 
-		teaModel, _ := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil, "")
+		teaModel, _ := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil, "", nil)
 		m := teaModel.(model)
 
 		assert.NotNil(t, m.incidentClusterMap, "incidentClusterMap should be initialized")

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -15,6 +15,7 @@ import (
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/log"
 	"github.com/clcollins/srepd/pkg/alert"
+	"github.com/clcollins/srepd/pkg/backplane"
 	pkgconfig "github.com/clcollins/srepd/pkg/config"
 	"github.com/clcollins/srepd/pkg/ocm"
 	"github.com/clcollins/srepd/pkg/pd"
@@ -131,7 +132,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		reflect.TypeOf(spinner.TickMsg{}),
 		reflect.TypeOf(tea.MouseMsg{}),
 		reflect.TypeOf(ocmServiceLogsMsg{}),
-		reflect.TypeOf(limitedSupportMsg{}):
+		reflect.TypeOf(limitedSupportMsg{}),
+		reflect.TypeOf(clusterReportsMsg{}):
 		shouldLog = false
 	}
 
@@ -357,6 +359,24 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.ocmClient = msg.Client
 		log.Info("OCM connected (async)")
+
+		if m.backplaneClient == nil && m.backplaneConfig != nil {
+			if m.backplaneConfig.URL == "" {
+				resolvedURL, urlErr := msg.Client.GetBackplaneURL()
+				if urlErr != nil {
+					log.Warn("Backplane URL resolution from OCM failed (deferred)", "error", urlErr)
+				} else {
+					m.backplaneConfig.URL = resolvedURL
+					log.Info("Backplane URL resolved from OCM (deferred)", "url", resolvedURL)
+				}
+			}
+			if m.backplaneConfig.URL != "" {
+				m.backplaneClient = backplane.NewClient(m.backplaneConfig, msg.Client.GetAccessToken)
+				log.Info("Backplane client initialized (deferred)")
+			} else {
+				log.Warn("Backplane client not created (deferred): no URL available")
+			}
+		}
 
 		var enrichCmds []tea.Cmd
 		for _, clusterIDs := range m.incidentClusterMap {
@@ -1487,6 +1507,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				)
 			}
 		}
+		if m.backplaneClient != nil {
+			if _, cached := m.clusterReportCache[cacheKey]; !cached {
+				phase2Cmds = append(phase2Cmds,
+					getClusterReports(m.backplaneClient, internalID, cacheKey),
+				)
+			}
+		}
 
 		// Rebuild table immediately so display names update
 		incidents := m.incidentList
@@ -1526,6 +1553,18 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.limitedSupportCache[msg.clusterID] = msg.reasons
 		log.Debug("ocm.GetLimitedSupportHistory cached", "cluster_id", msg.clusterID, "count", len(msg.reasons))
+		return m, nil
+
+	case clusterReportsMsg:
+		if msg.err != nil {
+			log.Debug("backplane.ListReports failed", "cluster_id", msg.clusterID, "error", msg.err)
+			return m, nil
+		}
+		if m.clusterReportCache == nil {
+			m.clusterReportCache = make(map[string][]backplane.ReportSummary)
+		}
+		m.clusterReportCache[msg.clusterID] = msg.reports
+		log.Debug("backplane.ListReports cached", "cluster_id", msg.clusterID, "count", len(msg.reports))
 		return m, nil
 
 	case updateAvailableMsg:

--- a/pkg/tui/update_test.go
+++ b/pkg/tui/update_test.go
@@ -334,7 +334,7 @@ func TestDevModeFieldSet(t *testing.T) {
 			Client: &pd.MockPagerDutyClient{},
 		}
 
-		teaModel, _ := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil, "")
+		teaModel, _ := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil, "", nil)
 		m := teaModel.(model)
 
 		assert.True(t, m.devMode, "devMode should be true for InitialModelWithConfig")

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -15,6 +15,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/log"
 	"github.com/clcollins/srepd/pkg/alert"
+	"github.com/clcollins/srepd/pkg/backplane"
 	"github.com/clcollins/srepd/pkg/ocm"
 )
 
@@ -304,6 +305,8 @@ func (m model) renderTabContent() (string, error) {
 		return m.renderServiceLogsTab()
 	case tabLimitedSupport:
 		return m.renderLimitedSupportTab()
+	case tabReports:
+		return m.renderClusterReportsTab()
 	}
 	return "", nil
 }
@@ -520,6 +523,48 @@ func (m model) renderLimitedSupportTab() (string, error) {
 		if r.Details != "" {
 			fmt.Fprintf(&content, "\n> %s\n", r.Details)
 		}
+		if i < total-1 {
+			content.WriteString("\n---\n")
+		}
+	}
+	return content.String(), nil
+}
+
+func (m model) renderClusterReportsTab() (string, error) {
+	if m.backplaneClient == nil {
+		return "\n_Backplane not enabled; ensure your ~/.config/backplane/config.json exists and is readable..._\n", nil
+	}
+
+	if len(m.clusterReportCache) == 0 {
+		if m.ocmClient == nil {
+			if m.ocmAuthPending {
+				return "\n_OCM authenticating — complete login in browser..._\n", nil
+			}
+			return "\n_OCM not connected_\n", nil
+		}
+		return "\n_Loading cluster reports..._\n", nil
+	}
+
+	var allReports []backplane.ReportSummary
+	for _, id := range m.sortedClusterIDs() {
+		allReports = append(allReports, m.clusterReportCache[id]...)
+	}
+
+	if len(allReports) == 0 {
+		return "\n_No cluster reports_\n", nil
+	}
+
+	slices.SortFunc(allReports, func(a, b backplane.ReportSummary) int {
+		return strings.Compare(b.CreatedAt, a.CreatedAt)
+	})
+
+	total := len(allReports)
+	var content strings.Builder
+	for i, r := range allReports {
+		fmt.Fprintf(&content, "### Report %d/%d\n\n", i+1, total)
+		fmt.Fprintf(&content, "* ID: %s\n", r.ReportID)
+		fmt.Fprintf(&content, "* Summary: %s\n", r.Summary)
+		fmt.Fprintf(&content, "* Timestamp: %s\n", r.CreatedAt)
 		if i < total-1 {
 			content.WriteString("\n---\n")
 		}
@@ -784,7 +829,8 @@ const (
 	tabCluster        = 3
 	tabServiceLogs    = 4
 	tabLimitedSupport = 5
-	tabCount          = 6
+	tabReports        = 6
+	tabCount          = 7
 )
 
 func tabBorderWithBottom(left, middle, right string) lipgloss.Border {
@@ -836,6 +882,12 @@ func (m model) renderTabBar() string {
 		lsCount += len(m.limitedSupportCache[id])
 	}
 	tabLabels[tabLimitedSupport] = fmt.Sprintf("LS History (%d)", lsCount)
+
+	reportCount := 0
+	for _, id := range incidentClusters {
+		reportCount += len(m.clusterReportCache[id])
+	}
+	tabLabels[tabReports] = fmt.Sprintf("Reports (%d)", reportCount)
 
 	var renderedTabs []string
 	for i, label := range tabLabels {

--- a/testdata/fixtures/clusterreports.json
+++ b/testdata/fixtures/clusterreports.json
@@ -1,0 +1,21 @@
+{
+  "cluster-osd-001": [
+    {
+      "report_id": "rpt-cora-001",
+      "summary": "CORA automated triage: ClusterOperatorDown (monitoring)",
+      "created_at": "2026-06-01T14:30:00Z"
+    },
+    {
+      "report_id": "rpt-cora-002",
+      "summary": "CORA automated triage: KubePersistentVolumeFillingUp",
+      "created_at": "2026-05-28T09:15:00Z"
+    }
+  ],
+  "cluster-osd-002": [
+    {
+      "report_id": "rpt-cora-003",
+      "summary": "CORA automated triage: PodDisruptionBudgetLimitSRE",
+      "created_at": "2026-06-02T11:00:00Z"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds a new **Reports** tab (tab 6) to display CORA cluster diagnostic reports fetched from the backplane API
- New `pkg/backplane/` package with direct HTTP client — no `backplane-cli` dependency
- Reads `~/.config/backplane/config.json` for proxy config, resolves backplane URL from OCM environment metadata
- Graceful degradation when backplane is not configured

Closes #316

## Details

**New package: `pkg/backplane/`**
- `backplane.go` — types (`ReportSummary`, `Report`) and `BackplaneClient` interface
- `config.go` — reads `~/.config/backplane/config.json` (proxy-url, govcloud); accepts empty URL (resolved from OCM)
- `client.go` — HTTP client with Bearer auth from OCM access token, proxy support
- `mock.go` — mock client for dev mode with fixture loading from `testdata/fixtures/clusterreports.json`

**OCMClient interface additions:**
- `GetAccessToken() (string, error)` — extracts OCM access token via `conn.Tokens()` for Bearer auth
- `GetBackplaneURL() (string, error)` — resolves backplane API URL from OCM environment metadata

**TUI integration:**
- New `tabReports` (tab 6) with `renderClusterReportsTab()`
- Phase 2 enrichment dispatches `getClusterReports()` after cluster info resolves
- `clusterReportsMsg` handler caches results per cluster
- Deferred backplane client creation when OCM auth completes asynchronously
- Tab shows "Backplane not enabled; ensure your ~/.config/backplane/config.json exists and is readable..." when unconfigured

**Test coverage:** 92.1% on `pkg/backplane/`

## Test plan

- [ ] `make test-all` passes (fmt, vet, lint, test, race)
- [ ] Dev mode (`srepd --dev`) shows Reports tab with fixture data
- [ ] Live mode with backplane config shows real cluster reports
- [ ] Live mode without backplane config shows "Backplane not enabled..." message
- [ ] Async OCM auth flow creates backplane client after browser auth completes
- [ ] Tab bar shows correct report count per incident

Created with assistance from Claude 🤖 <claude@anthropic.com>