### PR TITLE
Add context timeouts to raw PagerDuty client calls

### DIFF
--- a/docs/plans/098-api-context-timeouts.md
+++ b/docs/plans/098-api-context-timeouts.md
@@ -1,0 +1,69 @@
+# Plan 098: Add context timeouts to raw PagerDuty client calls
+
+**Branch:** `srepd/api-context-timeouts`
+
+## Problem
+
+Three `tea.Cmd` bodies in `pkg/tui/commands.go` called the PagerDuty client
+directly with a bare `context.Background()` instead of a timeout-bounded context,
+bypassing the `pd` package's `contextWithTimeout()` convention:
+
+- `getIncident` — `p.Client.GetIncidentWithContext(context.Background(), id)`
+- `reassignIncidents` — `GetCurrentUserWithContext(context.Background(), ...)`
+- `addNoteToIncident` — `GetCurrentUserWithContext(context.Background(), ...)`
+
+The client is wrapped by `RateLimitedClient`, which retries with backoff and passes
+the context straight through. With no deadline, a persistently failing/slow endpoint
+can block (and retry) indefinitely.
+
+## Solution
+
+Route all three through timeout-wrapped `pd` helpers:
+
+- `getIncident` now calls the existing `pd.GetIncident(p.Client, id)` (pd.go:258),
+  which applies `contextWithTimeout()` and wraps the error with a `pd.GetIncident():`
+  prefix.
+- Added one new exported wrapper `pd.GetCurrentUser(client)` (mirroring
+  `pd.GetCurrentUserTeams`) that applies the default timeout. Both
+  `reassignIncidents` and `addNoteToIncident` now call it.
+
+## Files Modified
+
+- `pkg/pd/pd.go` — new `GetCurrentUser` wrapper.
+- `pkg/pd/pd_test.go` — `TestGetCurrentUser_Success` / `_Error`.
+- `pkg/tui/commands.go` — three call sites routed through the wrappers.
+- `pkg/tui/commands_test.go` — error-path assertion updated for the wrapped error.
+
+## Tests (TDD)
+
+Written first, seen red (`undefined: GetCurrentUser`), then green:
+- `TestGetCurrentUser_Success` — returns the user and calls
+  `GetCurrentUserWithContext` (proving it routes through the timeout wrapper).
+- `TestGetCurrentUser_Error` — wraps the error with the `pd.GetCurrentUser()` prefix.
+
+Existing tests act as the regression net (`TestReassignIncidents_*`,
+`TestAddNoteToIncident_*`, `TestReassignIncidents_GetCurrentUserError` — the last uses
+`errors.Is`, unaffected by wrapping).
+
+### Deliberate existing-test change (documented per convention)
+
+`TestGetIncident`'s error subtest asserted exact equality against the bare
+`pd.ErrMockError`. Because `getIncident` now routes through `pd.GetIncident`, the
+error carries a `pd.GetIncident():` prefix (matching the pre-existing
+`GetAlerts`/`GetNotes` wrappers). That subtest was replaced by
+`TestGetIncident_ErrorIsWrapped`, which asserts the message contains both the wrapper
+prefix and the original mock error text — strictly more context than before, no
+behavior regression for callers that surface the error string.
+
+## Verification
+
+`make test-all` green (fmt, vet, lint, test, test-race, test-fixtures).
+
+## Lessons Learned
+
+- Any raw `p.Client.*WithContext(context.Background(), ...)` call in the tui package
+  bypasses the `pd` timeout convention. Prefer the `pd.*` wrappers; they centralize
+  `contextWithTimeout()` and consistent error wrapping.
+- The `pd` wrappers wrap with `%v`, not `%w`, so `errors.Is` against the sentinel does
+  not survive. Tests on wrapped errors should assert on the message substring (as the
+  sibling `GetAlerts`/`GetNotes` tests do), not sentinel identity.

--- a/pkg/pd/pd.go
+++ b/pkg/pd/pd.go
@@ -380,6 +380,21 @@ func GetCurrentUserTeams(client PagerDutyClient) ([]pagerduty.Team, error) {
 	return user.Teams, nil
 }
 
