### PR TITLE
Harden launcher against argument injection

### DIFF
--- a/docs/plans/100-launcher-arg-injection.md
+++ b/docs/plans/100-launcher-arg-injection.md
@@ -1,0 +1,63 @@
+# Plan 100: Harden launcher against argument injection
+
+**Branch:** `srepd/launcher-arg-injection`
+
+## Problem
+
+`replaceVars` (`pkg/launcher/launcher.go`) substituted template variables
+(`%%CLUSTER_ID%%`, `%%INCIDENT_ID%%`) by joining all args on a single space,
+running `strings.ReplaceAll`, then splitting back on spaces. Any substituted value
+containing a space was **re-tokenized into extra argv elements**.
+
+The values come from PagerDuty alert data (`getDetailFieldFromAlert("cluster_id", …)`)
+and are not validated. Because the built command is passed to `exec.Command` (no
+shell), this is not shell RCE — but a `cluster_id` like `x --evil-flag y` could inject
+extra command-line arguments into `ocm backplane login` / `rosa-boundary`.
+
+## Solution — two complementary layers
+
+1. **Per-arg substitution.** `replaceVars` now iterates each arg and substitutes in
+   place, never joining/splitting. A substituted value with spaces stays within its
+   single argv slot.
+2. **Validate at the TUI boundary.** Added exported `ocm.ValidClusterID(id)` (wrapping
+   the existing `clusterIDPattern = ^[a-zA-Z0-9_-]+$`). `getUniqueClusters`
+   (`pkg/tui/commands.go`) now skips any cluster_id that fails validation (and logs a
+   warning), so malformed values never reach the launcher `vars` map.
+
+## Files Modified
+
+- `pkg/launcher/launcher.go` — `replaceVars` rewritten per-arg.
+- `pkg/launcher/launcher_test.go` — `TestReplaceVars_PreservesArgBoundaries`.
+- `pkg/ocm/client.go` — exported `ValidClusterID`.
+- `pkg/ocm/ocm_test.go` — `TestValidClusterID`.
+- `pkg/tui/commands.go` — `getUniqueClusters` validates cluster IDs.
+- `pkg/tui/commands_test.go` — `TestGetUniqueClusters_RejectsMalformedClusterID`.
+
+## Tests (TDD)
+
+Written first, seen red, then green:
+- `TestReplaceVars_PreservesArgBoundaries` — a value with spaces stays one argv
+  element (fails on the old join/split); simple/no-space cases and nil inputs unchanged.
+  **Asserts on the `[]string` slice**, not a joined string, so it cannot pass if arg
+  boundaries regress (the existing `TestLoginCommandBuild` compares via `strings.Join`,
+  which is boundary-blind — this test closes that gap).
+- `TestValidClusterID` — accepts UUID/underscore IDs, rejects empty / spaces /
+  injected flags / shell metacharacters.
+- `TestGetUniqueClusters_RejectsMalformedClusterID` — malformed IDs filtered, good ID
+  kept.
+
+Existing `TestLoginCommandBuild` and all `TestGetUniqueClusters_*` remain green.
+
+## Verification
+
+`make test-all` green. Manual: an alert with a space-bearing `cluster_id` no longer
+injects extra args into the launched login command (value is dropped at
+`getUniqueClusters` and, defensively, would stay one argv slot in `replaceVars`).
+
+## Lessons Learned
+
+- Join-then-split on spaces silently destroys argv boundaries; substitute per-arg.
+- Tests that compare argv via `strings.Join` cannot detect boundary regressions —
+  assert on the slice.
+- Attacker-influenceable data (PagerDuty alert fields) must be validated at the trust
+  boundary before it reaches `exec.Command`, even without a shell.

--- a/pkg/launcher/launcher.go
+++ b/pkg/launcher/launcher.go
@@ -264,20 +264,26 @@ func (l *ClusterLauncher) logCommand(command []string) {
 	}
 }
 
