### PR TITLE
Harden AI providers: no token leak in errors, request timeouts

### DIFF
--- a/docs/plans/101-ai-provider-hardening.md
+++ b/docs/plans/101-ai-provider-hardening.md
@@ -1,0 +1,59 @@
+# Plan 101: Harden AI providers (no token leak, request timeouts)
+
+**Branch:** `srepd/ai-provider-hardening`
+
+## Problem
+
+1. **Token leak vector.** On non-200 responses, `openai_compat.go` and `ollama.go`
+   read the response body and interpolated it into the returned error
+   (`server returned %d: %s`). A proxy/gateway that echoes the `Authorization: Bearer
+   <token>` header back in its error body would leak the API token into srepd's error
+   output and logs.
+2. **No request-timeout defense.** The providers share a single `http.Client` with no
+   `Timeout`. Callers pass a deadline context today, but there was no defense-in-depth
+   if a caller ever passed a deadline-less context.
+
+## Solution
+
+1. **Drop the body from error paths.** All four `Query`/`StreamQuery` non-200 branches
+   now return the status code only (`server returned %d`), matching the existing
+   `Healthy` methods. The token is never in the request/response body — only the
+   header — so status-only removes the leak regardless of what the server echoes.
+2. **Per-request default timeout for non-streaming calls.** Added
+   `defaultRequestTimeout` (60s) and `ensureTimeout(ctx, d)` in `provider.go`:
+   returns ctx unchanged if it already has a deadline, else derives a bounded one.
+   Applied in both providers' `Query` and `Healthy`. **Not** applied to `StreamQuery`
+   (a whole-request timeout would truncate long token streams) and **not** set on the
+   shared `http.Client.Timeout` (same reason — it would hit the stream path).
+
+## Files Modified
+
+- `pkg/ai/provider.go` — `defaultRequestTimeout`, `ensureTimeout`.
+- `pkg/ai/openai_compat.go` / `ollama.go` — drop body from 4 error sites; add
+  `requestTimeout` field; `ensureTimeout` in `Query`/`Healthy`; remove now-unused `io`.
+- `pkg/ai/openai_compat_test.go` / `ollama_test.go` — leak + timeout tests.
+
+## Tests (TDD)
+
+Written first, seen red, then green:
+- `TestOpenAIQuery_DoesNotLeakTokenInError` / `_StreamQuery...` /
+  `TestOllamaQuery_DoesNotLeakHeadersInError` — server echoes the Authorization header
+  in a 401 body; the error must contain `401` but never the token/marker (red on the
+  old body-echoing error).
+- `TestOpenAIQuery_AppliesDefaultTimeout` — a hung server + `context.Background()`
+  (no deadline) returns promptly via the provider's default timeout.
+
+Existing `TestOpenAIQuery_ServerError` / `TestOllamaQuery_ServerError` assert
+`Contains("500")` — still true (status code retained), so unchanged.
+
+## Verification
+
+`make test-all` green (fmt, vet, lint, test, race, test-fixtures).
+
+## Lessons Learned
+
+- Never interpolate an upstream response body into an error surfaced to logs when the
+  request carries a secret header — a reflecting proxy turns it into a credential leak.
+  Prefer status-code-only (as the `Healthy` methods already did).
+- A client-level `http.Client.Timeout` is a whole-request deadline and will truncate
+  streaming responses; bound non-streaming calls via the request context instead.

--- a/pkg/ai/ollama.go
+++ b/pkg/ai/ollama.go
@@ -6,17 +6,18 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/log"
 )
 
 type ollamaProvider struct {
-	endpoint   string
-	model      string
-	httpClient *http.Client
+	endpoint       string
+	model          string
+	httpClient     *http.Client
+	requestTimeout time.Duration
 }
 
 func newOllamaProvider(cfg Config) (*ollamaProvider, error) {
@@ -31,9 +32,10 @@ func newOllamaProvider(cfg Config) (*ollamaProvider, error) {
 	}
 
 	return &ollamaProvider{
-		endpoint:   strings.TrimRight(endpoint, "/"),
-		model:      model,
-		httpClient: &http.Client{},
+		endpoint:       strings.TrimRight(endpoint, "/"),
+		model:          model,
+		httpClient:     &http.Client{},
+		requestTimeout: defaultRequestTimeout,
 	}, nil
 }
 
