### PR TITLE
Add rosa-boundary cluster login support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ If no config file exists, running `srepd` automatically enters the configuration
 | `editor` | `string` | `vim` | Editor for incident notes |
 | `terminal` | `string` | `gnome-terminal` | Terminal emulator for cluster login |
 | `cluster_login_command` | `string` | `ocm backplane login %%CLUSTER_ID%%` | Cluster login command |
+| `rosa_boundary_command` | `string` | `rosa-boundary start-task --cluster-id %%CLUSTER_ID%% --connect` | rosa-boundary cluster login command |
 | `toolbox_mode` | `string` | `auto` | Toolbox detection: `auto`, `true`, or `false` |
 | `chord_prefix` | `string` | `ctrl+x` | Prefix key for chord commands |
 | `flag_marker` | `string` | `🚩 ` | Prefix marker for flagged incidents (alt: `\|►`) |
@@ -106,6 +107,7 @@ teams:
 default_silent_escalation_policy: P654321
 terminal: gnome-terminal
 cluster_login_command: ocm-container --cluster-id %%CLUSTER_ID%%
+rosa_boundary_command: rosa-boundary start-task --cluster-id %%CLUSTER_ID%% --connect
 toolbox_mode: auto
 ```
 
@@ -194,6 +196,14 @@ Press `h` to toggle the help overlay inside srepd.
 | `Tab`/`Shift+Tab`/`←`/`→` | Switch tabs (incident view) | `↑`/`↓` | Scroll within tab |
 
 Chord commands use a configurable prefix (default `ctrl+x`) followed by a second key. Set `chord_prefix` in config to change.
+
+### rosa-boundary Support
+
+SREPD supports [rosa-boundary](https://github.com/openshift-online/rosa-boundary) as
+an alternative cluster login method. Use `ctrl+x b` to open a rosa-boundary session
+for the selected incident's cluster. The default command is
+`rosa-boundary start-task --cluster-id %%CLUSTER_ID%% --connect`. Override via the
+`rosa_boundary_command` config key or `SREPD_ROSA_BOUNDARY_COMMAND` environment variable.
 
 ## Environment Variables
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -98,6 +98,7 @@ func launchTUIWithConfig() {
 		viper.GetStringSlice("ignoredusers"),
 		viper.GetStringSlice("editor"),
 		l,
+		launcher.ClusterLauncher{}, // rosa-boundary not needed in config mode
 		viper.GetBool("debug"),
 		ocmClient,
 		viper.GetStringMapString("colors"),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -215,6 +215,16 @@ func launchTUI() {
 		}
 	}
 
+	var rbl launcher.ClusterLauncher
+	rbCmd := viper.GetString("rosa_boundary_command")
+	if rbCmd != "" {
+		rbl, err = launcher.NewClusterLauncher(viper.GetString("terminal"), rbCmd, viper.GetString("toolbox_mode"))
+		if err != nil {
+			log.Warn("rosa-boundary launcher disabled", "error", err)
+			rbl = launcher.ClusterLauncher{}
+		}
+	}
+
 	m, _ := tui.InitialModel(
 		viper.GetString("token"),
 		viper.GetStringSlice("teams"),
@@ -222,6 +232,7 @@ func launchTUI() {
 		viper.GetStringSlice("ignoredusers"),
 		viper.GetStringSlice("editor"),
 		l,
+		rbl,
 		viper.GetBool("debug"),
 		ocmClient,
 		viper.GetStringMapString("colors"),
@@ -417,6 +428,7 @@ func runDevMode() {
 		config,
 		viper.GetStringSlice("editor"),
 		devLauncher,
+		launcher.ClusterLauncher{}, // rosa-boundary not needed in dev mode
 		viper.GetBool("debug"),
 		ocmMock,
 		nil, // aiProvider — not used in dev mode

--- a/docs/plans/096-rosa-boundary-support.md
+++ b/docs/plans/096-rosa-boundary-support.md
@@ -1,0 +1,48 @@
+# 096: rosa-boundary Cluster Login Support
+
+## Problem
+
+SREPD currently supports a single cluster login method via `cluster_login_command`
+(default: `ocm backplane login`). rosa-boundary is a new CLI for launching ephemeral
+SRE investigation containers on AWS Fargate via ECS Exec, and SREs need to use it
+alongside the existing login flow.
+
+## Approach
+
+Add rosa-boundary as a second, parallel login method accessible via the chord
+`ctrl+x b`. The rosa-boundary command is standardized across all SREs, so the
+default value is written into the config file on first setup.
+
+- New config key `rosa_boundary_command` with default
+  `rosa-boundary start-task --cluster-id %%CLUSTER_ID%% --connect`
+- New chord `ctrl+x b` triggers rosa-boundary login
+- Second `ClusterLauncher` stored on the model, validated at startup
+- Simplified login function that skips PagerDuty env var injection
+  (Fargate containers have their own environment)
+- Multi-cluster incidents reuse the existing cluster selector UI
+
+## Files Changed
+
+- `pkg/config/config.go` - New config key in DefaultOptionalKeys, OptionalKeys,
+  BuildFullConfig()
+- `pkg/tui/model.go` - rosaBoundaryLauncher and rosaBoundaryClusterSelect fields;
+  updated InitialModel/InitialModelWithConfig signatures
+- `pkg/tui/chords.go` - Registered chord "b" with chordRosaBoundaryLogin handler
+- `pkg/tui/commands.go` - rosaBoundaryLoginMsg, rosaBoundaryClusterSelectedMsg types;
+  rosaBoundaryLogin() function
+- `pkg/tui/tui.go` - Update handlers for both new message types
+- `pkg/tui/msgHandlers.go` - Cluster select dispatch checks rosaBoundaryClusterSelect
+- `cmd/root.go` - Creates second launcher, passes to InitialModel
+- `cmd/config.go` - Passes zero-value launcher for config mode
+- `README.md` - Documents new config key and chord
+
+## Testing
+
+- Config: TestDefaultOptionalKeys_RosaBoundaryCommand, updated BuildFullConfig and
+  EndToEnd tests
+- Chords: TestChordRosaBoundaryLogin_Registered, _LauncherDisabled, _LauncherEnabled
+- All existing tests updated for new InitialModel signature
+
+## Post-Mortem / Lessons Learned
+
+(To be filled after merge)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,6 +35,7 @@ var (
 		"emoji":                 "true",
 		"agent_system_prompt":   "You are in read-only investigation mode for SRE PagerDuty incident triage. Suggest commands for the user to run if changes are needed. Do not modify cluster state. All cluster commands must be read-only (oc get, oc describe, NOT oc delete/patch). If a fix requires changes, OUTPUT the commands for the SRE to review and run manually.",
 		"watcher_system_prompt": "You are an SRE assistant with access to PagerDuty incident data and OpenShift cluster information. Provide concise, actionable analysis. Do not suggest destructive commands.",
+		"rosa_boundary_command": "rosa-boundary start-task --cluster-id %%CLUSTER_ID%% --connect",
 	}
 	OptionalKeys = map[string]string{
 		"editor":                             fmt.Sprintf("Editor to use for notes (default: %v)", DefaultOptionalKeys["editor"]),
@@ -47,6 +48,7 @@ var (
 		"emoji":                              "Use emoji markers for flags/agent/watcher (default: true, set false for text fallbacks)",
 		"agent_system_prompt":                "System prompt for :agent CLI queries (customizable per-user)",
 		"watcher_system_prompt":              "System prompt for :watcher LLM queries and ambient analysis (customizable per-user)",
+		"rosa_boundary_command":              fmt.Sprintf("rosa-boundary login command (default: %v)", DefaultOptionalKeys["rosa_boundary_command"]),
 		"colors":                             "Custom color scheme (map of color name to hex value)",
 		"default_silent_escalation_policy":   "Default silent escalation policy ID (auto-discovered via srepd config)",
 		"custom_service_escalation_policies": "Per-service silent policy overrides (service ID → policy ID)",
@@ -379,6 +381,7 @@ func BuildFullConfig(final ResolvedValues, teamNames map[string]string, silentPo
 		{"cluster_login_command", "ocm backplane login %%CLUSTER_ID%%"},
 		{"toolbox_mode", "auto"},
 		{"chord_prefix", "ctrl+x"},
+		{"rosa_boundary_command", "rosa-boundary start-task --cluster-id %%CLUSTER_ID%% --connect"},
 	} {
 		fmt.Fprintf(&sb, "%s: %s\n", entry.key, entry.val)
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1058,6 +1058,13 @@ func TestBuildSummary_TokenMasked(t *testing.T) {
 
 // --- BuildFullConfig tests ---
 
+func TestDefaultOptionalKeys_RosaBoundaryCommand(t *testing.T) {
+	val, ok := DefaultOptionalKeys["rosa_boundary_command"]
+	assert.True(t, ok, "rosa_boundary_command must be in DefaultOptionalKeys")
+	assert.Contains(t, val, "%%CLUSTER_ID%%", "default must contain %%CLUSTER_ID%% placeholder")
+	assert.Contains(t, val, "rosa-boundary", "default must reference the rosa-boundary CLI")
+}
+
 func TestBuildFullConfig_AllFields(t *testing.T) {
 	final := ResolvedValues{
 		Token: "test-token-value",
@@ -1079,6 +1086,7 @@ func TestBuildFullConfig_AllFields(t *testing.T) {
 	assert.Contains(t, output, "cluster_login_command: ocm backplane login %%CLUSTER_ID%%")
 	assert.Contains(t, output, "toolbox_mode: auto")
 	assert.Contains(t, output, "chord_prefix: ctrl+x")
+	assert.Contains(t, output, "rosa_boundary_command: rosa-boundary start-task --cluster-id %%CLUSTER_ID%% --connect")
 }
 
 func TestBuildFullConfig_MinimalNoOptionals(t *testing.T) {
@@ -1441,6 +1449,7 @@ func TestBuildFullConfig_OptionalKeysAreRealValues(t *testing.T) {
 	assert.Equal(t, "ocm backplane login %%CLUSTER_ID%%", parsed["cluster_login_command"])
 	assert.Equal(t, "auto", parsed["toolbox_mode"])
 	assert.Equal(t, "ctrl+x", parsed["chord_prefix"])
+	assert.Equal(t, "rosa-boundary start-task --cluster-id %%CLUSTER_ID%% --connect", parsed["rosa_boundary_command"])
 }
 
 func TestBuildFullConfig_OptionalKeysHaveDescriptionComments(t *testing.T) {
@@ -1499,6 +1508,7 @@ func TestEndToEnd_NewFileWritesRealDefaults(t *testing.T) {
 	assert.Contains(t, parsed["cluster_login_command"], "%%CLUSTER_ID%%")
 	assert.Equal(t, "auto", parsed["toolbox_mode"])
 	assert.Equal(t, "ctrl+x", parsed["chord_prefix"])
+	assert.Contains(t, parsed["rosa_boundary_command"], "%%CLUSTER_ID%%")
 }
 
 // --- CommentOutOldPolicies tests ---

--- a/pkg/tui/chords.go
+++ b/pkg/tui/chords.go
@@ -23,6 +23,7 @@ var chordRegistry = []struct {
 	Hidden      bool
 }{
 	{Key: "?", Description: "show chord help"},
+	{Key: "b", Description: "rosa-boundary login"},
 	{Key: "d", Description: "view debug log"},
 	{Key: "s", Description: "bulk silence", Hidden: true},
 }
@@ -33,6 +34,7 @@ var chordRegistry = []struct {
 func getChordActions() []chordAction {
 	handlers := map[string]func(m model) (tea.Model, tea.Cmd){
 		"?": chordShowHelp,
+		"b": chordRosaBoundaryLogin,
 		"d": chordViewLog,
 		"s": chordBulkSilence,
 	}
@@ -118,6 +120,30 @@ func chordHelpText(prefix string) string {
 		fmt.Fprintf(&b, "%s=%s", entry.Key, entry.Description)
 	}
 	return b.String()
+}
+
+func chordRosaBoundaryLogin(m model) (tea.Model, tea.Cmd) {
+	if !m.rosaBoundaryLauncher.Enabled {
+		m.setStatus("rosa-boundary not configured")
+		return m, nil
+	}
+	if m.viewingIncident {
+		if m.selectedIncident == nil {
+			m.setStatus("no incident selected")
+			return m, nil
+		}
+		if !m.incidentAlertsLoaded {
+			m.setStatus("Loading incident alerts, please wait...")
+			return m, nil
+		}
+		return m, func() tea.Msg { return rosaBoundaryLoginMsg("login") }
+	}
+	return m, doIfIncidentSelected(&m, func() tea.Msg {
+		return waitForSelectedIncidentThenDoMsg{
+			action: func() tea.Msg { return rosaBoundaryLoginMsg("login") },
+			msg:    "wait",
+		}
+	})
 }
 
 // chordBulkSilence enters the bulk-silence incident selection mode.

--- a/pkg/tui/chords_test.go
+++ b/pkg/tui/chords_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/PagerDuty/go-pagerduty"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/clcollins/srepd/pkg/launcher"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -425,5 +426,46 @@ func TestChordViewLog_ReturnsCommand(t *testing.T) {
 		assert.True(t, ok, "command should produce a logFileContentMsg, got %T", result)
 		assert.Contains(t, string(msg), "No log file found",
 			"should indicate log file not found for nonexistent path")
+	})
+}
+
+func TestChordRosaBoundaryLogin_Registered(t *testing.T) {
+	t.Run("rosa-boundary chord is registered", func(t *testing.T) {
+		action := resolveChord("b")
+		assert.NotNil(t, action, "resolveChord should return an action for 'b'")
+		assert.Equal(t, "b", action.Key)
+		assert.Equal(t, "rosa-boundary login", action.Description)
+	})
+}
+
+func TestChordRosaBoundaryLogin_LauncherDisabled(t *testing.T) {
+	t.Run("rosa-boundary login with disabled launcher shows status", func(t *testing.T) {
+		m := createTestModel()
+		m.rosaBoundaryLauncher = launcher.ClusterLauncher{}
+
+		result, cmd := chordRosaBoundaryLogin(m)
+		updated := result.(model)
+
+		assert.Contains(t, updated.status, "rosa-boundary not configured")
+		assert.Nil(t, cmd)
+	})
+}
+
+func TestChordRosaBoundaryLogin_LauncherEnabled(t *testing.T) {
+	t.Run("rosa-boundary login with enabled launcher returns message from incident view", func(t *testing.T) {
+		m := createTestModel()
+		m.rosaBoundaryLauncher = launcher.ClusterLauncher{Enabled: true}
+		m.viewingIncident = true
+		m.selectedIncident = &pagerduty.Incident{
+			APIObject: pagerduty.APIObject{ID: "P123"},
+		}
+		m.incidentAlertsLoaded = true
+
+		_, cmd := chordRosaBoundaryLogin(m)
+		assert.NotNil(t, cmd, "should return a command")
+
+		msg := cmd()
+		_, ok := msg.(rosaBoundaryLoginMsg)
+		assert.True(t, ok, "command should produce rosaBoundaryLoginMsg, got %T", msg)
 	})
 }

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -526,6 +526,10 @@ type loginMsg string
 // multi-cluster selection prompt. The string value is the cluster_id.
 type clusterSelectedMsg string
 
+type rosaBoundaryLoginMsg string
+
+type rosaBoundaryClusterSelectedMsg string
+
 type loginFinishedMsg struct {
 	err error
 }
@@ -731,6 +735,33 @@ func login(vars map[string]string, l launcher.ClusterLauncher, incident *pagerdu
 		err := c.Wait()
 		if err != nil {
 			log.Debug("tui.login(): terminal process exited", "error", err)
+		}
+	}()
+
+	return func() tea.Msg {
+		return loginFinishedMsg{}
+	}
+}
+
+func rosaBoundaryLogin(vars map[string]string, l launcher.ClusterLauncher) tea.Cmd {
+	command := l.BuildLoginCommand(vars)
+
+	c := exec.Command(command[0], command[1:]...)
+
+	log.Debug("tui.rosaBoundaryLogin()", "command", c.String())
+
+	startCmdErr := c.Start()
+	if startCmdErr != nil {
+		log.Error("tui.rosaBoundaryLogin()", "error", startCmdErr)
+		return func() tea.Msg {
+			return loginFinishedMsg{startCmdErr}
+		}
+	}
+
+	go func() {
+		err := c.Wait()
+		if err != nil {
+			log.Debug("tui.rosaBoundaryLogin(): terminal process exited", "error", err)
 		}
 	}()
 

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -59,9 +59,10 @@ var initialScheduledJobs = []*scheduledJob{
 type model struct {
 	err error
 
-	config   *pd.Config
-	editor   []string
-	launcher launcher.ClusterLauncher
+	config               *pd.Config
+	editor               []string
+	launcher             launcher.ClusterLauncher
+	rosaBoundaryLauncher launcher.ClusterLauncher
 
 	table table.Model
 	input textinput.Model
@@ -105,10 +106,11 @@ type model struct {
 
 	// clusterSelectMode is true when the user must choose which cluster to log into
 	// because the incident has alerts referencing multiple distinct cluster_ids.
-	clusterSelectMode    bool
-	clusterSelectOptions []string
-	clusterSelectTable   table.Model
-	clusterSelectPrompt  string
+	clusterSelectMode         bool
+	clusterSelectOptions      []string
+	clusterSelectTable        table.Model
+	clusterSelectPrompt       string
+	rosaBoundaryClusterSelect bool
 
 	// chordPending is true when the chord prefix key has been pressed and
 	// the system is waiting for the second key to complete the chord.
@@ -221,6 +223,7 @@ func InitialModel(
 	ignoredusers []string,
 	editor []string,
 	launcher launcher.ClusterLauncher,
+	rosaBoundaryLauncher launcher.ClusterLauncher,
 	debug bool,
 	ocmClient ocm.OCMClient,
 	colors map[string]string,
@@ -259,6 +262,7 @@ func InitialModel(
 
 		editor:                editor,
 		launcher:              launcher,
+		rosaBoundaryLauncher:  rosaBoundaryLauncher,
 		debug:                 debug,
 		help:                  newHelp(),
 		table:                 t,
@@ -339,6 +343,7 @@ func InitialModelWithConfig(
 	config *pd.Config,
 	editor []string,
 	launcher launcher.ClusterLauncher,
+	rosaBoundaryLauncher launcher.ClusterLauncher,
 	debug bool,
 	ocmClient ocm.OCMClient,
 	aiProvider ai.Provider,
@@ -369,6 +374,7 @@ func InitialModelWithConfig(
 
 		editor:                editor,
 		launcher:              launcher,
+		rosaBoundaryLauncher:  rosaBoundaryLauncher,
 		debug:                 debug,
 		help:                  newHelp(),
 		table:                 t,

--- a/pkg/tui/model_test.go
+++ b/pkg/tui/model_test.go
@@ -1457,7 +1457,7 @@ func TestInitialModel_ValidConfig(t *testing.T) {
 			},
 		}
 
-		teaModel, cmd := InitialModelWithConfig(config, editor, l, false, nil, nil, "", nil)
+		teaModel, cmd := InitialModelWithConfig(config, editor, l, launcher.ClusterLauncher{}, false, nil, nil, "", nil)
 		assert.NotNil(t, teaModel, "InitialModelWithConfig should return a non-nil model")
 		assert.NotNil(t, cmd, "InitialModelWithConfig should return a non-nil cmd")
 
@@ -1484,7 +1484,7 @@ func TestInitialModel_DebugFlag(t *testing.T) {
 			},
 		}
 
-		teaModel, _ := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, true, nil, nil, "", nil)
+		teaModel, _ := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, launcher.ClusterLauncher{}, true, nil, nil, "", nil)
 		m := teaModel.(model)
 
 		assert.True(t, m.debug, "debug should be true when passed as true")
@@ -1493,7 +1493,7 @@ func TestInitialModel_DebugFlag(t *testing.T) {
 
 func TestInitialModelWithConfig_NilConfig(t *testing.T) {
 	t.Run("nil config sets m.err", func(t *testing.T) {
-		teaModel, cmd := InitialModelWithConfig(nil, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil, "", nil)
+		teaModel, cmd := InitialModelWithConfig(nil, []string{"vi"}, launcher.ClusterLauncher{}, launcher.ClusterLauncher{}, false, nil, nil, "", nil)
 		m := teaModel.(model)
 
 		assert.NotNil(t, m.err, "m.err should be set when config is nil")
@@ -1511,7 +1511,7 @@ func TestInitialModelWithConfig_SetsConfig(t *testing.T) {
 			},
 		}
 
-		teaModel, _ := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil, "", nil)
+		teaModel, _ := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, launcher.ClusterLauncher{}, false, nil, nil, "", nil)
 		m := teaModel.(model)
 
 		assert.Equal(t, config, m.config, "config should be stored on the model")
@@ -1528,7 +1528,7 @@ func TestInitialModelWithConfig_CmdReturnsErrMsg(t *testing.T) {
 			},
 		}
 
-		_, cmd := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil, "", nil)
+		_, cmd := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, launcher.ClusterLauncher{}, false, nil, nil, "", nil)
 		assert.NotNil(t, cmd, "cmd should be non-nil")
 
 		msg := cmd()
@@ -1540,7 +1540,7 @@ func TestInitialModelWithConfig_CmdReturnsErrMsg(t *testing.T) {
 
 func TestInitialModelWithConfig_CmdReturnsErrMsgForNilConfig(t *testing.T) {
 	t.Run("cmd produces errMsg with non-nil error for nil config", func(t *testing.T) {
-		_, cmd := InitialModelWithConfig(nil, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil, "", nil)
+		_, cmd := InitialModelWithConfig(nil, []string{"vi"}, launcher.ClusterLauncher{}, launcher.ClusterLauncher{}, false, nil, nil, "", nil)
 		assert.NotNil(t, cmd, "cmd should be non-nil")
 
 		msg := cmd()
@@ -1559,7 +1559,7 @@ func TestInitialModel_ScheduledJobsInitialized(t *testing.T) {
 			},
 		}
 
-		teaModel, _ := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil, "", nil)
+		teaModel, _ := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, launcher.ClusterLauncher{}, false, nil, nil, "", nil)
 		m := teaModel.(model)
 
 		assert.GreaterOrEqual(t, len(m.scheduledJobs), 1, "should have at least one scheduled job (PollIncidents)")
@@ -1575,7 +1575,7 @@ func TestInitialModel_MarkdownRenderer(t *testing.T) {
 			},
 		}
 
-		teaModel, _ := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil, "", nil)
+		teaModel, _ := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, launcher.ClusterLauncher{}, false, nil, nil, "", nil)
 		m := teaModel.(model)
 
 		// markdownRenderer should be non-nil (created by NewTermRenderer)
@@ -1757,10 +1757,10 @@ func TestInitialModelWithConfig_FieldInitialization(t *testing.T) {
 		},
 	}
 	editor := []string{"vim"}
-	launcher := launcher.ClusterLauncher{}
+	l := launcher.ClusterLauncher{}
 	debug := true
 
-	result, cmd := InitialModelWithConfig(mockConfig, editor, launcher, debug, nil, nil, "", nil)
+	result, cmd := InitialModelWithConfig(mockConfig, editor, l, launcher.ClusterLauncher{}, debug, nil, nil, "", nil)
 
 	assert.NotNil(t, result, "model should not be nil")
 	assert.NotNil(t, cmd, "cmd should not be nil")

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -378,6 +378,7 @@ func switchClusterSelectFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(msg, defaultKeyMap.Back):
 			m.clusterSelectMode = false
 			m.clusterSelectOptions = nil
+			m.rosaBoundaryClusterSelect = false
 			m.setStatus("cluster selection cancelled")
 			m.table.Focus()
 			return m, nil
@@ -389,9 +390,14 @@ func switchClusterSelectFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			selected := selectedRow[0]
+			isRosaBoundary := m.rosaBoundaryClusterSelect
 			m.clusterSelectMode = false
 			m.clusterSelectOptions = nil
+			m.rosaBoundaryClusterSelect = false
 			m.table.Focus()
+			if isRosaBoundary {
+				return m, func() tea.Msg { return rosaBoundaryClusterSelectedMsg(selected) }
+			}
 			return m, func() tea.Msg { return clusterSelectedMsg(selected) }
 
 		default:

--- a/pkg/tui/ocm_enrichment_test.go
+++ b/pkg/tui/ocm_enrichment_test.go
@@ -293,7 +293,7 @@ func TestInitialModelWithConfig_MapsInitialized(t *testing.T) {
 			Client: &pd.MockPagerDutyClient{},
 		}
 
-		teaModel, _ := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil, "", nil)
+		teaModel, _ := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, launcher.ClusterLauncher{}, false, nil, nil, "", nil)
 		m := teaModel.(model)
 
 		assert.NotNil(t, m.incidentClusterMap, "incidentClusterMap should be initialized")

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -1078,6 +1078,78 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			"alert", alert.ExtractAlertName(m.selectedIncident.Title))
 		cmds = append(cmds, login(vars, m.launcher, m.selectedIncident, m.selectedIncidentAlerts, m.selectedIncidentNotes))
 
+	case rosaBoundaryLoginMsg:
+		if m.selectedIncident == nil {
+			m.setStatus("unable to login via rosa-boundary - no selected incident")
+			return m, nil
+		}
+
+		if len(m.selectedIncidentAlerts) == 0 {
+			log.Debug("tui.Update()", "msg_type", reflect.TypeOf(msg), "msg", "no alerts found for incident - requeuing")
+			return m, func() tea.Msg { return rosaBoundaryLoginMsg("requeue") }
+		}
+
+		clusters := getUniqueClusters(m.selectedIncidentAlerts)
+
+		var cluster string
+		switch len(clusters) {
+		case 0:
+			return m, m.flashNotification("No cluster_id found in alerts — cannot login via rosa-boundary")
+		case 1:
+			cluster = clusters[0]
+			m.setStatus(fmt.Sprintf("rosa-boundary login to cluster %s", cluster))
+		default:
+			m.clusterSelectMode = true
+			m.rosaBoundaryClusterSelect = true
+			m.clusterSelectOptions = clusters
+			m.clusterSelectPrompt = "Select cluster for rosa-boundary login (Enter=select, Esc=cancel):"
+			clusterServices := mapClusterServices(m.selectedIncidentAlerts)
+			cols := []table.Column{
+				{Title: "Cluster ID", Width: m.layout.ClusterSelectClusterIDWidth},
+				{Title: "Service", Width: m.layout.ClusterSelectServiceWidth},
+			}
+			var rows []table.Row
+			for _, c := range clusters {
+				rows = append(rows, table.Row{c, clusterServices[c]})
+			}
+			m.clusterSelectTable = table.New(table.WithColumns(cols), table.WithRows(rows), table.WithFocused(true))
+			m.clusterSelectTable.SetStyles(m.styles.Table)
+			return m, nil
+		}
+
+		var vars = map[string]string{
+			"%%CLUSTER_ID%%":  cluster,
+			"%%INCIDENT_ID%%": m.selectedIncident.ID,
+		}
+
+		log.Info("rosa-boundary login initiated",
+			"user_id", m.config.CurrentUser.ID,
+			"cluster_id", cluster,
+			"reason", m.selectedIncident.HTMLURL,
+			"alert", alert.ExtractAlertName(m.selectedIncident.Title))
+		cmds = append(cmds, rosaBoundaryLogin(vars, m.rosaBoundaryLauncher))
+
+	case rosaBoundaryClusterSelectedMsg:
+		if m.selectedIncident == nil {
+			m.setStatus("unable to login via rosa-boundary - no selected incident")
+			return m, nil
+		}
+
+		cluster := string(msg)
+		m.setStatus(fmt.Sprintf("rosa-boundary login to cluster %s", cluster))
+
+		var vars = map[string]string{
+			"%%CLUSTER_ID%%":  cluster,
+			"%%INCIDENT_ID%%": m.selectedIncident.ID,
+		}
+
+		log.Info("rosa-boundary login initiated",
+			"user_id", m.config.CurrentUser.ID,
+			"cluster_id", cluster,
+			"reason", m.selectedIncident.HTMLURL,
+			"alert", alert.ExtractAlertName(m.selectedIncident.Title))
+		cmds = append(cmds, rosaBoundaryLogin(vars, m.rosaBoundaryLauncher))
+
 	case loginFinishedMsg:
 		if msg.err != nil {
 			m.status = fmt.Sprintf("failed to login: %s", msg.err)

--- a/pkg/tui/update_test.go
+++ b/pkg/tui/update_test.go
@@ -334,7 +334,7 @@ func TestDevModeFieldSet(t *testing.T) {
 			Client: &pd.MockPagerDutyClient{},
 		}
 
-		teaModel, _ := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, false, nil, nil, "", nil)
+		teaModel, _ := InitialModelWithConfig(config, []string{"vi"}, launcher.ClusterLauncher{}, launcher.ClusterLauncher{}, false, nil, nil, "", nil)
 		m := teaModel.(model)
 
 		assert.True(t, m.devMode, "devMode should be true for InitialModelWithConfig")


### PR DESCRIPTION
## Summary
- Adds rosa-boundary as a second, parallel cluster login method via the `ctrl+x b` chord
- New config key `rosa_boundary_command` with default `rosa-boundary start-task --cluster-id %%CLUSTER_ID%% --connect`
- Simplified login function that skips PagerDuty env var injection (Fargate containers have their own environment)

## Test plan
- [x] `make fmt-check` passes
- [x] `make vet` passes
- [x] `make lint` — 0 issues
- [x] `make test` — all pass
- [x] `make test-race` — all pass
- [x] `make test-fixtures` — all pass
- [x] `make readme-check` — pass
- [ ] CI pipeline passes all checks
- [ ] Manual test: `ctrl+x b` on an incident with rosa-boundary installed opens session
- [ ] Manual test: `ctrl+x b` without rosa-boundary shows "rosa-boundary not configured"

🤖 Generated with [Claude Code](https://claude.com/claude-code)