### PR TITLE
Add lazy enrichment, Info logging, and journal-aware log viewer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,21 @@ direct `ocm backplane` login.
 Pass extra test flags via `TESTOPTS`, e.g.:
 `make test TESTOPTS="-run TestFoo"`
 
+## Build and Versioning
+
+- `make build` runs `goreleaser build --snapshot --clean --single-target`
+- Goreleaser sets `Version` and `GitSHA` via `-ldflags` at build time
+- **Snapshot builds** (local): `Version` = git short commit hash (e.g., `51e405a`),
+  `GitSHA` = same hash. Shown in footer as `51e405a - 51e405a`
+- **Release builds** (CI/tagged): `Version` = semver from tag (e.g., `1.4.0`),
+  `GitSHA` = commit hash
+- **CRITICAL**: Goreleaser bakes the **last committed** hash into the binary.
+  Uncommitted changes are NOT reflected in the version string. You MUST
+  commit before building if you want the binary to show a new version.
+- The update banner triggers when `isNewerVersion(current, latest)` returns
+  true. For snapshot builds (no dot in version string), it always returns true.
+- Config: `.goreleaser.yaml` ldflags section
+
 ## Architecture
 
 - **Pattern**: Bubble Tea Model-View-Update (MVU)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -520,11 +520,13 @@ func configureLogging() {
 
 	switch dest {
 	case LogToJournal:
+		tui.LogDestination = "journal"
 		logWriter = newAsyncWriter(journalWriter{}, asyncWriterBufferSize)
 		log.SetOutput(logWriter)
 		log.Info("Logging to systemd journal")
 
 	case LogToFile:
+		tui.LogDestination = "file"
 		// Expand home directory if needed
 		if strings.HasPrefix(logPath, "~/") {
 			home, err := os.UserHomeDir()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -68,7 +68,7 @@ but rather a simple tool to make on-call tasks easier.`,
 			if viper.GetBool("debug") {
 				return log.DebugLevel
 			}
-			return log.WarnLevel
+			return log.InfoLevel
 		}())
 	},
 	PreRun: func(cmd *cobra.Command, args []string) {

--- a/docs/plans/337-lazy-enrich-logging-logviewer.md
+++ b/docs/plans/337-lazy-enrich-logging-logviewer.md
@@ -1,0 +1,65 @@
+# Plan: Lazy enrichment, Info logging, and journal-aware log viewer (#337)
+
+**Status:** Complete
+**PR:** #337
+
+## Problem
+
+Three separate issues addressed together:
+
+1. **Slow incident loading**: All incident data (alerts, notes, OCM, reports,
+   PD history) was fetched only when the user opened an incident. First open
+   always had a loading delay.
+
+2. **Silent Info log**: Default log level was Warn, filtering out all Info
+   messages. Key events (new incidents, enrichment completions, user actions)
+   were invisible in the journal.
+
+3. **Broken log viewer**: Ctrl+L only read the on-disk log file, showing
+   nothing when logging to the systemd journal. Also showed old session data
+   and didn't wrap long lines.
+
+## Solution
+
+### Lazy background enrichment
+
+A scheduled job fires every 3 seconds and enriches one un-cached incident
+via the existing `getIncidentMsg` cascade. Uses spiral ordering from the
+highlighted row (highlight first, then +1, -1, +2, -2, ...) so nearby
+incidents are ready first. The first incident is enriched immediately when
+the incident list loads, no 3-second wait.
+
+### Info logging
+
+Changed default log level from Warn to Info. Promoted key events:
+- Incident details/alerts/notes fetched (with counts)
+- New incidents appearing, incident count changes
+- OCM cluster enrichment (with name/region)
+- Service logs, limited support, reports fetched (with counts)
+- PD history completion (with totals)
+- Reassigned incidents
+
+### Journal-aware log viewer
+
+- Detects log destination (`journal` vs `file`) and reads from the right source
+- Journal: runs `journalctl _COMM=srepd --since <startupTime>`
+- File: filters lines by timestamp to current session only
+- Both paths wrap long lines to viewport width
+
+### PD History cluster matching fix
+
+Removed unconditional Tier 1 match for hive services — was matching ALL
+hive incidents from any cluster in team-wide scan. Now always verifies
+cluster_id via title or log entry extraction.
+
+## Key files
+
+| File | Change |
+|------|--------|
+| `pkg/tui/commands.go` | `lazyEnrichMsg`, `pickNextEnrichment`, `readJournalLog`, `readLogFile` session filter |
+| `pkg/tui/lazy_enrich_test.go` | Tests for spiral ordering, cache skip, empty table, no config |
+| `pkg/tui/model.go` | `logDestination`, `startupTime`, `readLog()`, lazy enrichment job |
+| `pkg/tui/tui.go` | Info log promotions, `wrapLines`, lazy enrich handler, immediate enrichment on load |
+| `pkg/tui/version.go` | `LogDestination` package variable |
+| `cmd/root.go` | Set `LogDestination`, change default level to Info |
+| `pkg/tui/prior_alerts.go` | Fix `matchIncidentToCluster` — always verify cluster |

--- a/pkg/tui/chords.go
+++ b/pkg/tui/chords.go
@@ -101,7 +101,7 @@ func (k chordKeymap) FullHelp() [][]key.Binding {
 
 // chordViewLog opens the debug log viewer (same as ctrl+l).
 func chordViewLog(m model) (tea.Model, tea.Cmd) {
-	return m, readLogFile(m.logFilePath)
+	return m, m.readLog()
 }
 
 // chordHelpText generates a human-readable help string listing all chord commands.

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -361,6 +361,21 @@ func readLogFile(path string) tea.Cmd {
 	}
 }
 
+func readJournalLog(since time.Time) tea.Cmd {
+	return func() tea.Msg {
+		sinceStr := since.Format("2006-01-02 15:04:05")
+		cmd := exec.Command("journalctl", "_COMM=srepd", "--since", sinceStr, "--no-pager")
+		out, err := cmd.Output()
+		if err != nil {
+			return logFileContentMsg(fmt.Sprintf("Failed to read journal: %v", err))
+		}
+		if len(out) == 0 {
+			return logFileContentMsg("No journal entries found for this session")
+		}
+		return logFileContentMsg(string(out))
+	}
+}
+
 type renderIncidentMsg string
 
 type renderedIncidentMsg struct {

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -297,6 +297,55 @@ type clearFlashMsg struct {
 
 type PollIncidentsMsg struct{}
 
+type lazyEnrichMsg struct{}
+
+func pickNextEnrichment(m *model) tea.Cmd {
+	if m.config == nil {
+		return nil
+	}
+
+	rows := m.table.Rows()
+	if len(rows) == 0 {
+		return nil
+	}
+
+	cursor := m.table.Cursor()
+	n := len(rows)
+
+	for offset := 0; offset < n; offset++ {
+		var indices []int
+		if offset == 0 {
+			indices = []int{cursor}
+		} else {
+			above := cursor - offset
+			below := cursor + offset
+			if below < n {
+				indices = append(indices, below)
+			}
+			if above >= 0 {
+				indices = append(indices, above)
+			}
+		}
+
+		for _, idx := range indices {
+			if idx < 0 || idx >= n {
+				continue
+			}
+			row := rows[idx]
+			if len(row) < 2 {
+				continue
+			}
+			incidentID := row[1]
+			if _, exists := m.incidentCache[incidentID]; exists {
+				continue
+			}
+			return func() tea.Msg { return getIncidentMsg(incidentID) }
+		}
+	}
+
+	return nil
+}
+
 // logFileContentMsg is a message containing the contents of the debug log file.
 type logFileContentMsg string
 

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -349,15 +349,27 @@ func pickNextEnrichment(m *model) tea.Cmd {
 // logFileContentMsg is a message containing the contents of the debug log file.
 type logFileContentMsg string
 
-// readLogFile returns a command that reads the log file at the given path.
-// If the file does not exist, it returns a logFileContentMsg with an error message.
-func readLogFile(path string) tea.Cmd {
+// readLogFile returns a command that reads the log file at the given path,
+// filtered to lines from the current session (on or after since).
+func readLogFile(path string, since time.Time) tea.Cmd {
 	return func() tea.Msg {
 		data, err := os.ReadFile(path)
 		if err != nil {
 			return logFileContentMsg(fmt.Sprintf("No log file found at %s", path))
 		}
-		return logFileContentMsg(string(data))
+		if since.IsZero() {
+			return logFileContentMsg(string(data))
+		}
+		lines := strings.Split(string(data), "\n")
+		sinceStr := since.Format("2006/01/02 15:04:05")
+		startIdx := len(lines)
+		for i, line := range lines {
+			if len(line) >= 19 && line[:19] >= sinceStr {
+				startIdx = i
+				break
+			}
+		}
+		return logFileContentMsg(strings.Join(lines[startIdx:], "\n"))
 	}
 }
 

--- a/pkg/tui/commands_test.go
+++ b/pkg/tui/commands_test.go
@@ -2264,7 +2264,7 @@ func TestReadLogFile_ExistingFile(t *testing.T) {
 	err := os.WriteFile(logPath, []byte(expectedContent), 0644)
 	assert.NoError(t, err)
 
-	cmd := readLogFile(logPath)
+	cmd := readLogFile(logPath, time.Time{})
 	result := cmd()
 
 	msg, ok := result.(logFileContentMsg)
@@ -2273,7 +2273,7 @@ func TestReadLogFile_ExistingFile(t *testing.T) {
 }
 
 func TestReadLogFile_MissingFile(t *testing.T) {
-	cmd := readLogFile("/tmp/nonexistent-log-file-srepd-test.log")
+	cmd := readLogFile("/tmp/nonexistent-log-file-srepd-test.log", time.Time{})
 	result := cmd()
 
 	msg, ok := result.(logFileContentMsg)

--- a/pkg/tui/lazy_enrich_test.go
+++ b/pkg/tui/lazy_enrich_test.go
@@ -1,0 +1,131 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/bubbles/table"
+	"github.com/clcollins/srepd/pkg/pd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeTableWithRows(incidentIDs []string) table.Model {
+	t := table.New(table.WithFocused(true))
+	var rows []table.Row
+	for _, id := range incidentIDs {
+		rows = append(rows, table.Row{"A", id, "Title", "Service"})
+	}
+	t.SetColumns([]table.Column{
+		{Title: "•", Width: 2},
+		{Title: "ID", Width: 15},
+		{Title: "Summary", Width: 40},
+		{Title: "Service", Width: 30},
+	})
+	t.SetRows(rows)
+	return t
+}
+
+func TestPickNextEnrichment_AllCached(t *testing.T) {
+	m := model{
+		table: makeTableWithRows([]string{"INC1", "INC2", "INC3"}),
+		incidentCache: map[string]*cachedIncidentData{
+			"INC1": {dataLoaded: true, notesLoaded: true, alertsLoaded: true},
+			"INC2": {dataLoaded: true, notesLoaded: true, alertsLoaded: true},
+			"INC3": {dataLoaded: true, notesLoaded: true, alertsLoaded: true},
+		},
+	}
+
+	cmd := pickNextEnrichment(&m)
+	assert.Nil(t, cmd, "should return nil when all incidents are cached")
+}
+
+func TestPickNextEnrichment_HighlightedFirst(t *testing.T) {
+	tbl := makeTableWithRows([]string{"INC1", "INC2", "INC3"})
+	tbl.SetCursor(1)
+
+	m := model{
+		table:         tbl,
+		incidentCache: make(map[string]*cachedIncidentData),
+		config:        &pd.Config{Client: &pd.MockPagerDutyClient{}},
+	}
+
+	cmd := pickNextEnrichment(&m)
+	require.NotNil(t, cmd, "should return a command")
+
+	msg := cmd()
+	enrichMsg, ok := msg.(getIncidentMsg)
+	require.True(t, ok, "should return getIncidentMsg")
+	assert.Equal(t, "INC2", string(enrichMsg), "should enrich the highlighted incident first")
+}
+
+func TestPickNextEnrichment_SpiralOrder(t *testing.T) {
+	tbl := makeTableWithRows([]string{"INC0", "INC1", "INC2", "INC3", "INC4"})
+	tbl.SetCursor(2)
+
+	cache := map[string]*cachedIncidentData{
+		"INC2": {dataLoaded: true, notesLoaded: true, alertsLoaded: true},
+	}
+
+	m := model{
+		table:         tbl,
+		incidentCache: cache,
+		config:        &pd.Config{Client: &pd.MockPagerDutyClient{}},
+	}
+
+	cmd := pickNextEnrichment(&m)
+	require.NotNil(t, cmd)
+	msg := cmd()
+	enrichMsg := msg.(getIncidentMsg)
+	assert.Equal(t, "INC3", string(enrichMsg), "should enrich highlight+1 after highlight is cached")
+
+	cache["INC3"] = &cachedIncidentData{dataLoaded: true, notesLoaded: true, alertsLoaded: true}
+	cmd = pickNextEnrichment(&m)
+	require.NotNil(t, cmd)
+	msg = cmd()
+	enrichMsg = msg.(getIncidentMsg)
+	assert.Equal(t, "INC1", string(enrichMsg), "should enrich highlight-1 next")
+}
+
+func TestPickNextEnrichment_SkipsPartialCache(t *testing.T) {
+	tbl := makeTableWithRows([]string{"INC1", "INC2"})
+	tbl.SetCursor(0)
+
+	m := model{
+		table: tbl,
+		incidentCache: map[string]*cachedIncidentData{
+			"INC1": {dataLoaded: true, notesLoaded: false, alertsLoaded: false},
+		},
+		config: &pd.Config{Client: &pd.MockPagerDutyClient{}},
+	}
+
+	cmd := pickNextEnrichment(&m)
+	require.NotNil(t, cmd)
+	msg := cmd()
+	enrichMsg := msg.(getIncidentMsg)
+	assert.Equal(t, "INC2", string(enrichMsg), "should skip partially cached incident (fetch already in progress)")
+}
+
+func TestPickNextEnrichment_EmptyTable(t *testing.T) {
+	m := model{
+		table:         makeTableWithRows(nil),
+		incidentCache: make(map[string]*cachedIncidentData),
+	}
+
+	cmd := pickNextEnrichment(&m)
+	assert.Nil(t, cmd, "should return nil for empty table")
+}
+
+func TestPickNextEnrichment_NoConfig(t *testing.T) {
+	m := model{
+		table:         makeTableWithRows([]string{"INC1"}),
+		incidentCache: make(map[string]*cachedIncidentData),
+		config:        nil,
+	}
+
+	cmd := pickNextEnrichment(&m)
+	assert.Nil(t, cmd, "should return nil when config is nil")
+}
+
+func TestLazyEnrichMsg_TypeExists(t *testing.T) {
+	_ = lazyEnrichMsg{}
+}

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -76,6 +76,8 @@ type model struct {
 	viewingLog       bool
 	logViewer        viewport.Model
 	logFilePath      string
+	logDestination   string
+	startupTime      time.Time
 	help             help.Model
 	spinner          spinner.Model
 	apiInProgress    bool
@@ -278,6 +280,8 @@ func InitialModel(
 		incidentViewer:        newIncidentViewer(),
 		logViewer:             newLogViewer(),
 		logFilePath:           defaultLogFilePath(),
+		logDestination:        LogDestination,
+		startupTime:           time.Now(),
 		spinner:               s,
 		markdownRenderer:      renderer,
 		apiInProgress:         false,
@@ -392,6 +396,8 @@ func InitialModelWithConfig(
 		incidentViewer:        newIncidentViewer(),
 		logViewer:             newLogViewer(),
 		logFilePath:           defaultLogFilePath(),
+		logDestination:        LogDestination,
+		startupTime:           time.Now(),
 		spinner:               s,
 		markdownRenderer:      renderer,
 		apiInProgress:         false,
@@ -445,6 +451,13 @@ func InitialModelWithConfig(
 	return m, func() tea.Msg {
 		return errMsg{m.err}
 	}
+}
+
+func (m *model) readLog() tea.Cmd {
+	if m.logDestination == "journal" {
+		return readJournalLog(m.startupTime)
+	}
+	return readLogFile(m.logFilePath)
 }
 
 func (m *model) clearSelectedIncident(reason interface{}) {

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -457,7 +457,7 @@ func (m *model) readLog() tea.Cmd {
 	if m.logDestination == "journal" {
 		return readJournalLog(m.startupTime)
 	}
-	return readLogFile(m.logFilePath)
+	return readLogFile(m.logFilePath, m.startupTime)
 }
 
 func (m *model) clearSelectedIncident(reason interface{}) {

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -51,6 +51,10 @@ var initialScheduledJobs = []*scheduledJob{
 		frequency: time.Second * 15,
 	},
 	{
+		jobMsg:    func() tea.Msg { return lazyEnrichMsg{} },
+		frequency: 3 * time.Second,
+	},
+	{
 		jobMsg:    checkForUpdate(false, ""),
 		frequency: time.Hour,
 	},

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -693,7 +693,7 @@ func switchTableFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Batch(m.flashNotification(fmt.Sprintf("Opened SOP for %s", m.selectedIncident.ID)), openBrowserCmd(c, link))
 
 		case key.Matches(msg, defaultKeyMap.ViewLog):
-			return m, readLogFile(m.logFilePath)
+			return m, m.readLog()
 
 		}
 	}

--- a/pkg/tui/prior_alerts.go
+++ b/pkg/tui/prior_alerts.go
@@ -69,22 +69,18 @@ func buildPriorAlertWeeks() []priorAlertWeek {
 // matchIncidentToCluster checks if an incident is related to the target cluster
 // using a three-tier strategy that avoids separate GetAlerts API calls:
 //
-// Tier 1 (1:1 services): osd_hive services are 1:1 with a cluster — every
-// incident from that service matches. Always returns true for these.
+// matchIncidentToCluster checks if an incident is related to the target cluster.
+// For service-scoped queries (1:1 hive services), all results already match —
+// call this only for the team-wide fallback scan.
 //
-// Tier 2 (title match): rhobs_hcp titles contain the cluster UUID
+// Tier 1 (title match): rhobs_hcp titles contain the cluster UUID
 // ("for HCP: <uuid>"). Check with strings.Contains.
 //
-// Tier 3 (log entry): Use FirstTriggerLogEntry.Channel.Raw to extract
+// Tier 2 (log entry): Use FirstTriggerLogEntry.Channel.Raw to extract
 // cluster_id from the inline alert payload (requires include[]=first_trigger_log_entries).
 func matchIncidentToCluster(incident pagerduty.Incident, clusterID string) bool {
-	serviceType := alert.IdentifyType(incident.Service.Summary)
-
-	switch serviceType {
-	case "osd_hive":
+	if strings.Contains(incident.Title, clusterID) {
 		return true
-	case "rhobs_hcp":
-		return strings.Contains(incident.Title, clusterID)
 	}
 
 	return extractClusterFromLogEntry(incident) == clusterID

--- a/pkg/tui/prior_alerts_test.go
+++ b/pkg/tui/prior_alerts_test.go
@@ -239,15 +239,16 @@ func TestMatchIncidentToCluster_Tiers(t *testing.T) {
 		expected  bool
 	}{
 		{
-			name: "Tier 1: hive service always matches",
+			name: "hive service without cluster_id in title does not match",
 			incident: pagerduty.Incident{
+				Title:   "ClusterOperatorDown CRITICAL (1)",
 				Service: pagerduty.APIObject{Summary: "osd-test-hive-cluster"},
 			},
-			clusterID: "anything",
-			expected:  true,
+			clusterID: "abc-123",
+			expected:  false,
 		},
 		{
-			name: "Tier 2: rhobs_hcp title contains cluster UUID",
+			name: "title contains cluster UUID",
 			incident: pagerduty.Incident{
 				Title:   "[HCP] [RHOBS] (Critical) AlertName for HCP: abc-123",
 				Service: pagerduty.APIObject{Summary: "rhobs-hcp-prod-critical-us-east-1"},
@@ -336,7 +337,7 @@ func TestRenderPDHistoryTab_WithData(t *testing.T) {
 
 	result, err := m.renderPDHistoryTab()
 	assert.NoError(t, err)
-	assert.Contains(t, result, "Same Alert")
+	assert.Contains(t, result, "Prior Instances of Alert")
 	assert.Contains(t, result, "Other Alerts for this Cluster")
 	assert.Contains(t, result, "ClusterOperatorDown")
 	assert.Contains(t, result, "KubePodNotReady")
@@ -397,7 +398,7 @@ func TestRenderPDHistoryTab_FetchDoneNoData(t *testing.T) {
 
 	result, err := m.renderPDHistoryTab()
 	assert.NoError(t, err)
-	assert.Contains(t, result, "No PD history available")
+	assert.Contains(t, result, "No prior PD history found")
 }
 
 func TestTabConstants(t *testing.T) {

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -134,7 +134,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		reflect.TypeOf(ocmServiceLogsMsg{}),
 		reflect.TypeOf(limitedSupportMsg{}),
 		reflect.TypeOf(clusterReportsMsg{}),
-		reflect.TypeOf(priorAlertsMsg{}):
+		reflect.TypeOf(priorAlertsMsg{}),
+		reflect.TypeOf(lazyEnrichMsg{}):
 		shouldLog = false
 	}
 
@@ -577,6 +578,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.apiInProgress = true
 		return m, tea.Batch(m.spinner.Tick, updateIncidentList(m.config))
+
+	case lazyEnrichMsg:
+		cmd := pickNextEnrichment(&m)
+		if cmd != nil {
+			return m, cmd
+		}
+		return m, nil
 
 	// Command to get an incident by ID
 	case getIncidentMsg:

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -854,6 +854,27 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, m.flashNotification(resolvedMsg))
 		}
 
+		// Detect new incidents
+		oldIDs := make(map[string]bool, len(m.incidentList))
+		for _, i := range m.incidentList {
+			oldIDs[i.ID] = true
+		}
+		var newIDs []string
+		for _, i := range msg.incidents {
+			if !oldIDs[i.ID] {
+				newIDs = append(newIDs, i.ID)
+			}
+		}
+		if len(newIDs) > 0 {
+			log.Info("new incidents", "count", len(newIDs), "ids", newIDs)
+		}
+
+		oldCount := len(m.incidentList)
+		newCount := len(msg.incidents)
+		if oldCount != newCount && oldCount > 0 {
+			log.Info("incident count changed", "old", oldCount, "new", newCount)
+		}
+
 		// Overwrite m.incidentList with current incidents
 		m.incidentList = msg.incidents
 
@@ -1423,6 +1444,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case reassignedIncidentsMsg:
 		incidentIDs := getIDsFromIncidents(msg)
+		log.Info("reassigned incidents", "incident_ids", incidentIDs)
 		m.setStatus(fmt.Sprintf("reassigned incidents %v; refreshing Incident List ", incidentIDs))
 		return m, func() tea.Msg { return updateIncidentListMsg("sender: reassignedIncidentsMsg") }
 
@@ -1617,7 +1639,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.clusterCache = make(map[string]*ocm.ClusterInfo)
 		}
 		m.clusterCache[msg.clusterID] = msg.info
-		log.Debug("ocm.GetCluster cached", "cluster_id", msg.clusterID)
+		log.Info("OCM enriched cluster", "cluster_id", msg.clusterID, "name", msg.info.DisplayName, "region", msg.info.Region)
 
 		m.rebuildFlagMatchCache()
 
@@ -1673,7 +1695,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.serviceLogCache = make(map[string][]ocm.ServiceLog)
 		}
 		m.serviceLogCache[msg.clusterID] = msg.logs
-		log.Debug("ocm.GetServiceLogs cached", "cluster_id", msg.clusterID, "count", len(msg.logs))
+		log.Info("service logs fetched", "cluster_id", msg.clusterID, "count", len(msg.logs))
 		return m, nil
 
 	case limitedSupportMsg:
@@ -1685,7 +1707,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.limitedSupportCache = make(map[string][]ocm.LimitedSupportReason)
 		}
 		m.limitedSupportCache[msg.clusterID] = msg.reasons
-		log.Debug("ocm.GetLimitedSupportHistory cached", "cluster_id", msg.clusterID, "count", len(msg.reasons))
+		log.Info("limited support fetched", "cluster_id", msg.clusterID, "count", len(msg.reasons))
 		return m, nil
 
 	case clusterReportsMsg:
@@ -1697,14 +1719,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.clusterReportCache = make(map[string][]backplane.Report)
 		}
 		m.clusterReportCache[msg.clusterID] = msg.reports
-		log.Debug("backplane.ListReports cached", "cluster_id", msg.clusterID, "count", len(msg.reports))
+		log.Info("cluster reports fetched", "cluster_id", msg.clusterID, "count", len(msg.reports))
 		return m, nil
 
 	case priorAlertsMsg:
 		if m.priorAlertPending[msg.clusterID] > 0 {
 			m.priorAlertPending[msg.clusterID]--
 		}
-		if m.priorAlertPending[msg.clusterID] == 0 {
+		allWeeksDone := m.priorAlertPending[msg.clusterID] == 0
+		if allWeeksDone {
 			delete(m.priorAlertPending, msg.clusterID)
 		}
 		if m.priorAlertCache == nil {
@@ -1724,6 +1747,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				"week_same", len(msg.data.SameAlert), "week_other", len(msg.data.OtherAlerts),
 				"total_same", len(existing.SameAlert), "total_other", len(existing.OtherAlerts),
 				"pending", m.priorAlertPending[msg.clusterID])
+		}
+		if allWeeksDone {
+			log.Info("PD history complete", "cluster_id", msg.clusterID,
+				"same_alert", len(existing.SameAlert), "other_alerts", len(existing.OtherAlerts))
 		}
 		var nextCmd tea.Cmd
 		if len(msg.nextWeeks) > 0 {

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -74,6 +74,22 @@ type scheduledJob struct {
 	frequency time.Duration
 }
 
+func wrapLines(text string, width int) string {
+	if width <= 0 {
+		return text
+	}
+	lines := strings.Split(text, "\n")
+	var wrapped []string
+	for _, line := range lines {
+		for len(line) > width {
+			wrapped = append(wrapped, line[:width])
+			line = line[width:]
+		}
+		wrapped = append(wrapped, line)
+	}
+	return strings.Join(wrapped, "\n")
+}
+
 func filterMsgContent(msg tea.Msg) tea.Msg {
 	var truncatedMsg string
 	switch msg := msg.(type) {
@@ -1328,7 +1344,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, msg.action
 
 	case logFileContentMsg:
-		m.logViewer.SetContent(string(msg))
+		m.logViewer.SetContent(wrapLines(string(msg), m.logViewer.Width))
 		m.logViewer.GotoBottom()
 		m.viewingLog = true
 		return m, nil

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -639,6 +639,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		if shouldUpdate {
+			log.Info("incident details fetched", "incident_id", msg.incident.ID, "title", msg.incident.Title)
 			m.setStatus(fmt.Sprintf("got incident %s", msg.incident.ID))
 			m.selectedIncident = msg.incident
 			m.incidentDataLoaded = true
@@ -684,6 +685,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			m.selectedIncidentNotes = msg.notes
 			m.incidentNotesLoaded = true
+			log.Info("notes fetched", "incident_id", msg.incidentID, "count", len(msg.notes))
 
 			// Stop spinner if all incident data is loaded (details, notes, alerts)
 			if m.incidentDataLoaded && m.incidentNotesLoaded && m.incidentAlertsLoaded {
@@ -726,6 +728,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			m.selectedIncidentAlerts = msg.alerts
 			m.incidentAlertsLoaded = true
+			log.Info("alerts fetched", "incident_id", msg.incidentID, "count", len(msg.alerts))
 
 			// Stop spinner if all incident data is loaded (details, notes, alerts)
 			if m.incidentDataLoaded && m.incidentNotesLoaded && m.incidentAlertsLoaded {
@@ -1030,6 +1033,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					cmds = append(cmds, getIncidentAlerts(m.config, id))
 				}
 			}
+		}
+
+		// Kick off enrichment for the first un-enriched incident immediately
+		if enrichCmd := pickNextEnrichment(&m); enrichCmd != nil {
+			cmds = append(cmds, enrichCmd)
 		}
 
 		// Re-sync selectedIncident to match highlighted row

--- a/pkg/tui/version.go
+++ b/pkg/tui/version.go
@@ -7,3 +7,7 @@ var (
 	// GitSHA is the short git commit hash, set at build time
 	GitSHA = "dev"
 )
+
+// LogDestination is set by cmd/root.go before model creation.
+// Valid values: "journal", "file", "stderr"
+var LogDestination = "file"

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -626,7 +626,7 @@ func (m model) renderPDHistoryTab() (string, error) {
 		if anyLoading {
 			return "\n_Loading PD history..._\n", nil
 		}
-		return "\n_No PD history available_\n", nil
+		return "\n_No prior PD history found for this cluster_\n", nil
 	}
 
 	slices.SortFunc(allSame, func(a, b PriorAlert) int {
@@ -655,7 +655,7 @@ func (m model) renderPDHistoryTab() (string, error) {
 
 	var content strings.Builder
 
-	fmt.Fprintf(&content, "## Same Alert (%s)\n\n", timeRange)
+	fmt.Fprintf(&content, "## Prior Instances of Alert (%s)\n\n", timeRange)
 	if len(allSame) == 0 {
 		content.WriteString("_No prior instances of this alert for this cluster_\n")
 	} else {


### PR DESCRIPTION
## Summary

- **Lazy background enrichment**: Scheduled job enriches one incident every 3s via spiral ordering from the highlighted row. First incident enriches immediately on startup. Existing enrichment cascade (OCM, SLs, LS, reports, PD history) fires automatically once alerts arrive. All tabs pre-populated before the user opens an incident.
- **Info logging**: Changed default log level from Warn to Info. Key events now visible in journal: incident details/alerts/notes fetched, new incidents, count changes, OCM enrichment, service logs/LS/reports fetched, PD history completion, reassignment.
- **Journal-aware Ctrl+L viewer**: Detects log destination and reads from `journalctl` when logging to journal (filtered to current session via `--since`). File-based log also filtered to current session by timestamp. Both paths word-wrap long lines to viewport width.
- **PD History fix**: Always verify cluster_id match in team-wide scan — was incorrectly matching all hive service incidents from any cluster.
- **AGENTS.md**: Document goreleaser versioning behavior (snapshot vs release builds).

## Test plan

- [x] `make test-all` passes
- [x] New `lazy_enrich_test.go` — spiral ordering, all-cached, partial cache skip, empty table, no config
- [x] Verify journal shows Info lines on startup (incidents, alerts, notes, OCM enrichment)
- [x] Verify Ctrl+L shows current session only (not old invocations)
- [x] Verify long log lines wrap in the Ctrl+L viewer
- [x] Verify lazy enrichment populates tabs before user opens incident
- [ ] Verify no 429 rate limit errors from lazy enrichment

🤖 Generated with [Claude Code](https://claude.com/claude-code)