### PR TITLE
Fix asyncWriter data race and send-on-closed-channel panic

### DIFF
--- a/cmd/asyncwriter.go
+++ b/cmd/asyncwriter.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync"
 	"sync/atomic"
 )
 
@@ -34,8 +35,13 @@ import (
 // The background goroutine periodically emits a synthetic log entry
 // reporting how many messages were dropped.
 type asyncWriter struct {
-	out     chan []byte
-	done    chan struct{}
+	out  chan []byte
+	done chan struct{}
+	// mu guards closed AND the send on out in Write, so a Write can never send on
+	// a channel that Close has already closed (which would panic). A plain bool or
+	// atomic.Bool is insufficient: the closed-check and the channel-send are two
+	// separate operations, and Close could run between them.
+	mu      sync.Mutex
 	closed  bool
 	dropped uint64 // accessed atomically
 }
@@ -81,13 +87,19 @@ func newAsyncWriter(w io.Writer, bufferSize int) *asyncWriter {
 }
 
 func (aw *asyncWriter) Write(p []byte) (n int, err error) {
+	// Make a copy since the caller might reuse the buffer. Done before taking the
+	// lock to keep the critical section small.
+	msg := make([]byte, len(p))
+	copy(msg, p)
+
+	// Hold mu across the closed-check AND the send so Close cannot close aw.out
+	// between them (which would panic with "send on closed channel").
+	aw.mu.Lock()
+	defer aw.mu.Unlock()
+
 	if aw.closed {
 		return 0, os.ErrClosed
 	}
-
-	// Make a copy since the caller might reuse the buffer
-	msg := make([]byte, len(p))
-	copy(msg, p)
 
 	// Non-blocking send - if buffer is full, drop the message
 	// This prevents blocking the UI if logging falls behind
@@ -107,10 +119,19 @@ func (aw *asyncWriter) Dropped() uint64 {
 }
 
 func (aw *asyncWriter) Close() error {
-	if !aw.closed {
-		aw.closed = true
-		close(aw.out)
-		<-aw.done // Wait for goroutine to finish
+	aw.mu.Lock()
+	if aw.closed {
+		aw.mu.Unlock()
+		return nil
 	}
+	aw.closed = true
+	close(aw.out)
+	// Release the lock before waiting on the drain goroutine: Write's send is
+	// non-blocking, so the goroutine's completion does not depend on mu, and
+	// holding it would needlessly block concurrent Writes (which will now see
+	// closed==true and return os.ErrClosed).
+	aw.mu.Unlock()
+
+	<-aw.done // Wait for goroutine to finish
 	return nil
 }

--- a/cmd/asyncwriter_test.go
+++ b/cmd/asyncwriter_test.go
@@ -166,3 +166,53 @@ func TestAsyncWriter_CopiesInput(t *testing.T) {
 	assert.NotContains(t, buf.String(), "modified",
 		"mutation of input slice should not affect written data")
 }
+
+// TestAsyncWriter_ConcurrentWriteClose stresses concurrent Write vs Close. Under the
+// race detector it must not report a data race on the closed flag, and it must never
+// panic with "send on closed channel" (a Write that passes the closed check before
+// Close runs must not then send on a closed channel). Writes after Close return
+// os.ErrClosed.
+func TestAsyncWriter_ConcurrentWriteClose(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		var buf syncBuffer
+		aw := newAsyncWriter(&buf, 4)
+
+		var wg sync.WaitGroup
+		for w := 0; w < 8; w++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for j := 0; j < 50; j++ {
+					// A returned error (os.ErrClosed) is fine; a panic is not.
+					_, _ = aw.Write([]byte("log line\n"))
+				}
+			}()
+		}
+
+		// Close concurrently with the writers.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = aw.Close()
+		}()
+
+		wg.Wait()
+
+		// Writes after close must report closed, not panic.
+		_, err := aw.Write([]byte("after close\n"))
+		assert.ErrorIs(t, err, os.ErrClosed)
+	}
+}
+
+// syncBuffer is a minimal concurrency-safe io.Writer for the stress test (the
+// asyncWriter goroutine writes to it while the test may read).
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}

--- a/docs/plans/104-asyncwriter-race.md
+++ b/docs/plans/104-asyncwriter-race.md
@@ -1,0 +1,53 @@
+# Plan 104: Fix asyncWriter data race and send-on-closed-channel panic
+
+**Branch:** `srepd/asyncwriter-race`
+
+## Problem
+
+`cmd/asyncwriter.go` had two concurrency defects on the `closed` flag, which is read
+in `Write` (from the logging goroutine) and written in `Close` (from shutdown):
+
+1. **Data race** on the plain `bool closed`.
+2. **`panic: send on closed channel`** (TOCTOU): `Write` passes the `if aw.closed`
+   check, then `Close` runs fully — sets `closed`, `close(aw.out)` — then `Write`
+   reaches `case aw.out <- msg` and panics.
+
+An `atomic.Bool` would fix (1) but **not** (2): the check and the send are separate
+operations on separate objects, so an atomic flag cannot make them one transaction.
+
+## Solution
+
+Add a `sync.Mutex` that guards the `closed`-check **and** the channel send in `Write`,
+and the `closed`-set **and** `close(aw.out)` in `Close`. Because they share the lock,
+a `Write` can never send on a channel `Close` has already closed. `dropped` stays on
+`atomic` (it was already race-free).
+
+`Close` releases the lock before waiting on `<-aw.done` (the drain goroutine), since
+`Write`'s send is non-blocking and the goroutine's completion does not depend on the
+lock; a concurrent `Write` then sees `closed==true` and returns `os.ErrClosed`.
+
+## Files Modified
+
+- `cmd/asyncwriter.go` — `sync.Mutex`; locked `Write`/`Close`.
+- `cmd/asyncwriter_test.go` — `TestAsyncWriter_ConcurrentWriteClose` + `syncBuffer`.
+
+## Tests (TDD)
+
+Written first, run under `-race`, seen **fail** with both a data-race report and
+`panic: send on closed channel` (confirming atomic-alone would be insufficient), then
+green after the mutex:
+- `TestAsyncWriter_ConcurrentWriteClose` — 50 iterations of 8 concurrent writers
+  racing a concurrent `Close`; asserts no panic and post-`Close` writes return
+  `os.ErrClosed`.
+
+## Verification
+
+`make test-all` green; `go test -race ./cmd/...` green.
+
+## Lessons Learned
+
+- `atomic.Bool` fixes a flag race but not a check-then-act TOCTOU across two objects
+  (flag + channel). When a "closed" check gates a channel send, both must be under the
+  same lock, or the send can hit a closed channel and panic.
+- Reproduce concurrency bugs with a stress loop under `-race` *before* fixing — it
+  proved the panic was real and that the atomic-only approach would not have sufficed.


### PR DESCRIPTION
## Summary

The `closed` flag was read in `Write` (logging goroutine) and written in `Close`
(shutdown) with no synchronization — a **data race**, plus a **`send on closed
channel` panic** (TOCTOU: `Write` passes the `closed` check, `Close` closes
`aw.out`, `Write` then sends).

An `atomic.Bool` fixes the race but **not** the panic (check and send are
separate ops on separate objects). Added a `sync.Mutex` guarding the
`closed`-check + channel send in `Write` and the close in `Close`.

## Test plan

- [x] TDD: `TestAsyncWriter_ConcurrentWriteClose` written first; under `-race` it
  **failed with both a data-race report and the panic** (confirming atomic-alone
  is insufficient), then green after the mutex
- [x] `make test-all` + `go test -race ./cmd/...` green

No README trigger files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)