+// replaceVars substitutes template variables (e.g. %%CLUSTER_ID%%) in each arg,
+// operating per-arg so a substituted value never crosses argv boundaries. The
+// previous implementation joined all args on spaces, substituted, then split back
+// on spaces — which re-tokenized any substituted value containing a space into
+// extra argv elements. Because these args are passed to exec.Command (no shell),
+// that allowed attacker-controlled alert data (cluster/incident IDs) to inject
+// additional command-line arguments. Per-arg substitution closes that.
 func replaceVars(args []string, vars map[string]string) []string {
 	if args == nil || vars == nil {
 		return []string{}
 	}
 
-	str := strings.Join(args, " ")
-
-	for k, v := range vars {
-		log.Debug("launcher.replaceVars()", "string", str, "key", k, "value", v)
-		str = strings.ReplaceAll(str, k, v)
+	out := make([]string, len(args))
+	for i, arg := range args {
+		for k, v := range vars {
+			arg = strings.ReplaceAll(arg, k, v)
+		}
+		out[i] = arg
 	}
 
-	log.Debug("launcher.replaceVars()", "result", str)
-
-	transformedArgs := strings.Split(str, " ")
-	return transformedArgs
+	log.Debug("launcher.replaceVars()", "result", out)
+	return out
 }

--- a/pkg/launcher/launcher_test.go
+++ b/pkg/launcher/launcher_test.go
@@ -411,3 +411,44 @@ func TestLoginCommandBuild(t *testing.T) {
 		})
 	}
 }
+
+// TestReplaceVars_PreservesArgBoundaries verifies that a substituted value
+// containing spaces stays within its single argv element and does not get
+// re-tokenized into extra arguments. This is the core of the argument-injection
+// hardening: an attacker-controlled %%CLUSTER_ID%% like "x --evil-flag y" must
+// not inject extra arguments into the launched command.
+func TestReplaceVars_PreservesArgBoundaries(t *testing.T) {
+	t.Run("value with spaces stays a single argv element", func(t *testing.T) {
+		args := []string{"login", "-c", "%%CLUSTER_ID%%"}
+		vars := map[string]string{"%%CLUSTER_ID%%": "evil --flag injected"}
+
+		got := replaceVars(args, vars)
+
+		assert.Equal(t, []string{"login", "-c", "evil --flag injected"}, got,
+			"substituted value must occupy exactly one argv slot")
+		assert.Len(t, got, 3, "must not re-tokenize the substituted value into extra args")
+	})
+
+	t.Run("simple substitution without spaces is unchanged", func(t *testing.T) {
+		args := []string{"login", "-c", "%%CLUSTER_ID%%", "--incident", "%%INCIDENT_ID%%"}
+		vars := map[string]string{"%%CLUSTER_ID%%": "abcdefg", "%%INCIDENT_ID%%": "PD123456"}
+
+		got := replaceVars(args, vars)
+
+		assert.Equal(t, []string{"login", "-c", "abcdefg", "--incident", "PD123456"}, got)
+	})
+
+	t.Run("nil args or vars returns empty slice", func(t *testing.T) {
+		assert.Equal(t, []string{}, replaceVars(nil, map[string]string{"a": "b"}))
+		assert.Equal(t, []string{}, replaceVars([]string{"a"}, nil))
+	})
+
+	t.Run("multiple vars in one arg all substitute in place", func(t *testing.T) {
+		args := []string{"prefix-%%CLUSTER_ID%%-%%INCIDENT_ID%%-suffix"}
+		vars := map[string]string{"%%CLUSTER_ID%%": "CID", "%%INCIDENT_ID%%": "IID"}
+
+		got := replaceVars(args, vars)
+
+		assert.Equal(t, []string{"prefix-CID-IID-suffix"}, got)
+	})
+}

