### PR TITLE
cmd: surface home-dir errors and mask config values by allowlist

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -27,6 +27,36 @@ const description = `The config command is used to create or validate the SREPD 
 The config file is located at ~/.config/srepd/srepd.yaml and is used to store
 the configuration options for the SREPD application.`
 
+// safeToLogConfigKeys is the allowlist of config keys whose values are safe to log
+// verbatim under --debug. Any key not in this set is masked, so secret-bearing keys
+// are protected by default rather than only when their name literally contains
+// "token" (which missed api_key, secret, password, etc.).
+var safeToLogConfigKeys = map[string]bool{
+	"teams":                              true,
+	"editor":                             true,
+	"terminal":                           true,
+	"cluster_login_command":              true,
+	"toolbox_mode":                       true,
+	"rosa_boundary_command":              true,
+	"ignoredusers":                       true,
+	"colors":                             true,
+	"default_silent_escalation_policy":   true,
+	"service_escalation_policies":        true,
+	"custom_service_escalation_policies": true,
+	"log_to_journal":                     true,
+	"log_level":                          true,
+	"agent_cli_command":                  true,
+}
+
+// maskConfigValue returns value if key is on the safe-to-log allowlist, otherwise
+// "*****". Masking by default protects any current or future secret-bearing key.
+func maskConfigValue(key, value string) string {
+	if safeToLogConfigKeys[key] {
+		return value
+	}
+	return "*****"
+}
+
 // configCmd represents the config command
 var configCmd = &cobra.Command{
 	Use:          "config",
@@ -170,12 +200,7 @@ func validateConfig() error {
 			continue
 		}
 
-		var v string
-
-		v = fmt.Sprintf("%v", settings[k])
-		if strings.Contains(k, "token") {
-			v = "*****"
-		}
+		v := maskConfigValue(k, fmt.Sprintf("%v", settings[k]))
 
 		log.Debug("Found key", k, v)
 

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -230,3 +230,36 @@ func TestRunConfigWizardCallsLaunchTUIWithConfig(t *testing.T) {
 	assert.Contains(t, configGoSource, "launchTUIWithConfig()",
 		"runConfigWizard should call launchTUIWithConfig to launch the TUI in config mode")
 }
+
+// TestMaskConfigValue verifies the config-value masking used in --debug logging is
+// allowlist-based: only known-safe keys reveal their value; everything else (any
+// current or future secret-bearing key, not just those literally named "token") is
+// masked.
+func TestMaskConfigValue(t *testing.T) {
+	tests := []struct {
+		name   string
+		key    string
+		value  string
+		masked bool
+	}{
+		{"token is masked", "token", "PCGXUDY1", true},
+		{"api_key is masked", "api_key", "sk-secret", true},
+		{"secret is masked", "webhook_secret", "shh", true},
+		{"password is masked", "password", "hunter2", true},
+		{"unknown key masked by default", "some_future_key", "sensitive", true},
+		{"teams is revealed", "teams", "TEAM1", false},
+		{"editor is revealed", "editor", "vim", false},
+		{"terminal is revealed", "terminal", "gnome-terminal --", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := maskConfigValue(tt.key, tt.value)
+			if tt.masked {
+				assert.Equal(t, "*****", got, "value should be masked")
+				assert.NotContains(t, got, tt.value)
+			} else {
+				assert.Equal(t, tt.value, got, "known-safe key should reveal its value")
+			}
+		})
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -77,14 +77,15 @@ but rather a simple tool to make on-call tasks easier.`,
 			return
 		}
 
-		home, _ := os.UserHomeDir()
-		configFile := filepath.Join(home, pkgconfig.CfgFileDir, pkgconfig.CfgFileName)
+		configFile, err := resolveConfigFilePath(os.UserHomeDir)
+		if err != nil {
+			log.Fatal("could not determine config file path", "error", err)
+		}
 		if _, err := os.Stat(configFile); errors.Is(err, os.ErrNotExist) {
 			return
 		}
 
-		err := validateConfig()
-		if err != nil {
+		if err := validateConfig(); err != nil {
 			log.Fatal(err)
 		}
 
@@ -99,8 +100,10 @@ but rather a simple tool to make on-call tasks easier.`,
 			return
 		}
 
-		home, _ := os.UserHomeDir()
-		configFile := filepath.Join(home, pkgconfig.CfgFileDir, pkgconfig.CfgFileName)
+		configFile, err := resolveConfigFilePath(os.UserHomeDir)
+		if err != nil {
+			log.Fatal("could not determine config file path", "error", err)
+		}
 		if _, err := os.Stat(configFile); errors.Is(err, os.ErrNotExist) {
 			ensureViperDefaults()
 			launchTUIWithConfig()
@@ -109,6 +112,17 @@ but rather a simple tool to make on-call tasks easier.`,
 
 		launchTUI()
 	},
+}
+
+// resolveConfigFilePath builds the path to the srepd config file, surfacing (rather
+// than swallowing) any error from the home-directory lookup. homeDir is injectable
+// for testing; production callers pass os.UserHomeDir.
+func resolveConfigFilePath(homeDir func() (string, error)) (string, error) {
+	home, err := homeDir()
+	if err != nil {
+		return "", fmt.Errorf("could not determine home directory: %w", err)
+	}
+	return filepath.Join(home, pkgconfig.CfgFileDir, pkgconfig.CfgFileName), nil
 }
 
 func autoCommentOldPolicies(configFile string) (bool, error) {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	pkgconfig "github.com/clcollins/srepd/pkg/config"
 	"github.com/coreos/go-systemd/journal"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -551,4 +552,22 @@ func TestJournalWriter_WriteError(t *testing.T) {
 	n, err := jw.Write([]byte("test"))
 	assert.Error(t, err)
 	assert.Equal(t, 0, n)
+}
+
+// TestResolveConfigFilePath verifies the config-path resolver surfaces a home-dir
+// lookup error instead of silently producing a bogus relative path (the previous
+// `home, _ := os.UserHomeDir()` ignored the error, so an empty home yielded a
+// relative ".config/srepd/srepd.yaml" resolved against CWD).
+func TestResolveConfigFilePath(t *testing.T) {
+	t.Run("returns joined path on success", func(t *testing.T) {
+		path, err := resolveConfigFilePath(func() (string, error) { return "/home/user", nil })
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join("/home/user", pkgconfig.CfgFileDir, pkgconfig.CfgFileName), path)
+	})
+
+	t.Run("surfaces home dir error", func(t *testing.T) {
+		_, err := resolveConfigFilePath(func() (string, error) { return "", fmt.Errorf("no home") })
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no home")
+	})
 }

--- a/docs/plans/103-cmd-correctness.md
+++ b/docs/plans/103-cmd-correctness.md
@@ -1,0 +1,49 @@
+# Plan 103: cmd/ correctness — home-dir errors and allowlist token masking
+
+**Branch:** `srepd/cmd-correctness`
+
+## Problem
+
+1. **Ignored `os.UserHomeDir()` errors** — `cmd/root.go` `PreRun` and `Run` used
+   `home, _ := os.UserHomeDir()`. On failure `home` is `""`, so `configFile` became a
+   relative `.config/srepd/srepd.yaml` resolved against CWD, silently mis-detecting
+   whether the config exists.
+2. **Substring token masking** — `validateConfig` masked a key's value under `--debug`
+   only when the key name contained the literal substring `"token"`. Any secret-bearing
+   key not named `*token*` (`api_key`, `secret`, `password`, a future OCM/webhook key)
+   was logged in cleartext.
+
+## Solution
+
+1. Added `resolveConfigFilePath(homeDir func() (string, error)) (string, error)` that
+   surfaces the home-dir error. Both `PreRun` and `Run` call it and `log.Fatal` on
+   error instead of proceeding with a bogus path. `homeDir` is injectable for tests;
+   production passes `os.UserHomeDir`.
+2. Replaced the substring check with `maskConfigValue(key, value)` backed by an
+   **allowlist** (`safeToLogConfigKeys`) of known non-secret keys. Anything not on the
+   allowlist is masked — secret-by-default.
+
+## Files Modified
+
+- `cmd/root.go` — `resolveConfigFilePath`; both closures use it and handle the error.
+- `cmd/config.go` — `safeToLogConfigKeys`, `maskConfigValue`; `validateConfig` uses it.
+- `cmd/root_test.go` — `TestResolveConfigFilePath`.
+- `cmd/config_test.go` — `TestMaskConfigValue`.
+
+## Tests (TDD)
+
+Written first, seen red, then green:
+- `TestResolveConfigFilePath` — joins on success; surfaces the home-dir error.
+- `TestMaskConfigValue` — masks `token`/`api_key`/`secret`/`password`/unknown keys;
+  reveals allowlisted keys (`teams`, `editor`, `terminal`).
+
+## Verification
+
+`make test-all` green (fmt, vet, lint, test, race, test-fixtures).
+
+## Lessons Learned
+
+- Ignoring `os.UserHomeDir()`'s error turns a missing HOME into a wrong-but-plausible
+  relative path — surface it.
+- Secret masking must be an allowlist (safe-by-name), not a denylist substring; a
+  `token`-substring check silently leaks every other secret-bearing key.


### PR DESCRIPTION
## Summary

1. **Home-dir errors:** `PreRun`/`Run` used `home, _ := os.UserHomeDir()` — an empty
   home yielded a bogus relative config path that silently mis-detected config
   presence. Added `resolveConfigFilePath` (injectable `homeDir`) that surfaces the
   error; both closures `log.Fatal` on failure.
2. **Token masking:** `validateConfig` masked a `--debug`-logged value only when the
   key name contained `"token"`, leaking any other secret-bearing key (`api_key`,
   `secret`, `password`, future keys). Replaced with `maskConfigValue` backed by an
   **allowlist** of known-safe keys — secret-by-default.

## Test plan

- [x] TDD: `TestResolveConfigFilePath` + `TestMaskConfigValue` written first (red), then green
- [x] `make test-all` green (fmt, vet, lint, test, race, test-fixtures)

`skip-readme`: internal correctness/security, no user-facing config/flag/keybinding changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)