### PR TITLE
Refactor agent CLI tests to eliminate real subprocess calls

### DIFF
--- a/docs/plans/095-refactor-agent-cli-tests.md
+++ b/docs/plans/095-refactor-agent-cli-tests.md
@@ -1,0 +1,31 @@
+# Plan: Refactor agent CLI tests to eliminate real subprocess calls (#318)
+
+**Status:** Complete
+**Issue:** #318
+**PR:** TBD
+
+## Problem
+
+Several tests in `pkg/tui/claude_test.go` called real system binaries
+(`echo`, `cat`, `sh`) via `exec.CommandContext`. Tests should be fully
+self-contained and not depend on external processes.
+
+## Solution
+
+Introduced a `CommandExecutor` interface that abstracts command execution.
+The default `execCommandExecutor` wraps `os/exec` for production use.
+Tests inject a `mockCommandExecutor` that records arguments and returns
+pre-configured results, eliminating all subprocess calls.
+
+## Files changed
+
+- `pkg/tui/claude.go` — added `CommandExecutor` interface, `execCommandExecutor`
+  default impl; changed `agentQuery` to accept executor parameter
+- `pkg/tui/claude_test.go` — added `mockCommandExecutor`; refactored 7 tests
+  to use mock instead of real binaries
+- `pkg/tui/model.go` — added `cmdExecutor` field; wired into both constructors
+- `pkg/tui/model_test.go` — set `cmdExecutor` in `createTestModel()`
+
+## Post-mortem / lessons learned
+
+None — straightforward interface extraction.

--- a/pkg/tui/claude.go
+++ b/pkg/tui/claude.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -12,6 +13,27 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/log"
 )
