### PR TITLE
Small correctness fixes and doc drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ direct `ocm backplane` login.
 | `make test-race` | Run tests with race detector |
 | `make test-vuln` | Check for known vulnerabilities |
 | `make test-coverage-threshold` | Enforce minimum coverage threshold (55%) |
-| `make test-all` | Run all checks: fmt-check, vet, lint, test, test-race |
+| `make test-all` | Run all checks: fmt-check, vet, lint, test, test-race, test-fixtures |
 
 Pass extra test flags via `TESTOPTS`, e.g.:
 `make test TESTOPTS="-run TestFoo"`
@@ -149,4 +149,6 @@ approach, and key design decisions. See existing plans for format examples.
 | `pkg/tui/msgHandlers.go` | Focus-mode key dispatch |
 | `pkg/launcher/launcher.go` | Terminal command builder |
 | `cmd/root.go` | CLI entry point |
-| `cmd/config.go` | Config validation |
+| `cmd/config.go` | Config validation + interactive wizard launcher |
+| `cmd/update.go` | Self-update / version-check command |
+| `cmd/asyncwriter.go` | Non-blocking async log writer |

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -3,7 +3,7 @@
 ## Language -- Go
 
 - Language: Go
-- Go version: 1.26.4 (from go.mod)
+- Go version: 1.26.5 (from go.mod)
 - Module path: `github.com/clcollins/srepd`
 - Entry point: `main.go` using cobra + viper
 - Linter: golangci-lint

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -3,7 +3,7 @@
 ## Language -- Go
 
 - Language: Go
-- Go version: 1.26.3 (from go.mod)
+- Go version: 1.26.4 (from go.mod)
 - Module path: `github.com/clcollins/srepd`
 - Entry point: `main.go` using cobra + viper
 - Linter: golangci-lint
@@ -39,13 +39,14 @@ docs/plans/       Plan documents (one per PR)
 - All targets `.PHONY`
 - Must include `build`, `test`, `lint`, `clean`, `fmt`, `coverage`,
   `vet`, and `test-all` targets
-- `test-all` runs all checks: `fmt-check`, `vet`, `lint`, `test`
+- `test-all` runs all checks: `fmt-check`, `vet`, `lint`, `test`,
+  `test-race`, `test-fixtures`
 - Each target is independently callable
 - `test` runs unit tests only (no lint dependency)
 - `fmt-check` exits non-zero if code is unformatted (CI-friendly)
 - Variables for configurable values (Go binary path, lint version)
-- Build output: goreleaser for releases, `/tmp/` or `GOPATH/bin` for
-  dev installs
+- Build output: goreleaser for releases; `make install` →
+  `$GOPATH/bin`, `make install-local` → `~/.local/bin`
 
 ## CI Testing
 

--- a/docs/plans/105-small-correctness-doc-drift.md
+++ b/docs/plans/105-small-correctness-doc-drift.md
@@ -1,0 +1,59 @@
+# Plan 105: Small correctness fixes and documentation drift
+
+**Branch:** `srepd/small-correctness-docs`
+
+## Problem
+
+A batch of small, localized correctness issues and stale docs surfaced in review.
+
+## Changes
+
+### Correctness (with tests)
+
+- **`pkg/tui/claude.go` — panic on whitespace-only agent command.**
+  `handleClaudePrompt` did `strings.Fields(agentCmd)[0]`. A whitespace-only
+  `agent_cli_command` is non-empty (skips the `""` default) but `strings.Fields`
+  returns an empty slice → index panic. Added a `len(fields)==0` guard (mirrors
+  `agentQuery`).
+- **`pkg/pd/pd.go` — nil-pointer panics.** `ReassignIncidents` and
+  `ReEscalateIncidents` dereferenced `user.Email` (and `policy.ID`) with no nil check.
+  `ReEscalateIncidents` receives `p.CurrentUser` with no guard at the call site. Added
+  nil guards returning errors (never panic in library code).
+- **`pkg/backplane/client.go` — unchecked type assertion.**
+  `http.DefaultTransport.(*http.Transport)` panics if a dependency reassigns the
+  mutable global. Added comma-ok with a fresh-transport fallback.
+- **`pkg/ocm/client.go` — missing timeouts.** `GetBackplaneURL` used `.Send()` and
+  `GetAccessToken` used `.Tokens()`, both without a context. Switched to
+  `SendContext`/`TokensContext` with a 30s `ocmRequestTimeout`.
+
+### Documentation drift
+
+- `CONVENTIONS.md`: Go `1.26.3`→`1.26.4`; `test-all` list now includes `test-race`
+  and `test-fixtures`; corrected the build-output note (`make install` →
+  `$GOPATH/bin`, `install-local` → `~/.local/bin`; no `/tmp`).
+- `AGENTS.md`: `test-all` list updated; Key Files table adds `cmd/update.go` and
+  `cmd/asyncwriter.go`, and clarifies `cmd/config.go`.
+
+## Tests (TDD)
+
+Written first, seen red (panics), then green:
+- `TestHandleClaudePrompt_WhitespaceOnlyCommand` — no panic, flashes an error, does
+  not start a query.
+- `TestReassignIncidents_NilUser`, `TestReEscalateIncidents_NilUser` — return an error,
+  not a panic.
+
+Existing reassign/reescalate/claude tests remain green.
+
+## Verification
+
+`make test-all` green (fmt, vet, lint, test, race, test-fixtures).
+
+## Lessons Learned
+
+- `strings.Fields(s)[0]` is only safe after a `len()==0` check — whitespace-only
+  strings are non-empty but tokenize to nothing.
+- Library functions that dereference pointer params must nil-check and return an error,
+  never panic. Guard even "internal" callers (`p.CurrentUser`).
+- `http.DefaultTransport` is a mutable global — always comma-ok the assertion.
+- Docs that hardcode a version or a target list drift; keep them matched to the
+  Makefile/go.mod source of truth.

