### PR TITLE
Add test coverage for dependency touch points

### DIFF
--- a/docs/plans/336-dep-coverage-tests.md
+++ b/docs/plans/336-dep-coverage-tests.md
@@ -1,0 +1,37 @@
+# Plan: Add test coverage for Dependabot dependency touch points (#336)
+
+**Status:** Complete
+**PR:** #336
+
+## Problem
+
+Three open Dependabot PRs update dependencies (glamour/v2, ocm-sdk-go,
+ocm-common) but the functions that directly use these dependencies lack
+unit test coverage. Without tests exercising these touch points, a
+breaking change in a dependency bump could go undetected.
+
+## Solution
+
+Add targeted unit tests for the functions that directly consume these
+dependencies:
+
+### glamour/v2 — `buildGlamourStyle`
+
+`pkg/tui/theme.go:buildGlamourStyle` converts a Theme into a glamour
+`ansi.StyleConfig`. It was the only glamour-consuming function without
+tests. New tests verify all color mappings, bold flags, and background
+clearing.
+
+### ocm-sdk-go — `clusterFromResponse`
+
+`pkg/ocm/client.go:clusterFromResponse` converts an OCM SDK
+`cmv1.Cluster` into a local `ClusterInfo`. Tests use the SDK's builder
+API (`cmv1.NewCluster()`) to construct realistic cluster objects and
+verify field mapping, display name logic (DomainPrefix + DNS), and
+nil-safety for optional fields (Region, Hypershift, CCS, Subscription).
+
+### ocm-common
+
+Already well-tested via `CheckTokens`, `ApplyAuthToken`, and config
+loading tests. The `clusterFromResponse` tests indirectly exercise the
+types that flow through the ocm-common connection builder.

--- a/pkg/ocm/client_test.go
+++ b/pkg/ocm/client_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	ocmconfig "github.com/openshift-online/ocm-common/pkg/ocm/config"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
 func TestCheckTokens_NoConfigFile(t *testing.T) {
@@ -120,5 +121,109 @@ func TestNewClientFromConfig_NilConfig(t *testing.T) {
 		_, err := NewClientFromConfig(nil, "test-version")
 
 		assert.Error(t, err)
+	})
+}
+
+func TestClusterFromResponse(t *testing.T) {
+	t.Run("basic field mapping", func(t *testing.T) {
+		cluster, err := cmv1.NewCluster().
+			ID("internal-id-123").
+			ExternalID("ext-uuid-456").
+			Name("mycluster").
+			OpenshiftVersion("4.16.38").
+			State(cmv1.ClusterStateReady).
+			Build()
+		require.NoError(t, err)
+
+		info := clusterFromResponse(cluster)
+
+		assert.Equal(t, "internal-id-123", info.ID)
+		assert.Equal(t, "ext-uuid-456", info.ExternalID)
+		assert.Equal(t, "mycluster", info.Name)
+		assert.Equal(t, "mycluster", info.DisplayName)
+		assert.Equal(t, "4.16.38", info.Version)
+		assert.Equal(t, "ready", info.State)
+	})
+
+	t.Run("display name uses domain prefix and DNS", func(t *testing.T) {
+		cluster, err := cmv1.NewCluster().
+			ID("id-1").
+			Name("mycluster").
+			DomainPrefix("mycluster").
+			DNS(cmv1.NewDNS().BaseDomain("abc1.p1.openshiftapps.com")).
+			Build()
+		require.NoError(t, err)
+
+		info := clusterFromResponse(cluster)
+
+		assert.Equal(t, "mycluster.abc1.p1.openshiftapps.com", info.DisplayName)
+		assert.Equal(t, "mycluster", info.Name)
+	})
+
+	t.Run("region extraction", func(t *testing.T) {
+		cluster, err := cmv1.NewCluster().
+			ID("id-1").
+			Name("test").
+			Region(cmv1.NewCloudRegion().ID("us-east-1")).
+			Build()
+		require.NoError(t, err)
+
+		info := clusterFromResponse(cluster)
+
+		assert.Equal(t, "us-east-1", info.Region)
+	})
+
+	t.Run("hypershift flag", func(t *testing.T) {
+		cluster, err := cmv1.NewCluster().
+			ID("id-1").
+			Name("test").
+			Hypershift(cmv1.NewHypershift().Enabled(true)).
+			Build()
+		require.NoError(t, err)
+
+		info := clusterFromResponse(cluster)
+
+		assert.True(t, info.Hypershift)
+	})
+
+	t.Run("CCS flag", func(t *testing.T) {
+		cluster, err := cmv1.NewCluster().
+			ID("id-1").
+			Name("test").
+			CCS(cmv1.NewCCS().Enabled(true)).
+			Build()
+		require.NoError(t, err)
+
+		info := clusterFromResponse(cluster)
+
+		assert.True(t, info.CCS)
+	})
+
+	t.Run("nil optional fields are safe", func(t *testing.T) {
+		cluster, err := cmv1.NewCluster().
+			ID("id-1").
+			Name("test").
+			Build()
+		require.NoError(t, err)
+
+		info := clusterFromResponse(cluster)
+
+		assert.Empty(t, info.Region)
+		assert.False(t, info.Hypershift)
+		assert.False(t, info.CCS)
+		assert.Empty(t, info.Organization)
+	})
+
+	t.Run("cloud provider extraction", func(t *testing.T) {
+		cluster, err := cmv1.NewCluster().
+			ID("id-1").
+			Name("test").
+			CloudProvider(cmv1.NewCloudProvider().ID("aws")).
+			Build()
+		require.NoError(t, err)
+
+		info := clusterFromResponse(cluster)
+
+		assert.Equal(t, "aws", info.CloudProvider)
 	})
 }