@@ -59,6 +61,8 @@ type ollamaChatResponse struct {
 
 func (p *ollamaProvider) Query(ctx context.Context, systemPrompt string, userPrompt string) (string, error) {
 	log.Debug("ollama.Query", "endpoint", p.endpoint, "model", p.model)
+	ctx, cancel := ensureTimeout(ctx, p.requestTimeout)
+	defer cancel()
 	messages := buildOllamaMessages(systemPrompt, userPrompt)
 
 	body, err := json.Marshal(ollamaChatRequest{
@@ -83,8 +87,8 @@ func (p *ollamaProvider) Query(ctx context.Context, systemPrompt string, userPro
 	defer resp.Body.Close() //nolint:errcheck
 
 	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("ollama: server returned %d: %s", resp.StatusCode, string(respBody))
+		// Status code only — the body may echo request headers (see openai provider).
+		return "", fmt.Errorf("ollama: server returned %d", resp.StatusCode)
 	}
 
 	var chatResp ollamaChatResponse
@@ -123,8 +127,8 @@ func (p *ollamaProvider) StreamQuery(ctx context.Context, systemPrompt string, u
 	defer resp.Body.Close() //nolint:errcheck
 
 	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("ollama: server returned %d: %s", resp.StatusCode, string(respBody))
+		// Status code only — the body may echo request headers (see openai provider).
+		return fmt.Errorf("ollama: server returned %d", resp.StatusCode)
 	}
 
 	scanner := bufio.NewScanner(resp.Body)
@@ -157,6 +161,8 @@ func (p *ollamaProvider) StreamQuery(ctx context.Context, systemPrompt string, u
 
 func (p *ollamaProvider) Healthy(ctx context.Context) error {
 	log.Debug("ollama.Healthy", "endpoint", p.endpoint)
+	ctx, cancel := ensureTimeout(ctx, p.requestTimeout)
+	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.endpoint+"/api/tags", nil)
 	if err != nil {
 		return fmt.Errorf("ollama: create health request: %w", err)

--- a/pkg/ai/ollama_test.go
+++ b/pkg/ai/ollama_test.go
@@ -86,6 +86,26 @@ func TestOllamaQuery_ServerError(t *testing.T) {
 	assert.Contains(t, err.Error(), "500")
 }
 
+// TestOllamaQuery_DoesNotLeakHeadersInError ensures a non-200 error carries the
+// status code but not an echoed request body (which could contain headers).
+func TestOllamaQuery_DoesNotLeakHeadersInError(t *testing.T) {
+	const secret = "ollama-secret-marker"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte("denied " + r.Header.Get("Authorization") + secret))
+	}))
+	defer server.Close()
+
+	provider, err := newOllamaProvider(Config{Endpoint: server.URL, Model: "m"})
+	assert.NoError(t, err)
+
+	_, err = provider.Query(context.Background(), "", "test")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "401")
+	assert.NotContains(t, err.Error(), secret, "error must not include the echoed response body")
+}
+
 func TestOllamaStreamQuery_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req ollamaChatRequest

--- a/pkg/ai/openai_compat.go
+++ b/pkg/ai/openai_compat.go
@@ -6,18 +6,19 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/log"
 )
 
 type openaiCompatProvider struct {
-	endpoint   string
-	model      string
-	apiKey     string
-	httpClient *http.Client
+	endpoint       string
+	model          string
+	apiKey         string
+	httpClient     *http.Client
+	requestTimeout time.Duration
 }
 
 func newOpenAICompatProvider(cfg Config, apiKey string) (*openaiCompatProvider, error) {
@@ -26,10 +27,11 @@ func newOpenAICompatProvider(cfg Config, apiKey string) (*openaiCompatProvider, 
 	}
 
 	return &openaiCompatProvider{
-		endpoint:   strings.TrimRight(cfg.Endpoint, "/"),
-		model:      cfg.Model,
-		apiKey:     apiKey,
-		httpClient: &http.Client{},
+		endpoint:       strings.TrimRight(cfg.Endpoint, "/"),
+		model:          cfg.Model,
+		apiKey:         apiKey,
+		httpClient:     &http.Client{},
+		requestTimeout: defaultRequestTimeout,
 	}, nil
 }
 