+// GetCurrentUser returns the currently-authenticated PagerDuty user, applying the
+// default API timeout. It exists so callers do not open-code
+// GetCurrentUserWithContext(context.Background(), ...), which has no timeout.
+func GetCurrentUser(client PagerDutyClient) (*pagerduty.User, error) {
+	ctx, cancel := contextWithTimeout()
+	defer cancel()
+
+	user, err := client.GetCurrentUserWithContext(ctx, pagerduty.GetCurrentUserOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("pd.GetCurrentUser(): failed to get current user: %w", err)
+	}
+
+	return user, nil
+}
+
 func GetUserOnCalls(client PagerDutyClient, id string, opts pagerduty.ListOnCallOptions) ([]pagerduty.OnCall, error) {
 	ctx, cancel := contextWithTimeout()
 	defer cancel()

--- a/pkg/pd/pd_test.go
+++ b/pkg/pd/pd_test.go
@@ -446,6 +446,32 @@ func TestGetCurrentUserTeams_Error(t *testing.T) {
 	assert.Nil(t, teams)
 }
 
+func TestGetCurrentUser_Success(t *testing.T) {
+	mockClient := &MockPagerDutyClient{}
+
+	user, err := GetCurrentUser(mockClient)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, user)
+	assert.Equal(t, "MOCK_USER", user.ID)
+	assert.Equal(t, "mock@example.com", user.Email)
+	// The wrapper must apply a timeout context, so it routes through
+	// GetCurrentUserWithContext (not a bare Background call).
+	assert.GreaterOrEqual(t, mockClient.CallCounts["GetCurrentUserWithContext"], 1)
+}
+
+func TestGetCurrentUser_Error(t *testing.T) {
+	mockClient := &MockPagerDutyClient{
+		GetCurrentUserErr: ErrMockError,
+	}
+
+	user, err := GetCurrentUser(mockClient)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "pd.GetCurrentUser()")
+	assert.Nil(t, user)
+}
+
 func TestNewConfig_Success(t *testing.T) {
 	mockClient := &MockPagerDutyClient{}
 	policies := map[string]string{

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -86,8 +86,9 @@ func getIncident(p *pd.Config, id string) tea.Cmd {
 		if id == "" {
 			return setStatusMsg{nilIncidentMsg}
 		}
-		ctx := context.Background()
-		i, err := p.Client.GetIncidentWithContext(ctx, id)
+		// Route through pd.GetIncident, which applies the default API timeout,
+		// instead of calling the raw client with context.Background().
+		i, err := pd.GetIncident(p.Client, id)
 		return gotIncidentMsg{i, err}
 	}
 }
@@ -874,7 +875,7 @@ type reassignedIncidentsMsg []pagerduty.Incident
 
 func reassignIncidents(p *pd.Config, i []pagerduty.Incident, users []*pagerduty.User) tea.Cmd {
 	return func() tea.Msg {
-		u, err := p.Client.GetCurrentUserWithContext(context.Background(), pagerduty.GetCurrentUserOptions{})
+		u, err := pd.GetCurrentUser(p.Client)
 		if err != nil {
 			return errMsg{err}
 		}
@@ -983,7 +984,7 @@ func addNoteToIncident(p *pd.Config, incident *pagerduty.Incident, file *os.File
 
 		note := removeCommentsFromBytes(bytes, "#")
 
-		u, err := p.Client.GetCurrentUserWithContext(context.Background(), pagerduty.GetCurrentUserOptions{})
+		u, err := pd.GetCurrentUser(p.Client)
 		if err != nil {
 			return errMsg{err}
 		}

--- a/pkg/tui/commands_test.go
+++ b/pkg/tui/commands_test.go
@@ -187,15 +187,6 @@ func TestGetIncident(t *testing.T) {
 				err: nil,
 			},
 		},
-		{
-			name:   "return gotIncidentMsg with not-nil error if error occurs",
-			config: mockConfig,
-			id:     "err", // "err" signals the mock client to produce a mock error
-			expected: gotIncidentMsg{
-				incident: &pagerduty.Incident{},
-				err:      pd.ErrMockError,
-			},
-		},
 	}
 
 	for _, test := range tests {
@@ -204,6 +195,25 @@ func TestGetIncident(t *testing.T) {
 			actual := cmd()
 			assert.Equal(t, test.expected, actual)
 		})
+	}
+}
+
+// TestGetIncident_ErrorIsWrapped verifies the error path separately. getIncident now
+// routes through pd.GetIncident, which applies a timeout AND wraps the underlying
+// error with a "pd.GetIncident():" prefix for context (consistent with the sibling
+// pd.GetAlerts / pd.GetNotes wrappers). The wrapped message still contains the
+// original mock error text, so callers that surface the error string see strictly
+// more context than before — an intentional improvement, not a regression.
+func TestGetIncident_ErrorIsWrapped(t *testing.T) {
+	mockConfig := &pd.Config{Client: &pd.MockPagerDutyClient{}}
+
+	msg := getIncident(mockConfig, "err")()
+
+	got, ok := msg.(gotIncidentMsg)
+	assert.True(t, ok, "expected gotIncidentMsg")
+	if assert.Error(t, got.err) {
+		assert.Contains(t, got.err.Error(), "pd.GetIncident()", "error should carry the wrapper prefix")
+		assert.Contains(t, got.err.Error(), pd.ErrMockError.Error(), "wrapped error must retain the original message")
 	}
 }
 


### PR DESCRIPTION
## Summary

Three `tea.Cmd` bodies called the PagerDuty client with a bare
`context.Background()`, bypassing the `pd` package's `contextWithTimeout()`
convention. With the retrying `RateLimitedClient` this can block indefinitely on
a slow/failing endpoint.

- `getIncident` → routes through the existing `pd.GetIncident` wrapper.
- `reassignIncidents` + `addNoteToIncident` → new `pd.GetCurrentUser(client)`
  wrapper (mirrors `pd.GetCurrentUserTeams`), applying the default timeout.

## Test plan

- [x] TDD: `TestGetCurrentUser_Success` / `_Error` written first (red), then green
- [x] `TestGetIncident`'s exact-equality error subtest replaced by
  `TestGetIncident_ErrorIsWrapped` — deliberate, documented change (error now
  carries a `pd.GetIncident()` prefix while retaining the original message)
- [x] Existing `TestReassignIncidents_*` / `TestAddNoteToIncident_*` unchanged and green
- [x] `make test-all` green (fmt, vet, lint, test, race, test-fixtures)

`skip-readme`: internal timeout hardening, no user-facing config/flag/keybinding changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)