+
+// CommandExecutor abstracts command execution so tests can inject a mock
+// instead of spawning real subprocesses.
+type CommandExecutor interface {
+	Execute(ctx context.Context, name string, args []string, stdin io.Reader, env []string) (stdout []byte, stderr string, err error)
+}
+
+// execCommandExecutor is the default implementation that uses os/exec.
+type execCommandExecutor struct{}
+
+func (e *execCommandExecutor) Execute(ctx context.Context, name string, args []string, stdin io.Reader, env []string) ([]byte, string, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdin = stdin
+	cmd.Env = env
+
+	var stderrBuf strings.Builder
+	cmd.Stderr = &stderrBuf
+
+	output, err := cmd.Output()
+	return output, strings.TrimSpace(stderrBuf.String()), err
+}
 
 const (
 	claudeTimeout = 60 * time.Second
@@ -70,8 +92,9 @@ func buildClaudeEnvVars(incident *pagerduty.Incident, alerts []pagerduty.Inciden
 
 // agentQuery dispatches a prompt to the configured CLI agent and returns the
 // response. The command is parsed from the agentCLICommand config string.
-// The prompt is piped via stdin for safety.
-func agentQuery(agentCLICommand string, systemPrompt string, prompt string, incidentContext string, incident *pagerduty.Incident, alerts []pagerduty.IncidentAlert) tea.Cmd {
+// The prompt is piped via stdin for safety. The executor parameter abstracts
+// command execution for testability.
+func agentQuery(executor CommandExecutor, agentCLICommand string, systemPrompt string, prompt string, incidentContext string, incident *pagerduty.Incident, alerts []pagerduty.IncidentAlert) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), claudeTimeout)
 		defer cancel()
@@ -86,18 +109,12 @@ func agentQuery(agentCLICommand string, systemPrompt string, prompt string, inci
 			fullPrompt += "\n\nContext:\n" + incidentContext
 		}
 
-		cmd := exec.CommandContext(ctx, args[0], args[1:]...)
-		cmd.Stdin = strings.NewReader(fullPrompt)
-		cmd.Env = append(os.Environ(), buildClaudeEnvVars(incident, alerts)...)
-
-		var stderr strings.Builder
-		cmd.Stderr = &stderr
+		env := append(os.Environ(), buildClaudeEnvVars(incident, alerts)...)
 
 		log.Debug("tui.agentQuery()", "command", agentCLICommand, "prompt", prompt)
 
-		output, err := cmd.Output()
+		output, stderrStr, err := executor.Execute(ctx, args[0], args[1:], strings.NewReader(fullPrompt), env)
 		if err != nil {
-			stderrStr := strings.TrimSpace(stderr.String())
 			if stderrStr != "" {
 				log.Warn("tui.agentQuery()", "stderr", stderrStr)
 			}
@@ -160,7 +177,7 @@ func (m model) handleClaudePrompt(msg claudePromptMsg, lookPath func(string) (st
 	incidentContext := buildWatcherContext(&m)
 	return m, tea.Batch(
 		m.spinner.Tick,
-		agentQuery(agentCmd, m.agentSystemPrompt, msg.prompt, incidentContext, m.selectedIncident, m.selectedIncidentAlerts),
+		agentQuery(m.cmdExecutor, agentCmd, m.agentSystemPrompt, msg.prompt, incidentContext, m.selectedIncident, m.selectedIncidentAlerts),
 	)
 }
 

--- a/pkg/tui/claude_test.go
+++ b/pkg/tui/claude_test.go
@@ -1,9 +1,9 @@
 package tui
 
 import (
+	"context"
 	"fmt"
-	"os"
-	"path/filepath"
+	"io"
 	"testing"
 
 	"github.com/PagerDuty/go-pagerduty"
@@ -11,6 +11,30 @@ import (
 	pkgconfig "github.com/clcollins/srepd/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
+
+// mockCommandExecutor records the arguments passed to Execute and returns
+// pre-configured results, eliminating all real subprocess calls.
+type mockCommandExecutor struct {
+	name      string
+	args      []string
+	stdinData string
+	env       []string
+
+	stdout []byte
+	stderr string
+	err    error
+}
+
+func (m *mockCommandExecutor) Execute(_ context.Context, name string, args []string, stdin io.Reader, env []string) ([]byte, string, error) {
+	m.name = name
+	m.args = args
+	m.env = env
+	if stdin != nil {
+		data, _ := io.ReadAll(stdin)
+		m.stdinData = string(data)
+	}
+	return m.stdout, m.stderr, m.err
+}
 
 func TestInputCharLimit_Increased(t *testing.T) {
 	// newTextInput should have a CharLimit of 500 (increased from 32)
@@ -324,7 +348,8 @@ func TestDefaultLookPath_NoPanic(t *testing.T) {
 }
 
 func TestAgentQuery_EmptyCommand(t *testing.T) {
-	cmd := agentQuery("", "test system", "test prompt", "", nil, nil)
+	mock := &mockCommandExecutor{}
+	cmd := agentQuery(mock, "", "test system", "test prompt", "", nil, nil)
 	msg := cmd()
 	resp, ok := msg.(claudeResponseMsg)
 	assert.True(t, ok)
@@ -333,25 +358,32 @@ func TestAgentQuery_EmptyCommand(t *testing.T) {
 }
 
 func TestAgentQuery_CommandParsing(t *testing.T) {
-	cmd := agentQuery("echo hello world", "", "ignored", "", nil, nil)
+	mock := &mockCommandExecutor{stdout: []byte("hello world")}
+	cmd := agentQuery(mock, "echo hello world", "", "ignored", "", nil, nil)
 	msg := cmd()
 	resp, ok := msg.(claudeResponseMsg)
 	assert.True(t, ok)
 	assert.NoError(t, resp.err)
 	assert.Equal(t, "hello world", resp.response)
+	assert.Equal(t, "echo", mock.name)
+	assert.Equal(t, []string{"hello", "world"}, mock.args)
 }
 
 func TestAgentQuery_MultiWordCommand(t *testing.T) {
-	cmd := agentQuery("echo -n test", "", "ignored", "", nil, nil)
+	mock := &mockCommandExecutor{stdout: []byte("test")}
+	cmd := agentQuery(mock, "echo -n test", "", "ignored", "", nil, nil)
 	msg := cmd()
 	resp, ok := msg.(claudeResponseMsg)
 	assert.True(t, ok)
 	assert.NoError(t, resp.err)
 	assert.Equal(t, "test", resp.response)
+	assert.Equal(t, "echo", mock.name)
+	assert.Equal(t, []string{"-n", "test"}, mock.args)
 }
 
 func TestAgentQuery_CommandNotFound(t *testing.T) {
-	cmd := agentQuery("nonexistent-binary-99999 --flag", "", "test", "", nil, nil)
+	mock := &mockCommandExecutor{err: fmt.Errorf("exec: \"nonexistent-binary-99999\": executable file not found in $PATH")}
+	cmd := agentQuery(mock, "nonexistent-binary-99999 --flag", "", "test", "", nil, nil)
 	msg := cmd()
 	resp, ok := msg.(claudeResponseMsg)
 	assert.True(t, ok)
@@ -360,11 +392,11 @@ func TestAgentQuery_CommandNotFound(t *testing.T) {
 }
 
 func TestAgentQuery_StderrCaptured(t *testing.T) {
-	script := filepath.Join(t.TempDir(), "fail.sh")
-	err := os.WriteFile(script, []byte("#!/bin/sh\necho oops >&2\nexit 1\n"), 0755)
-	assert.NoError(t, err)
-
-	cmd := agentQuery(script, "", "test", "", nil, nil)
+	mock := &mockCommandExecutor{
+		stderr: "oops",
+		err:    fmt.Errorf("exit status 1"),
+	}
+	cmd := agentQuery(mock, "/bin/fail", "", "test", "", nil, nil)
 	msg := cmd()
 	resp, ok := msg.(claudeResponseMsg)
 	assert.True(t, ok)
@@ -373,9 +405,7 @@ func TestAgentQuery_StderrCaptured(t *testing.T) {
 }
 
 func TestAgentQuery_PassesEnvVars(t *testing.T) {
-	script := filepath.Join(t.TempDir(), "env.sh")
-	err := os.WriteFile(script, []byte("#!/bin/sh\necho $PAGERDUTY_INCIDENT_ID\n"), 0755)
-	assert.NoError(t, err)
+	mock := &mockCommandExecutor{stdout: []byte("ok")}
 
 	incident := &pagerduty.Incident{
 		APIObject: pagerduty.APIObject{ID: "PD999"},
@@ -385,22 +415,33 @@ func TestAgentQuery_PassesEnvVars(t *testing.T) {
 		Service:   pagerduty.APIObject{Summary: "svc"},
 	}
 
-	cmd := agentQuery(script, "", "test", "", incident, nil)
+	cmd := agentQuery(mock, "/bin/agent", "", "test", "", incident, nil)
 	msg := cmd()
 	resp, ok := msg.(claudeResponseMsg)
 	assert.True(t, ok)
 	assert.NoError(t, resp.err)
-	assert.Equal(t, "PD999", resp.response)
+
+	envMap := make(map[string]string)
+	for _, e := range mock.env {
+		for i := 0; i < len(e); i++ {
+			if e[i] == '=' {
+				envMap[e[:i]] = e[i+1:]
+				break
+			}
+		}
+	}
+	assert.Equal(t, "PD999", envMap["PAGERDUTY_INCIDENT_ID"])
 }
 
 func TestAgentQuery_PipesStdin(t *testing.T) {
-	cmd := agentQuery("cat", "test system prompt", "user question here", "", nil, nil)
+	mock := &mockCommandExecutor{stdout: []byte("ok")}
+	cmd := agentQuery(mock, "cat", "test system prompt", "user question here", "", nil, nil)
 	msg := cmd()
 	resp, ok := msg.(claudeResponseMsg)
 	assert.True(t, ok)
 	assert.NoError(t, resp.err)
-	assert.Contains(t, resp.response, "user question here")
-	assert.Contains(t, resp.response, "test system prompt")
+	assert.Contains(t, mock.stdinData, "user question here")
+	assert.Contains(t, mock.stdinData, "test system prompt")
 }
 
 func TestHandleClaudePrompt_DefaultCommand(t *testing.T) {

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -122,6 +122,7 @@ type model struct {
 	// claudeQuerying is true while a Claude CLI query is in progress
 	claudeQuerying      bool
 	agentCLICommand     string
+	cmdExecutor         CommandExecutor
 	agentSystemPrompt   string
 	watcherSystemPrompt string
 
@@ -290,6 +291,7 @@ func InitialModel(
 		configModeRequested:   configMode,
 		aiProvider:            aiProvider,
 		agentCLICommand:       agentCLICommand,
+		cmdExecutor:           &execCommandExecutor{},
 		watcherViewport:       newWatcherViewport(),
 		watcherBuffer:         newWatcherBuffer(50),
 	}
@@ -396,6 +398,7 @@ func InitialModelWithConfig(
 		styles:                styles,
 		aiProvider:            aiProvider,
 		agentCLICommand:       agentCLICommand,
+		cmdExecutor:           &execCommandExecutor{},
 		watcherViewport:       newWatcherViewport(),
 		watcherBuffer:         newWatcherBuffer(50),
 	}

--- a/pkg/tui/model_test.go
+++ b/pkg/tui/model_test.go
@@ -31,6 +31,7 @@ func createTestModel() model {
 		incidentList:    []pagerduty.Incident{},
 		theme:           theme,
 		styles:          styles,
+		cmdExecutor:     &execCommandExecutor{},
 		watcherBuffer:   newWatcherBuffer(50),
 		watcherViewport: newWatcherViewport(),
 		watcherMarker:   emojiWatcherMarker,


### PR DESCRIPTION

## Summary

- Introduces `CommandExecutor` interface to abstract `exec.CommandContext` in `agentQuery`, enabling dependency injection for tests
- Refactors 7 tests (`CommandParsing`, `MultiWordCommand`, `CommandNotFound`, `StderrCaptured`, `PassesEnvVars`, `PipesStdin`, `EmptyCommand`) to use a `mockCommandExecutor` — zero subprocess calls, fully self-contained

## Test plan

- [x] `make test-all` passes locally (fmt-check, vet, lint, test, test-race, test-fixtures)
- [x] `make plan-check` passes
- [x] `make readme-check` passes
- [ ] CI passes on PR

Closes #318


💘 Generated with Crush