--- a/pkg/backplane/client.go
+++ b/pkg/backplane/client.go
@@ -27,7 +27,15 @@ type Client struct {
 
 // NewClient creates a BackplaneClient from config and a token provider function.
 func NewClient(cfg *Config, tokenFunc func() (string, error)) BackplaneClient {
-	transport := http.DefaultTransport.(*http.Transport).Clone()
+	// http.DefaultTransport is a mutable package global; use comma-ok and fall back
+	// to a fresh transport if some imported package has replaced it with a different
+	// RoundTripper, rather than panicking on the type assertion.
+	var transport *http.Transport
+	if dt, ok := http.DefaultTransport.(*http.Transport); ok {
+		transport = dt.Clone()
+	} else {
+		transport = &http.Transport{}
+	}
 
 	if cfg.ProxyURL != nil && *cfg.ProxyURL != "" && !cfg.Govcloud {
 		proxyURL, err := url.Parse(*cfg.ProxyURL)

--- a/pkg/ocm/client.go
+++ b/pkg/ocm/client.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	auth "github.com/openshift-online/ocm-sdk-go/authentication"
@@ -21,6 +22,9 @@ import (
 const (
 	productionURL = "https://api.openshift.com"
 	clientID      = "ocm-cli"
+
+	// ocmRequestTimeout bounds OCM calls that do not receive a caller context.
+	ocmRequestTimeout = 30 * time.Second
 )
 
 var clusterIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
@@ -314,7 +318,9 @@ func (c *Client) GetLimitedSupportHistory(ctx context.Context, clusterID string)
 }
 
 func (c *Client) GetBackplaneURL() (string, error) {
-	resp, err := c.conn.ClustersMgmt().V1().Environment().Get().Send()
+	ctx, cancel := context.WithTimeout(context.Background(), ocmRequestTimeout)
+	defer cancel()
+	resp, err := c.conn.ClustersMgmt().V1().Environment().Get().SendContext(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch OCM environment: %w", err)
 	}
@@ -327,7 +333,9 @@ func (c *Client) GetBackplaneURL() (string, error) {
 }
 
 func (c *Client) GetAccessToken() (string, error) {
-	accessToken, _, err := c.conn.Tokens()
+	ctx, cancel := context.WithTimeout(context.Background(), ocmRequestTimeout)
+	defer cancel()
+	accessToken, _, err := c.conn.TokensContext(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to get OCM access token: %w", err)
 	}

--- a/pkg/pd/pd.go
+++ b/pkg/pd/pd.go
@@ -421,6 +421,10 @@ func loopManageIncidents(client PagerDutyClient, ctx context.Context, email stri
 
 // ReassignIncidents reassigns a list of incidents to a list of users
 func ReassignIncidents(client PagerDutyClient, incidents []pagerduty.Incident, user *pagerduty.User, users []*pagerduty.User) ([]pagerduty.Incident, error) {
+	if user == nil {
+		return nil, fmt.Errorf("pd.ReassignIncidents(): from-user is nil")
+	}
+
 	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
@@ -446,6 +450,13 @@ func ReassignIncidents(client PagerDutyClient, incidents []pagerduty.Incident, u
 
 // ReEscalateIncidents re-escalates a list of incidents to an escalation policy at a specific level
 func ReEscalateIncidents(client PagerDutyClient, incidents []pagerduty.Incident, user *pagerduty.User, policy *pagerduty.EscalationPolicy, level uint) ([]pagerduty.Incident, error) {
+	if user == nil {
+		return nil, fmt.Errorf("pd.ReEscalateIncidents(): user is nil")
+	}
+	if policy == nil {
+		return nil, fmt.Errorf("pd.ReEscalateIncidents(): policy is nil")
+	}
+
 	ctx, cancel := contextWithTimeout()
 	defer cancel()
 

--- a/pkg/pd/pd_test.go
+++ b/pkg/pd/pd_test.go
@@ -836,6 +836,30 @@ func TestReassignIncidents_Success(t *testing.T) {
 	assert.Len(t, result, 2)
 }
 
+func TestReassignIncidents_NilUser(t *testing.T) {
+	mockClient := &MockPagerDutyClient{}
+	incidents := []pagerduty.Incident{{APIObject: pagerduty.APIObject{ID: "INCIDENT1"}}}
+
+	// A nil "from" user must return an error, not panic on user.Email.
+	result, err := ReassignIncidents(mockClient, incidents, nil, []*pagerduty.User{})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "pd.ReassignIncidents()")
+	assert.Nil(t, result)
+}
+
+func TestReEscalateIncidents_NilUser(t *testing.T) {
+	mockClient := &MockPagerDutyClient{}
+	incidents := []pagerduty.Incident{{APIObject: pagerduty.APIObject{ID: "INCIDENT1"}}}
+	policy := &pagerduty.EscalationPolicy{APIObject: pagerduty.APIObject{ID: "POL1"}}
+
+	result, err := ReEscalateIncidents(mockClient, incidents, nil, policy, 1)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "pd.ReEscalateIncidents()")
+	assert.Nil(t, result)
+}
+
 func TestReassignIncidents_EmptyIncidents(t *testing.T) {
 	mockClient := &MockPagerDutyClient{}
 	user := &pagerduty.User{

--- a/pkg/tui/claude.go
+++ b/pkg/tui/claude.go
@@ -153,7 +153,13 @@ func (m model) handleClaudePrompt(msg claudePromptMsg, lookPath func(string) (st
 		agentCmd = "claude --print"
 	}
 
-	binary := strings.Fields(agentCmd)[0]
+	// Guard against a whitespace-only command: strings.Fields returns an empty
+	// slice, so indexing [0] would panic (mirrors agentQuery's len==0 check).
+	fields := strings.Fields(agentCmd)
+	if len(fields) == 0 {
+		return m, m.flashNotification("agent_cli_command is empty")
+	}
+	binary := fields[0]
 	if _, err := lookPath(binary); err != nil {
 		return m, m.flashNotification(fmt.Sprintf("agent CLI %q not found on PATH", binary))
 	}

--- a/pkg/tui/claude_test.go
+++ b/pkg/tui/claude_test.go
@@ -457,6 +457,25 @@ func TestHandleClaudePrompt_DefaultCommand(t *testing.T) {
 	assert.True(t, updated.claudeQuerying)
 }
 
+func TestHandleClaudePrompt_WhitespaceOnlyCommand(t *testing.T) {
+	// A whitespace-only agentCLICommand is non-empty, so it skips the "" default,
+	// but strings.Fields returns an empty slice — indexing [0] would panic. The
+	// handler must guard this (mirroring agentQuery's len==0 check) and flash an
+	// error instead of panicking. Library code must never panic.
+	m := createTestModel()
+	m.agentCLICommand = "   "
+
+	msg := claudePromptMsg{prompt: "test"}
+	assert.NotPanics(t, func() {
+		result, cmd := m.handleClaudePrompt(msg, func(s string) (string, error) {
+			return s, nil
+		})
+		updated := result.(model)
+		assert.False(t, updated.claudeQuerying, "should not start a query on an empty command")
+		assert.NotNil(t, cmd, "should flash a notification rather than panic")
+	})
+}
+
 func TestHandleClaudePrompt_CustomCommand(t *testing.T) {
 	m := createTestModel()
 	m.agentCLICommand = "/opt/bin/my-agent --verbose --print"


### PR DESCRIPTION
## Summary

A batch of small, localized correctness fixes plus doc drift:

**Correctness (with tests):**
- `claude.go`: guard `strings.Fields(agentCmd)[0]` against a whitespace-only
  `agent_cli_command` (was a panic); mirrors `agentQuery`'s `len==0` check.
- `pd.go`: nil-check `user` (and `policy`) in `ReassignIncidents` /
  `ReEscalateIncidents` — return an error instead of panicking on `user.Email`.
- `backplane`: comma-ok on `http.DefaultTransport.(*http.Transport)` with a fresh
  fallback (mutable global).
- `ocm`: 30s timeout context on `GetBackplaneURL` (`SendContext`) and
  `GetAccessToken` (`TokensContext`).

**Docs:** Go `1.26.3`→`1.26.4`; `test-all` target list; build-output note; add
`cmd/update.go` + `cmd/asyncwriter.go` to the AGENTS Key Files table.

## Test plan

- [x] TDD: whitespace-command + nil-user tests written first (panics → red), then green
- [x] `make test-all` green (fmt, vet, lint, test, race, test-fixtures)

No README trigger files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)