### PR TITLE
CI and Makefile hygiene

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -10,6 +10,11 @@ on:
     branches:
       - main
 
+# No job writes to the repo; the Codecov upload uses its own CODECOV_TOKEN secret,
+# not GITHUB_TOKEN. Grant the minimal read-only scope.
+permissions:
+  contents: read
+
 jobs:
   plan-doc:
     name: Plan Document
@@ -66,6 +71,19 @@ jobs:
 
       - name: Run go vet
         run: make vet
+
+  fixtures:
+    name: Fixture Sanitization
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      # Pure grep; no Go toolchain required. Ensures no real customer UUIDs or
+      # domains leak into testdata fixtures — previously only enforced locally.
+      - name: Check fixture sanitization
+        run: make test-fixtures
 
   lint:
     name: Lint
@@ -156,7 +174,7 @@ jobs:
         run: go test ./... -coverprofile=coverage.out -covermode=atomic
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
         with:
           files: coverage.out
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ unexport GOFLAGS
 GOOS ?= linux
 GOARCH ?= amd64
 GOENV = GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=0 GOFLAGS=
-GOPATH := $(shell go env GOPATH | awk -F: '{print $1}')
+GOPATH := $(shell go env GOPATH | awk -F: '{print $$1}')
 BIN_DIR := $(GOPATH)/bin
 HOME ?= $(shell echo ~)
 
@@ -230,7 +230,7 @@ ensure-goreleaser: ## Ensure goreleaser is installed
 .PHONY: release
 release: ensure-goreleaser ## Create a release using goreleaser (RELEASE_NOTES=/path/to/notes.md optional)
 	@echo "Creating a release..."
-	GITHUB_TOKEN=$$(jq -r .goreleaser_token ~/.config/goreleaser/goreleaser_token) && \
+	@GITHUB_TOKEN=$$(jq -r .goreleaser_token ~/.config/goreleaser/goreleaser_token) && \
 	export GITHUB_TOKEN && \
 	goreleaser release --clean --parallelism 1 $(if $(RELEASE_NOTES),--release-notes $(RELEASE_NOTES),)
 

--- a/docs/plans/102-ci-makefile-hygiene.md
+++ b/docs/plans/102-ci-makefile-hygiene.md
@@ -1,0 +1,58 @@
+# Plan 102: CI and Makefile hygiene
+
+**Branch:** `srepd/ci-makefile-hygiene`
+
+## Problem
+
+Several low-risk CI/build hygiene gaps:
+
+1. **No `permissions:` block** in `.github/workflows/go-ci.yml` — every job inherited
+   the repo-default `GITHUB_TOKEN` scope, broader than any job needs.
+2. **`test-fixtures` was not a CI job** — the customer-data sanitization check
+   (`Makefile` `test-fixtures`, scanning `testdata/fixtures/*.json` for real UUIDs and
+   domains) ran only locally via `make test-all`. A contributor who skipped it could
+   merge real customer data — the opposite of the "never commit customer data" rule.
+3. **`codecov/codecov-action` pinned to a mutable `@v6` tag** — third-party action, a
+   supply-chain risk (a prior version was compromised).
+4. **Makefile `GOPATH` bug** — `awk -F: '{print $1}'`: Make expands `$1` to empty
+   before awk runs, so awk printed `$0` (the whole line). Worked by accident only when
+   `GOPATH` had no `:`.
+5. **`make release` token line not `@`-silenced** — Make echoed the `jq`-token recipe
+   line (the command, not the resolved value) to stdout.
+
+## Solution
+
+- `.github/workflows/go-ci.yml`:
+  - Add top-level `permissions: contents: read`.
+  - Add a `fixtures` job running `make test-fixtures` (mirrors the `vet` job; pure
+    grep, no Go toolchain).
+  - Pin `codecov/codecov-action` to the `v6` commit SHA
+    (`fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6`).
+- `Makefile`:
+  - `awk -F: '{print $1}'` → `$$1` so awk receives the real program.
+  - `@`-prefix the `make release` `GITHUB_TOKEN=$$(jq …)` line.
+
+## Files Modified
+
+- `.github/workflows/go-ci.yml`
+- `Makefile`
+
+## Tests / Verification
+
+No Go code changed. Verified:
+- Workflow YAML parses (`yaml.safe_load`).
+- `GOPATH := $(shell …)` now resolves to the first path element
+  (`/home/…/pkgsets/go1.26.4/global`, not the whole line).
+- `make test-fixtures` passes.
+- `go build ./...`, `gofmt -s` clean; `make test-all` unaffected.
+
+The new `fixtures` CI job will run on this PR itself, exercising the change.
+
+## Lessons Learned
+
+- In Make recipes, `$1` inside a `$(shell …)` is eaten by Make — always `$$1` for awk/
+  shell positional args.
+- Fixture-sanitization is a safety-critical check; it belongs in CI, not just local
+  `make test-all`, since local steps can be skipped.
+- Pin third-party actions to a commit SHA (with a version comment) to resist
+  supply-chain tag mutation.


### PR DESCRIPTION
## Summary

Low-risk CI/build hygiene (no Go code changes):

- **`permissions: contents: read`** added top-level to `go-ci.yml` — jobs no longer
  inherit the broad default `GITHUB_TOKEN` scope (Codecov uses its own secret).
- **New `fixtures` CI job** running `make test-fixtures` — the customer-data
  sanitization check now runs in CI, not just locally (important given the "never
  commit customer data" rule).
- **Pin `codecov/codecov-action`** to its `v6` commit SHA (supply-chain).
- **Makefile GOPATH fix:** `awk '{print $1}'` → `$$1` (Make ate `$1`, so awk
  printed `$0` — the whole line).
- **`@`-silence** the `make release` `jq`-token recipe line.

## Test plan

- [x] Workflow YAML parses
- [x] `GOPATH` now resolves to the first path element, not the whole line
- [x] `make test-fixtures` passes (the new job runs on this PR)
- [x] `go build ./...`, `gofmt -s` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)