--- a/pkg/tui/theme_test.go
+++ b/pkg/tui/theme_test.go
@@ -120,6 +120,67 @@ func TestBuildStyles(t *testing.T) {
 	})
 }
 
+func TestBuildGlamourStyle(t *testing.T) {
+	theme := DefaultTheme()
+	style := buildGlamourStyle(theme)
+
+	t.Run("document color matches theme text", func(t *testing.T) {
+		assert.NotNil(t, style.Document.Color)
+		assert.Equal(t, theme.Text.Dark, *style.Document.Color)
+	})
+
+	t.Run("heading colors match theme highlight", func(t *testing.T) {
+		assert.NotNil(t, style.Heading.Color)
+		assert.Equal(t, theme.Highlight.Dark, *style.Heading.Color)
+		assert.NotNil(t, style.H1.Color)
+		assert.Equal(t, theme.Highlight.Dark, *style.H1.Color)
+		assert.NotNil(t, style.H2.Color)
+		assert.Equal(t, theme.Highlight.Dark, *style.H2.Color)
+		assert.NotNil(t, style.H3.Color)
+		assert.Equal(t, theme.Highlight.Dark, *style.H3.Color)
+	})
+
+	t.Run("H1 background cleared", func(t *testing.T) {
+		assert.Nil(t, style.H1.BackgroundColor)
+	})
+
+	t.Run("link colors match theme border", func(t *testing.T) {
+		assert.NotNil(t, style.Link.Color)
+		assert.Equal(t, theme.Border.Dark, *style.Link.Color)
+		assert.NotNil(t, style.HorizontalRule.Color)
+		assert.Equal(t, theme.Border.Dark, *style.HorizontalRule.Color)
+	})
+
+	t.Run("link text uses theme text color and bold", func(t *testing.T) {
+		assert.NotNil(t, style.LinkText.Color)
+		assert.Equal(t, theme.Text.Dark, *style.LinkText.Color)
+		assert.NotNil(t, style.LinkText.Bold)
+		assert.True(t, *style.LinkText.Bold)
+	})
+
+	t.Run("strong is bold", func(t *testing.T) {
+		assert.NotNil(t, style.Strong.Bold)
+		assert.True(t, *style.Strong.Bold)
+	})
+
+	t.Run("heading is bold", func(t *testing.T) {
+		assert.NotNil(t, style.Heading.Bold)
+		assert.True(t, *style.Heading.Bold)
+	})
+
+	t.Run("custom theme colors propagate", func(t *testing.T) {
+		custom := ThemeFromConfig(map[string]string{
+			"text":      "#112233",
+			"border":    "#445566",
+			"highlight": "#778899",
+		})
+		customStyle := buildGlamourStyle(custom)
+		assert.Equal(t, custom.Text.Dark, *customStyle.Document.Color)
+		assert.Equal(t, custom.Highlight.Dark, *customStyle.Heading.Color)
+		assert.Equal(t, custom.Border.Dark, *customStyle.Link.Color)
+	})
+}
+
 func TestIsValidHexColor(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
## Summary

- Add `TestBuildGlamourStyle` — verifies glamour `ansi.StyleConfig` is correctly built from Theme colors (document, heading, link, bold, horizontal rule colors, H1 background clearing, custom theme propagation)
- Add `TestClusterFromResponse` — verifies OCM SDK `cmv1.Cluster` → `ClusterInfo` conversion using the SDK builder API (field mapping, display name from DomainPrefix+DNS, region/hypershift/CCS extraction, cloud provider, nil-safety for optional fields)

These tests cover the functions that directly consume the dependencies being updated by Dependabot PRs #330 (glamour), #332 (ocm-sdk-go), and #333 (ocm-common), ensuring breaking changes in those bumps are caught.

## Test plan

- [x] `make test-all` passes
- [x] New tests pass against current main
- [x] `TestClusterFromResponse` uses SDK builders (no real API calls)
- [x] `TestBuildGlamourStyle` is pure function testing (no I/O)

🤖 Generated with [Claude Code](https://claude.com/claude-code)