### PR TITLE
Move auto-ack on-call check off the Update loop (async, never cached)

### DIFF
--- a/docs/plans/097-async-oncall-check.md
+++ b/docs/plans/097-async-oncall-check.md
@@ -1,0 +1,90 @@
+# Plan 097: Async on-call check for auto-acknowledge
+
+**Branch:** `srepd/async-oncall-check`
+
+## Problem
+
+The auto-acknowledge sweep in the `updatedIncidentListMsg` handler
+(`pkg/tui/tui.go`) called `UserIsOnCall(m.config, ...)` **synchronously**. That
+function issues a live PagerDuty `ListOnCalls` request via `pd.GetUserOnCalls`. Because
+the Bubble Tea `Update` loop is single-threaded, this blocked the entire UI for the
+duration of the request on **every 15s incident-list refresh** while `autoAcknowledge`
+was enabled — freezing navigation and rendering until the API responded (up to the 30s
+client timeout on a hung network).
+
+This is a UI-blocking bug, not a timeout bug: `pd.GetUserOnCalls` is already wrapped
+with `contextWithTimeout()`.
+
+## Solution
+
+Move the on-call check **off** the Update loop into a one-shot async command, and
+**never cache** the result.
+
+- New `checkOnCallAndAcknowledge(p *pd.Config, id string, candidates []pagerduty.Incident) tea.Cmd`
+  in `commands.go`. It runs `UserIsOnCall` off-loop, filters `candidates` by the fresh
+  on-call result via the existing `ShouldBeAcknowledgedCached`, and returns
+  `acknowledgeIncidentsMsg{incidents: ...}` — or a new `noAcknowledgeMsg{}` no-op when
+  the user is not on-call, the check fails, or nothing matches.
+- In `updatedIncidentListMsg`, first compute the on-call-independent candidate list
+  (`AssignedToUser && !AcknowledgedByUser`); **only if it is non-empty** dispatch the
+  command. This avoids firing an on-call API call every refresh when nothing is
+  assigned to the user.
+- New `noAcknowledgeMsg` handler in the Update switch is a no-op. It is deliberately
+  distinct from `acknowledgeIncidentsMsg`, whose `nil`-incidents fallback would
+  acknowledge the *selected* incident — which must never happen from the background
+  sweep.
+
+### Why no cache (critical safety property)
+
+On-call status is checked **live every refresh**, never cached:
+
+1. **Auto-ack:** if a user leaves SREPD running past the end of their shift, a cached
+   "on-call = true" would keep auto-acknowledging incidents that are no longer theirs.
+   A live check stops auto-ack within one refresh cycle of going off-call.
+2. **Re-escalate / reassign:** re-escalation almost always happens right after the user
+   goes off-call and reassigns to someone else — exactly when a cached value would be
+   wrong. Those paths (`reEscalateIncidents`/`reassignIncidents`) must always check
+   live and must never read a cached value. (They don't check on-call today; this
+   change does not add caching to them.)
+
+There is intentionally **no on-call field on the model** — eliminating it structurally
+prevents a future maintainer from wiring a stale value into any path.
+
+## Files Modified
+
+- `pkg/tui/commands.go` — `checkOnCallAndAcknowledge`, `noAcknowledgeMsg`.
+- `pkg/tui/tui.go` — candidate computation + async dispatch in `updatedIncidentListMsg`;
+  `noAcknowledgeMsg` no-op handler.
+- `pkg/tui/commands_test.go` — 5 new tests + `drainCmd` helper.
+
+## Tests (TDD)
+
+Written first, seen red (undefined symbols), then green:
+- `TestCheckOnCallAndAcknowledge_OnCall_ReturnsAckMsg` — on-call + candidates → ack msg.
+- `TestCheckOnCallAndAcknowledge_NotOnCall_ReturnsNoOp` — off-call → no-op (NOT an ack).
+- `TestCheckOnCallAndAcknowledge_OnCallError_ReturnsNoOp` — check error → no-op.
+- `TestCheckOnCallAndAcknowledge_OnCallButNoneMatch_ReturnsNoOp` — no match → no-op.
+- `TestUpdatedIncidentList_AutoAck_DispatchesFreshOnCallCheck` — regression: the
+  Update path dispatches an async command that performs a *fresh* `ListOnCalls` call
+  (asserts `CallCounts["ListOnCallsWithContext"] >= 1`) and acknowledges the
+  assigned+unacked incident. No cached on-call state exists on the model.
+
+Existing `TestUserIsOnCall_*` and `TestShouldBeAcknowledgedCached_*` remain valid and
+unchanged.
+
+## Verification
+
+`make test-all` (fmt-check, vet, lint, test, test-race, test-fixtures) green.
+Manual: with auto-ack on, the incident list no longer stalls the UI on refresh, and
+going off-call stops auto-acknowledging within one refresh cycle.
+
+## Lessons Learned
+
+- A blocking network call anywhere in the Bubble Tea `Update` loop (or `View`) freezes
+  the whole UI — always dispatch I/O as a `tea.Cmd`. `UserIsOnCall` was the last such
+  inline call.
+- `acknowledgeIncidentsMsg{incidents: nil}` is not a safe "nothing to do" signal — its
+  handler falls back to the selected incident. Background sweeps must use an explicit
+  no-op message (`noAcknowledgeMsg`).
+- On-call is a freshness-critical signal; caching it introduces a safety bug at shift
+  boundaries. The absence of a cache field is a deliberate invariant.

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -504,6 +504,46 @@ func UserIsOnCall(p *pd.Config, id string) bool {
 	return false
 }
 