@@ -59,6 +61,8 @@ type openaiChoice struct {
 
 func (p *openaiCompatProvider) Query(ctx context.Context, systemPrompt string, userPrompt string) (string, error) {
 	log.Debug("openai.Query", "endpoint", p.endpoint, "model", p.model)
+	ctx, cancel := ensureTimeout(ctx, p.requestTimeout)
+	defer cancel()
 	messages := buildOpenAIMessages(systemPrompt, userPrompt)
 
 	body, err := json.Marshal(openaiChatRequest{
@@ -83,8 +87,10 @@ func (p *openaiCompatProvider) Query(ctx context.Context, systemPrompt string, u
 	defer resp.Body.Close() //nolint:errcheck
 
 	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("openai: server returned %d: %s", resp.StatusCode, string(respBody))
+		// Do NOT include the response body: a proxy/gateway may echo the
+		// Authorization header back in its error body, which would leak the API
+		// token into logs. Status code only (matches the Healthy method).
+		return "", fmt.Errorf("openai: server returned %d", resp.StatusCode)
 	}
 
 	var chatResp openaiChatResponse
@@ -127,8 +133,8 @@ func (p *openaiCompatProvider) StreamQuery(ctx context.Context, systemPrompt str
 	defer resp.Body.Close() //nolint:errcheck
 
 	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("openai: server returned %d: %s", resp.StatusCode, string(respBody))
+		// Status code only — see the Query method: the body may echo the token.
+		return fmt.Errorf("openai: server returned %d", resp.StatusCode)
 	}
 
 	scanner := bufio.NewScanner(resp.Body)
@@ -163,6 +169,8 @@ func (p *openaiCompatProvider) StreamQuery(ctx context.Context, systemPrompt str
 
 func (p *openaiCompatProvider) Healthy(ctx context.Context) error {
 	log.Debug("openai.Healthy", "endpoint", p.endpoint)
+	ctx, cancel := ensureTimeout(ctx, p.requestTimeout)
+	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.endpoint+"/v1/models", nil)
 	if err != nil {
 		return fmt.Errorf("openai: create health request: %w", err)

--- a/pkg/ai/openai_compat_test.go
+++ b/pkg/ai/openai_compat_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -120,6 +121,73 @@ func TestOpenAIQuery_ServerError(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "500")
+}
+
+// TestOpenAIQuery_AppliesDefaultTimeout verifies that a non-streaming Query called
+// with a context that has no deadline still gets bounded by the provider's default
+// request timeout, so a hung server cannot block forever. The shared http.Client has
+// no Timeout (that would truncate streams), so this defense lives in the request
+// context.
+func TestOpenAIQuery_AppliesDefaultTimeout(t *testing.T) {
+	block := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		<-block // hang until the test releases it
+	}))
+	defer server.Close()
+	defer close(block)
+
+	provider, err := newOpenAICompatProvider(Config{Endpoint: server.URL, Model: "m"}, "")
+	assert.NoError(t, err)
+	// Shorten the default so the test is fast.
+	provider.requestTimeout = 100 * time.Millisecond
+
+	start := time.Now()
+	_, err = provider.Query(context.Background(), "", "test")
+	elapsed := time.Since(start)
+
+	assert.Error(t, err, "a hung server with no caller deadline should time out")
+	assert.Less(t, elapsed, 5*time.Second, "should return promptly via the default timeout")
+}
+
+// TestOpenAIQuery_DoesNotLeakTokenInError guards against a proxy/gateway that echoes
+// the Authorization header back in its error body: the returned error must contain
+// the status code but never the API key.
+func TestOpenAIQuery_DoesNotLeakTokenInError(t *testing.T) {
+	const secret = "sk-super-secret-token-value"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Simulate a gateway that reflects the Authorization header in the body.
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte("denied for " + r.Header.Get("Authorization")))
+	}))
+	defer server.Close()
+
+	provider, err := newOpenAICompatProvider(Config{Endpoint: server.URL, Model: "m"}, secret)
+	assert.NoError(t, err)
+
+	_, err = provider.Query(context.Background(), "", "test")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "401", "error should carry the status code")
+	assert.NotContains(t, err.Error(), secret, "error must not leak the API token")
+}
+
+func TestOpenAIStreamQuery_DoesNotLeakTokenInError(t *testing.T) {
+	const secret = "sk-super-secret-token-value"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte("denied for " + r.Header.Get("Authorization")))
+	}))
+	defer server.Close()
+
+	provider, err := newOpenAICompatProvider(Config{Endpoint: server.URL, Model: "m"}, secret)
+	assert.NoError(t, err)
+
+	ch := make(chan string, 4)
+	err = provider.StreamQuery(context.Background(), "", "test", ch)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "401")
+	assert.NotContains(t, err.Error(), secret, "stream error must not leak the API token")
 }
 
 func TestOpenAIQuery_NoSystemPrompt(t *testing.T) {

--- a/pkg/ai/provider.go
+++ b/pkg/ai/provider.go
@@ -1,6 +1,25 @@
 package ai
 
-import "context"
+import (
+	"context"
+	"time"
+)
+
+// defaultRequestTimeout bounds non-streaming provider requests when the caller's
+// context carries no deadline. Streaming requests are intentionally not bounded here
+// (a whole-request timeout would truncate long token streams); they rely on the
+// caller's context.
+const defaultRequestTimeout = 60 * time.Second
+
+// ensureTimeout returns ctx unchanged if it already has a deadline; otherwise it
+// derives a context bounded by timeout. The returned cancel func must always be
+// called by the caller.
+func ensureTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if _, ok := ctx.Deadline(); ok {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, timeout)
+}
 
 // Provider defines the interface for LLM API integrations.
 // Implementations must be safe for concurrent use.


### PR DESCRIPTION
## Summary

1. **Token leak fix:** on non-200 responses both providers interpolated the
   response body into the returned error. A proxy/gateway that echoes the
   `Authorization: Bearer <token>` header in its error body would leak the token
   into logs. Now return **status code only** (matching the `Healthy` methods) —
   the token is only ever in the request header, so this removes the leak.
2. **Timeouts:** added `ensureTimeout` applying a default 60s deadline to
   non-streaming `Query`/`Healthy` when the caller's context has none.
   **Not** applied to `StreamQuery` or the shared `http.Client.Timeout` — either
   would truncate long token streams.

## Test plan

- [x] TDD: leak + timeout tests written first (red), then green
- [x] `*_DoesNotLeakTokenInError` — server echoes the Authorization header in a
  401 body; error contains `401` but never the token
- [x] `TestOpenAIQuery_AppliesDefaultTimeout` — hung server + deadline-less
  context returns promptly
- [x] Existing `*_ServerError` tests (`Contains("500")`) still pass — status retained
- [x] `make test-all` green (fmt, vet, lint, test, race, test-fixtures)

No README trigger files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)