### PR TITLE
CI: Upgrade GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/actions/setup-go-from-mod/action.yml
+++ b/.github/actions/setup-go-from-mod/action.yml
@@ -9,6 +9,6 @@ runs:
         echo "GO_VERSION=$(grep '^go ' go.mod | awk '{print $2}')" >> $GITHUB_ENV
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ env.GO_VERSION }}

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go from go.mod
         uses: ./.github/actions/setup-go-from-mod
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go from go.mod
         uses: ./.github/actions/setup-go-from-mod
@@ -73,13 +73,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go from go.mod
         uses: ./.github/actions/setup-go-from-mod
 
       - name: Cache Go modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/go-build
@@ -97,7 +97,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go from go.mod
         uses: ./.github/actions/setup-go-from-mod
@@ -112,13 +112,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go from go.mod
         uses: ./.github/actions/setup-go-from-mod
 
       - name: Cache Go modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/go-build
@@ -137,13 +137,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go from go.mod
         uses: ./.github/actions/setup-go-from-mod
 
       - name: Cache Go modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/go-build
@@ -156,7 +156,7 @@ jobs:
         run: go test ./... -coverprofile=coverage.out -covermode=atomic
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           files: coverage.out
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -172,7 +172,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go from go.mod
         uses: ./.github/actions/setup-go-from-mod
@@ -187,7 +187,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go from go.mod
         uses: ./.github/actions/setup-go-from-mod

--- a/docs/plans/094-upgrade-ci-actions-node24.md
+++ b/docs/plans/094-upgrade-ci-actions-node24.md
@@ -1,0 +1,29 @@
+# Plan: Upgrade GitHub Actions to Node.js 24-compatible versions (#311)
+
+**Status:** Complete
+**Issue:** #311
+**PR:** TBD
+
+## Problem
+
+GitHub Actions CI emits deprecation warnings for Node.js 20 actions.
+After June 16, 2026, actions will be forced to run with Node.js 24 and
+may break.
+
+## Solution
+
+Bump all action version pins to Node.js 24-compatible releases:
+
+- `actions/checkout` v4 → v6
+- `actions/setup-go` v5 → v6
+- `actions/cache` v4 → v5
+- `codecov/codecov-action` v5 → v6
+
+## Files changed
+
+- `.github/workflows/go-ci.yml` — 14 version pin updates
+- `.github/actions/setup-go-from-mod/action.yml` — 1 version pin update
+
+## Post-mortem / lessons learned
+
+None — straightforward version bumps with no behavioral changes.


### PR DESCRIPTION

## Summary

- Bumps all GitHub Actions to Node.js 24-compatible versions ahead of the June 16, 2026 forced migration deadline: `actions/checkout` v4→v6, `actions/setup-go` v5→v6, `actions/cache` v4→v5, `codecov/codecov-action` v5→v6
- Eliminates CI deprecation warnings for Node.js 20 actions

## Test plan

- [x] `make test-all` passes locally (fmt-check, vet, lint, test, test-race, test-fixtures)
- [x] `make plan-check` passes
- [x] `make readme-check` passes
- [ ] CI passes on PR

Closes #311


💘 Generated with Crush