+// noAcknowledgeMsg is a no-op result from checkOnCallAndAcknowledge indicating
+// that no incidents should be auto-acknowledged (user not on-call, on-call check
+// failed, or no candidate matched). It is deliberately distinct from
+// acknowledgeIncidentsMsg: emitting acknowledgeIncidentsMsg{incidents: nil} would
+// fall back to acknowledging the currently selected incident (see the
+// acknowledgeIncidentsMsg handler), which must never happen from the background
+// auto-ack sweep.
+type noAcknowledgeMsg struct{}
+
+// checkOnCallAndAcknowledge runs the on-call check OFF the Bubble Tea Update loop
+// (so a slow PagerDuty request never freezes the UI), then filters the candidate
+// incidents by the FRESH on-call result and emits an acknowledgeIncidentsMsg for
+// those that should be auto-acknowledged.
+//
+// On-call status is NEVER cached — it is checked live on every refresh. A cached
+// value would keep auto-acknowledging incidents after the user's shift ends if they
+// leave SREPD running; checking live means auto-ack stops within one refresh cycle
+// of going off-call. For the same reason, the re-escalate/reassign paths must also
+// perform a live check and must never read a cached on-call value.
+func checkOnCallAndAcknowledge(p *pd.Config, id string, candidates []pagerduty.Incident) tea.Cmd {
+	return func() tea.Msg {
+		if !UserIsOnCall(p, id) {
+			return noAcknowledgeMsg{}
+		}
+
+		var toAck []pagerduty.Incident
+		for _, i := range candidates {
+			if ShouldBeAcknowledgedCached(i, id, true) {
+				toAck = append(toAck, i)
+			}
+		}
+
+		if len(toAck) == 0 {
+			return noAcknowledgeMsg{}
+		}
+
+		return acknowledgeIncidentsMsg{incidents: toAck}
+	}
+}
+
 // TODO: Can we use a single function and struct to handle
 // the openEditorCmd, login and openBrowserCmd commands?
 

--- a/pkg/tui/commands_test.go
+++ b/pkg/tui/commands_test.go
@@ -2695,3 +2695,153 @@ func TestGetEscalationPolicyKey_CustomPolicy(t *testing.T) {
 		assert.Equal(t, silentDefaultPolicyKey, key)
 	})
 }
