### PR TITLE
Add View-layer render tests for cluster reports tab

### DIFF
--- a/docs/plans/106-view-render-tests.md
+++ b/docs/plans/106-view-render-tests.md
@@ -1,0 +1,44 @@
+# Plan 106: View-layer render tests for cluster reports tab
+
+**Branch:** `srepd/view-render-tests`
+
+## Problem
+
+`renderClusterReportsTab` (`pkg/tui/views.go`) was the only fully-untested (0%)
+render function in the TUI package. View-layer rendering was under-covered, and its
+output (branching on backplane/OCM availability, report sorting, base64 decoding) was
+not locked in by any test.
+
+## Solution
+
+Add deterministic, fully-mocked render tests that drive `renderClusterReportsTab` with
+model state only — no PagerDuty/OCM/backplane API calls, no host tools, no filesystem
+(per the project's test-isolation rule). Every branch of the function is covered:
+
+- backplane disabled (nil client)
+- OCM not connected / OCM auth pending / loading (empty cache)
+- cache present but no reports → "No cluster reports"
+- with data: report numbering, summaries, newest-first sort, base64 `Data` decoded
+- invalid base64 → raw fallback
+
+These are characterization tests: they describe the desired verified behavior of an
+existing, correct function, so they pass immediately and guard against regressions.
+
+## Files Modified
+
+- `pkg/tui/views_render_test.go` (new) — 7 tests + small helpers.
+
+## Verification
+
+- `renderClusterReportsTab` coverage: **0% → 100%**; `pkg/tui` package 64.0% → 64.9%.
+- `make test-all` green (fmt, vet, lint, test, race, test-fixtures).
+
+## Lessons Learned
+
+- `renderClusterReportsTab` renders reports via `sortedClusterIDs()`, which requires a
+  `selectedIncident`, an `incidentClusterMap` entry, **and** the cluster present in
+  `clusterCache` — not just entries in `clusterReportCache`. Test setup must satisfy
+  all three (reuse `setupModelWithCluster` + seed `clusterCache`) to reach the
+  with-data path.
+- View functions that are pure over model state are cheap, deterministic coverage —
+  drive them directly rather than through a full `tea.Program`.

--- a/pkg/tui/views_render_test.go
+++ b/pkg/tui/views_render_test.go
@@ -1,0 +1,132 @@
+package tui
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/clcollins/srepd/pkg/backplane"
+	"github.com/clcollins/srepd/pkg/ocm"
+	"github.com/stretchr/testify/assert"
+)
+
+// These are deterministic, fully-mocked View-layer render tests. They drive the
+// renderClusterReportsTab pure function across all of its branches with model state
+// only — no PagerDuty/OCM/backplane API calls, no host tools, no filesystem. They
+// raise coverage of a previously-untested (0%) render path and lock in its output.
+
+func TestRenderClusterReportsTab_BackplaneDisabled(t *testing.T) {
+	m := createTestModel()
+	m.backplaneClient = nil
+
+	content, err := m.renderClusterReportsTab()
+
+	assert.NoError(t, err)
+	assert.Contains(t, content, "Backplane not enabled")
+}
+
+func TestRenderClusterReportsTab_OCMNotConnected(t *testing.T) {
+	m := createTestModel()
+	m.backplaneClient = backplane.NewMockClient()
+	m.clusterReportCache = map[string][]backplane.Report{}
+	m.ocmClient = nil
+	m.ocmAuthPending = false
+
+	content, err := m.renderClusterReportsTab()
+
+	assert.NoError(t, err)
+	assert.Contains(t, content, "OCM not connected")
+}
+
+func TestRenderClusterReportsTab_OCMAuthPending(t *testing.T) {
+	m := createTestModel()
+	m.backplaneClient = backplane.NewMockClient()
+	m.clusterReportCache = map[string][]backplane.Report{}
+	m.ocmClient = nil
+	m.ocmAuthPending = true
+
+	content, err := m.renderClusterReportsTab()
+
+	assert.NoError(t, err)
+	assert.Contains(t, content, "OCM authenticating")
+}
+
+func TestRenderClusterReportsTab_Loading(t *testing.T) {
+	m := createTestModel()
+	m.backplaneClient = backplane.NewMockClient()
+	m.clusterReportCache = map[string][]backplane.Report{}
+	m.ocmClient = createMockOCMClient()
+
+	content, err := m.renderClusterReportsTab()
+
+	assert.NoError(t, err)
+	assert.Contains(t, content, "Loading cluster reports")
+}
+
+func TestRenderClusterReportsTab_EmptyReports(t *testing.T) {
+	m := createTestModel()
+	m.backplaneClient = backplane.NewMockClient()
+	// Cache present for a cluster but with an empty report slice.
+	m.clusterReportCache = map[string][]backplane.Report{
+		"fake-cluster-123": {},
+	}
+
+	content, err := m.renderClusterReportsTab()
+
+	assert.NoError(t, err)
+	assert.Contains(t, content, "No cluster reports")
+}
+
+func TestRenderClusterReportsTab_WithData(t *testing.T) {
+	m := createTestModel()
+	setupModelWithCluster(&m) // selectedIncident + incidentClusterMap for sortedClusterIDs
+	m.clusterCache = map[string]*ocm.ClusterInfo{testClusterID: {ID: testClusterID}}
+	m.backplaneClient = backplane.NewMockClient()
+	encoded := base64.StdEncoding.EncodeToString([]byte("decoded report body"))
+	m.clusterReportCache = map[string][]backplane.Report{
+		testClusterID: {
+			{ReportID: "r1", Summary: "newer report", CreatedAt: "2026-06-02T00:00:00Z", Data: encoded},
+			{ReportID: "r2", Summary: "older report", CreatedAt: "2026-06-01T00:00:00Z", Data: ""},
+		},
+	}
+
+	content, err := m.renderClusterReportsTab()
+
+	assert.NoError(t, err)
+	assert.Contains(t, content, "Report 1/2")
+	assert.Contains(t, content, "Report 2/2")
+	assert.Contains(t, content, "newer report")
+	assert.Contains(t, content, "older report")
+	// base64 Data is decoded and included.
+	assert.Contains(t, content, "decoded report body")
+	// Reports are sorted newest-first by CreatedAt, so the newer one renders first.
+	assert.Less(t, indexOf(content, "newer report"), indexOf(content, "older report"),
+		"reports should be sorted newest-first")
+}
+
+func TestRenderClusterReportsTab_InvalidBase64FallsBackToRaw(t *testing.T) {
+	m := createTestModel()
+	setupModelWithCluster(&m)
+	m.clusterCache = map[string]*ocm.ClusterInfo{testClusterID: {ID: testClusterID}}
+	m.backplaneClient = backplane.NewMockClient()
+	m.clusterReportCache = map[string][]backplane.Report{
+		testClusterID: {
+			{ReportID: "r1", Summary: "s", CreatedAt: "2026-06-01T00:00:00Z", Data: "not-valid-base64!!!"},
+		},
+	}
+
+	content, err := m.renderClusterReportsTab()
+
+	assert.NoError(t, err)
+	// On decode failure the raw Data is written verbatim.
+	assert.Contains(t, content, "not-valid-base64!!!")
+}
+
+// indexOf is a small helper returning the index of sub in s, or -1.
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
## Summary

`renderClusterReportsTab` was the only fully-untested (0%) render function in the
TUI package. Added deterministic, **fully-mocked** render tests (model state only —
no PagerDuty/OCM/backplane API, no host tools, no filesystem) covering every branch:

- backplane disabled / OCM not connected / OCM auth pending / loading
- cache present but no reports
- with data: report numbering, summaries, newest-first sort, base64 `Data` decode
- invalid base64 → raw fallback

## Test plan

- [x] 7 render tests, all green (characterization of existing correct behavior)
- [x] `renderClusterReportsTab` coverage **0% → 100%**; `pkg/tui` 64.0% → 64.9%
- [x] `make test-all` green (fmt, vet, lint, test, race, test-fixtures)

Only test files + a plan doc touched; no README trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)