--- a/pkg/ocm/client.go
+++ b/pkg/ocm/client.go
@@ -25,6 +25,14 @@ const (
 
 var clusterIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 
+// ValidClusterID reports whether id is a well-formed cluster identifier
+// (non-empty, only [a-zA-Z0-9_-]). It is used to reject attacker-influenced
+// values from PagerDuty alert data before they are substituted into launched
+// commands, preventing argument injection.
+func ValidClusterID(id string) bool {
+	return clusterIDPattern.MatchString(id)
+}
+
 // Client wraps the OCM SDK connection for cluster enrichment.
 type Client struct {
 	conn *sdk.Connection

--- a/pkg/ocm/ocm_test.go
+++ b/pkg/ocm/ocm_test.go
@@ -160,6 +160,26 @@ func TestClusterIDPattern(t *testing.T) {
 	}
 }
 
+func TestValidClusterID(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		valid bool
+	}{
+		{"uuid format", "e7c5363a-fake-uuid-test-edf99fc3ea25", true},
+		{"alphanumeric with underscore", "cluster_id_123", true},
+		{"empty", "", false},
+		{"argument injection with flag", "abc --evil-flag x", false},
+		{"spaces", "cluster id", false},
+		{"shell metacharacters", "abc;rm -rf", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.valid, ValidClusterID(tt.input))
+		})
+	}
+}
+
 func TestLoadMockClientFromFixtures(t *testing.T) {
 	t.Run("loads all fixture types from directory", func(t *testing.T) {
 		mock, err := LoadMockClientFromFixtures("../../testdata/fixtures")

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -1069,7 +1069,11 @@ func getSOPLink(alerts []pagerduty.IncidentAlert) (string, bool) {
 }
 
 // getUniqueClusters extracts deduplicated cluster_ids from alerts, preserving
-// the order of first appearance. Alerts without a cluster_id are skipped.
+// the order of first appearance. Alerts without a cluster_id are skipped, as are
+// values that are not well-formed cluster IDs (ocm.ValidClusterID). Cluster IDs
+// originate from attacker-influenceable PagerDuty alert data and are later
+// substituted into launched commands, so rejecting malformed values here prevents
+// argument injection at the launcher boundary.
 func getUniqueClusters(alerts []pagerduty.IncidentAlert) []string {
 	seen := make(map[string]bool)
 	var clusters []string
@@ -1079,10 +1083,15 @@ func getUniqueClusters(alerts []pagerduty.IncidentAlert) []string {
 			normalized := alert.NormalizeAlert(a.Service.Summary, "", a)
 			cluster = normalized.ClusterID
 		}
-		if cluster != "" && !seen[cluster] {
-			seen[cluster] = true
-			clusters = append(clusters, cluster)
+		if cluster == "" || seen[cluster] {
+			continue
 		}
+		if !ocm.ValidClusterID(cluster) {
+			log.Warn("skipping malformed cluster_id from alert data", "cluster_id", cluster)
+			continue
+		}
+		seen[cluster] = true
+		clusters = append(clusters, cluster)
 	}
 	return clusters
 }

--- a/pkg/tui/commands_test.go
+++ b/pkg/tui/commands_test.go
@@ -1058,6 +1058,28 @@ func TestGetUniqueClusters_SingleCluster(t *testing.T) {
 	assert.Equal(t, []string{"cluster-abc-123"}, result)
 }
 
+func TestGetUniqueClusters_RejectsMalformedClusterID(t *testing.T) {
+	// A cluster_id from PagerDuty alert data that contains spaces / injected flags
+	// must be filtered out so it never reaches the launcher and injects arguments
+	// into the login command. A well-formed ID in the same batch is kept.
+	alerts := []pagerduty.IncidentAlert{
+		{Body: map[string]interface{}{"details": map[string]interface{}{
+			"cluster_id": "good-cluster-123",
+		}}},
+		{Body: map[string]interface{}{"details": map[string]interface{}{
+			"cluster_id": "evil --flag injected",
+		}}},
+		{Body: map[string]interface{}{"details": map[string]interface{}{
+			"cluster_id": "abc;rm -rf /",
+		}}},
+	}
+
+	result := getUniqueClusters(alerts)
+
+	assert.Equal(t, []string{"good-cluster-123"}, result,
+		"only well-formed cluster IDs may pass to the launcher")
+}
+
 func TestGetUniqueClusters_MultipleDifferent(t *testing.T) {
 	// 3 alerts with 2 distinct cluster_ids should return 2 entries
 	alerts := []pagerduty.IncidentAlert{


### PR DESCRIPTION
## Summary

`replaceVars` joined args on spaces → `ReplaceAll` → split on spaces,
re-tokenizing any substituted value containing a space into extra argv
elements. Cluster/incident IDs come from PagerDuty alert data and the command
is passed to `exec.Command`, so an attacker-controlled `cluster_id` like
`x --evil-flag y` could inject extra arguments (not shell RCE — argv injection).

**Two layers:**
1. `replaceVars` rewritten to substitute **per-arg** — a value with spaces stays
   one argv element.
2. Added exported `ocm.ValidClusterID`; `getUniqueClusters` now drops any
   `cluster_id` failing `^[a-zA-Z0-9_-]+$` before it reaches the launcher.

## Test plan

- [x] TDD: 3 test groups written first (red), then green
- [x] `TestReplaceVars_PreservesArgBoundaries` asserts on the **`[]string` slice**,
  not a joined string — the existing `TestLoginCommandBuild` compares via
  `strings.Join` and is boundary-blind, so this closes that gap
- [x] `TestValidClusterID` + `TestGetUniqueClusters_RejectsMalformedClusterID`
- [x] Existing launcher/ocm/tui tests unchanged and green
- [x] `make test-all` green (fmt, vet, lint, test, race, test-fixtures)

`skip-readme`: internal security hardening, no user-facing config/flag/keybinding changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)