+
+// --- PR1: async on-call auto-acknowledge ---
+//
+// checkOnCallAndAcknowledge performs the on-call check OFF the Bubble Tea Update
+// loop (so it never blocks the UI), then filters the candidate incidents by the
+// FRESH on-call result. On-call status is NEVER cached — it is checked live on
+// every refresh so that a user who leaves SREPD running past their shift stops
+// auto-acknowledging within one refresh cycle.
+
+// drainCmd executes a tea.Cmd tree, recursively expanding tea.BatchMsg, and invokes
+// visit for every non-batch message produced. It is used to inspect what an Update
+// dispatch actually does without running a full tea.Program.
+func drainCmd(t *testing.T, cmd tea.Cmd, visit func(tea.Msg)) {
+	t.Helper()
+	if cmd == nil {
+		return
+	}
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		for _, c := range batch {
+			drainCmd(t, c, visit)
+		}
+		return
+	}
+	if msg != nil {
+		visit(msg)
+	}
+}
+
+// onCallAckCandidate returns an incident assigned to id and not yet acknowledged
+// by id (i.e. one that passes ShouldBeAcknowledgedCached when the user is on-call).
+func onCallAckCandidate(incidentID, userID string) pagerduty.Incident {
+	return pagerduty.Incident{
+		APIObject:        pagerduty.APIObject{ID: incidentID},
+		Assignments:      []pagerduty.Assignment{{Assignee: pagerduty.APIObject{ID: userID}}},
+		Acknowledgements: []pagerduty.Acknowledgement{},
+	}
+}
+
+func onCallMockClient(t *testing.T, onCall bool) *pd.MockPagerDutyClient {
+	t.Helper()
+	now := time.Now().UTC()
+	start, end := now.Add(-1*time.Hour), now.Add(5*time.Hour)
+	if !onCall {
+		start, end = now.Add(-5*time.Hour), now.Add(-1*time.Hour)
+	}
+	return &pd.MockPagerDutyClient{
+		ListOnCallsResponses: []pagerduty.ListOnCallsResponse{
+			{OnCalls: []pagerduty.OnCall{{
+				User:  pagerduty.User{APIObject: pagerduty.APIObject{ID: "USER1"}},
+				Start: start.Format("2006-01-02T15:04:05Z"),
+				End:   end.Format("2006-01-02T15:04:05Z"),
+			}}},
+		},
+	}
+}
+
+func TestCheckOnCallAndAcknowledge_OnCall_ReturnsAckMsg(t *testing.T) {
+	config := &pd.Config{Client: onCallMockClient(t, true)}
+	candidates := []pagerduty.Incident{
+		onCallAckCandidate("INC1", "USER1"),
+		onCallAckCandidate("INC2", "USER1"),
+	}
+
+	msg := checkOnCallAndAcknowledge(config, "USER1", candidates)()
+
+	ackMsg, ok := msg.(acknowledgeIncidentsMsg)
+	assert.True(t, ok, "on-call user with candidates should yield acknowledgeIncidentsMsg")
+	assert.Len(t, ackMsg.incidents, 2)
+	if len(ackMsg.incidents) == 2 {
+		assert.Equal(t, "INC1", ackMsg.incidents[0].ID)
+		assert.Equal(t, "INC2", ackMsg.incidents[1].ID)
+	}
+}
+
+func TestCheckOnCallAndAcknowledge_NotOnCall_ReturnsNoOp(t *testing.T) {
+	config := &pd.Config{Client: onCallMockClient(t, false)}
+	candidates := []pagerduty.Incident{onCallAckCandidate("INC1", "USER1")}
+
+	msg := checkOnCallAndAcknowledge(config, "USER1", candidates)()
+
+	// MUST NOT be an acknowledgeIncidentsMsg — a nil-incidents ack would fall back
+	// to acknowledging the selected incident, which would be a serious bug.
+	_, isAck := msg.(acknowledgeIncidentsMsg)
+	assert.False(t, isAck, "off-call user must not produce an acknowledge message")
+	_, isNoOp := msg.(noAcknowledgeMsg)
+	assert.True(t, isNoOp, "off-call user should produce a no-op message")
+}
+
+func TestCheckOnCallAndAcknowledge_OnCallError_ReturnsNoOp(t *testing.T) {
+	// "err" user ID triggers the mock's error convention.
+	config := &pd.Config{Client: &pd.MockPagerDutyClient{}}
+	candidates := []pagerduty.Incident{onCallAckCandidate("INC1", "err")}
+
+	msg := checkOnCallAndAcknowledge(config, "err", candidates)()
+
+	_, isAck := msg.(acknowledgeIncidentsMsg)
+	assert.False(t, isAck, "on-call check failure must not produce an acknowledge message")
+	_, isNoOp := msg.(noAcknowledgeMsg)
+	assert.True(t, isNoOp, "on-call check failure should produce a no-op message")
+}
+
+func TestCheckOnCallAndAcknowledge_OnCallButNoneMatch_ReturnsNoOp(t *testing.T) {
+	config := &pd.Config{Client: onCallMockClient(t, true)}
+	// Candidate assigned to a DIFFERENT user — filtered out by ShouldBeAcknowledgedCached.
+	candidates := []pagerduty.Incident{onCallAckCandidate("INC1", "OTHERUSER")}
+
+	msg := checkOnCallAndAcknowledge(config, "USER1", candidates)()
+
+	_, isAck := msg.(acknowledgeIncidentsMsg)
+	assert.False(t, isAck, "when no candidate matches, must not produce an acknowledge message")
+	_, isNoOp := msg.(noAcknowledgeMsg)
+	assert.True(t, isNoOp, "when no candidate matches, should produce a no-op message")
+}
+
+// TestUpdatedIncidentList_AutoAck_DispatchesFreshOnCallCheck is the regression test
+// for PR1: the auto-ack sweep must NOT block the Update loop with an inline on-call
+// call, and must NOT cache on-call status. It drives updatedIncidentListMsg with
+// auto-ack on and an assigned+unacked incident, then executes the returned command
+// and asserts it performs a *fresh* on-call check (a live ListOnCalls call) and, when
+// on-call, yields an acknowledgeIncidentsMsg for that incident.
+func TestUpdatedIncidentList_AutoAck_DispatchesFreshOnCallCheck(t *testing.T) {
+	mockClient := onCallMockClient(t, true)
+	m := createTestModel()
+	m.autoAcknowledge = true
+	m.config = &pd.Config{
+		Client:      mockClient,
+		CurrentUser: &pagerduty.User{APIObject: pagerduty.APIObject{ID: "USER1"}},
+	}
+
+	incoming := []pagerduty.Incident{onCallAckCandidate("INC1", "USER1")}
+	result, cmd := m.Update(updatedIncidentListMsg{incidents: incoming})
+
+	// No on-call field should exist on the model to cache — structurally guaranteed —
+	// and the sweep must have produced a command to run off-loop, not blocked inline.
+	_ = result
+	assert.NotNil(t, cmd, "auto-ack with a candidate should dispatch an async command")
+
+	// Execute the batched command tree and confirm a fresh on-call check ran and
+	// produced an acknowledge message for the assigned+unacked incident.
+	foundAck := false
+	drainCmd(t, cmd, func(msg tea.Msg) {
+		if ack, ok := msg.(acknowledgeIncidentsMsg); ok && len(ack.incidents) == 1 && ack.incidents[0].ID == "INC1" {
+			foundAck = true
+		}
+	})
+	assert.True(t, foundAck, "fresh on-call check should acknowledge the assigned+unacked incident")
+	assert.GreaterOrEqual(t, mockClient.CallCounts["ListOnCallsWithContext"], 1,
+		"on-call status must be checked live (ListOnCalls called), never cached")
+}

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -907,20 +907,24 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		//    - When user presses 'l' to login (needs alerts)
 		// This reduces unnecessary API calls from O(n) to O(1) per incident list update.
 
-		// Check if any incidents should be auto-acknowledged;
-		// This must be done before adding the stale incidents
+		// Check if any incidents should be auto-acknowledged.
+		// The on-call check is done OFF the Update loop (checkOnCallAndAcknowledge)
+		// so a slow PagerDuty request never freezes the UI. On-call status is checked
+		// live every refresh — never cached — so leaving SREPD running past a shift
+		// stops auto-ack within one cycle.
+		//
+		// First compute the on-call-independent candidates (assigned && !acked). Only
+		// if there are candidates do we dispatch the on-call check, avoiding an API
+		// call every refresh when nothing is assigned to the user.
 		if m.autoAcknowledge {
-			// Cache the on-call check - it's the same for all incidents in this update
-			userIsOnCall := UserIsOnCall(m.config, m.config.CurrentUser.ID)
-
 			for _, i := range m.incidentList {
-				if ShouldBeAcknowledgedCached(i, m.config.CurrentUser.ID, userIsOnCall) {
+				if AssignedToUser(i, m.config.CurrentUser.ID) && !AcknowledgedByUser(i, m.config.CurrentUser.ID) {
 					acknowledgeIncidentsList = append(acknowledgeIncidentsList, i)
 				}
 			}
 
 			if len(acknowledgeIncidentsList) > 0 {
-				cmds = append(cmds, func() tea.Msg { return acknowledgeIncidentsMsg{incidents: acknowledgeIncidentsList} })
+				cmds = append(cmds, checkOnCallAndAcknowledge(m.config, m.config.CurrentUser.ID, acknowledgeIncidentsList))
 			}
 		}
 
@@ -1378,6 +1382,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			log.Debug("renderedIncidentMsg", "action", "discarding render - incident was closed")
 		}
+
+	case noAcknowledgeMsg:
+		// Background auto-ack sweep found nothing to acknowledge (user not on-call,
+		// on-call check failed, or no candidate matched). No-op — deliberately NOT an
+		// acknowledgeIncidentsMsg, whose nil-incidents fallback would ack the selected
+		// incident.
+		return m, nil
 
 	case acknowledgeIncidentsMsg:
 		// If incidents are provided in the message, use those


### PR DESCRIPTION
## Summary

The auto-acknowledge sweep in the `updatedIncidentListMsg` handler called
`UserIsOnCall` **synchronously**, issuing a live PagerDuty `ListOnCalls` request
on the single-threaded Bubble Tea `Update` loop. With `autoAcknowledge` enabled
this froze the entire UI on every 15s refresh until the API responded.

This moves the on-call check into a one-shot async command
(`checkOnCallAndAcknowledge`) that runs off-loop, filters candidates by the
**fresh** result, and emits `acknowledgeIncidentsMsg` — or a new
`noAcknowledgeMsg` no-op.

### On-call is never cached (safety property)

- **Auto-ack:** a cached "on-call = true" would keep auto-acknowledging incidents
  after a user's shift ends if they leave SREPD running. A live check stops
  auto-ack within one refresh cycle of going off-call.
- **Re-escalate/reassign:** these happen right at the on-call boundary, where a
  cached value would be wrong. There is deliberately **no on-call field on the
  model**, so no path can read a stale value.

`noAcknowledgeMsg` is distinct from `acknowledgeIncidentsMsg` because the
latter's `nil`-incidents fallback acknowledges the *selected* incident — which
must never happen from the background sweep.

Only fires the on-call API call when there are actually assigned+unacked
candidates, so it adds no API traffic when nothing is assigned to the user.

## Test plan

- [x] TDD: 5 tests written first (seen red), then green
- [x] `checkOnCallAndAcknowledge`: on-call→ack, off-call→no-op, error→no-op, no-match→no-op
- [x] Update-level regression: `updatedIncidentListMsg` dispatches a **fresh**
  `ListOnCalls` call (asserts `CallCounts`) and acks the assigned+unacked incident
- [x] `make test-all` green (fmt, vet, lint, test, race, test-fixtures)
- [x] Existing `TestUserIsOnCall_*` / `TestShouldBeAcknowledgedCached_*` unchanged

`skip-readme`: internal async refactor, no user-facing config/flag/keybinding changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)