### PR TITLE
Fix org flag matching: resolve org name via accounts mgmt API

### DIFF
--- a/docs/plans/338-fix-org-flag-matching.md
+++ b/docs/plans/338-fix-org-flag-matching.md
@@ -1,0 +1,60 @@
+# 338: Fix org flag matching and add OrganizationID
+
+## Problem
+
+The `:flag org <pattern>` command never matched any incidents because
+`clusterFromResponse` stored `cluster.Subscription().ID()` (a subscription
+UUID) into `info.Organization`. The flag system tried to glob-match a
+customer name like `"Camunda*"` against that UUID, which never matched.
+
+Additionally, the Cluster tab displayed this subscription UUID as the
+"Organization" field, which was not useful.
+
+## Approach
+
+1. **Add `OrganizationID` field** to `ClusterInfo` to store the raw org ID
+   separately from the human-readable name.
+
+2. **Fix org resolution in `GetCluster`** — remove the incorrect
+   `cluster.Subscription().ID()` assignment from `clusterFromResponse`.
+   Instead, extract the org ID from the accounts management subscription
+   response (which was already being queried), then fetch the org name via
+   `AccountsMgmt().V1().Organizations().Organization(orgID).Get()`. This is
+   best-effort: if the lookup fails, fields stay empty.
+
+3. **Match flags against both fields** — update `matchOrgName` to try
+   matching the pattern against both `Organization` (name) and
+   `OrganizationID`. This means `:flag org Camunda*` matches the org name
+   while `:flag org 1a2b3c4d` matches the org ID directly.
+
+4. **Display both fields** in the Cluster tab.
+
+## Key decisions
+
+- Org name resolution is best-effort and non-blocking to avoid slowing
+  cluster enrichment for a secondary API call.
+- The `:flag org` command transparently matches either field — no separate
+  `:flag orgid` command needed.
+- `clusterFromResponse` remains a pure mapping function; org resolution
+  happens in `GetCluster` where we have the subscription context.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `pkg/ocm/ocm.go` | Add `OrganizationID` field |
+| `pkg/ocm/client.go` | Fix org resolution, add `enrichOrganization` helper |
+| `pkg/tui/flags.go` | Match against both Organization and OrganizationID |
+| `pkg/tui/views.go` | Display Organization ID in Cluster tab |
+| `pkg/ocm/fixtures.go` | Add OrganizationID to fixture struct |
+| `pkg/ocm/client_test.go` | Update clusterFromResponse tests |
+| `pkg/ocm/ocm_test.go` | Add OrganizationID to test fixture |
+| `pkg/tui/flags_test.go` | Add test cases for org ID matching |
+| `testdata/fixtures/clusters.json` | Add organization_id to fixture data |
+
+## Testing
+
+- All existing tests pass
+- Three new flag test cases: org ID match, org ID exact match without name,
+  org name match when ID doesn't match
+- `make test-all` passes (fmt, vet, lint, test, race)

--- a/docs/plans/339-fix-help-incident-view-height.md
+++ b/docs/plans/339-fix-help-incident-view-height.md
@@ -1,0 +1,40 @@
+# 339: Fix help window pushing incident view off-screen
+
+## Problem
+
+When pressing `h`/`?` in incident view to toggle the help panel, the
+help text was appended below the incident viewer without shrinking it,
+pushing the top of the view (tabs, header) off the terminal. In table
+mode this worked correctly because `helpLines` was subtracted from the
+available height.
+
+## Root cause
+
+`computeLayout` in `layout.go` calculated the incident viewer height as:
+```go
+incidentViewerHeight := ws.Height - incidentViewerFixedOverhead
+```
+
+This did not subtract `helpLines`, unlike the table height calculation
+which did:
+```go
+availableRows := ws.Height - ... - helpLines
+```
+
+Additionally, `recomputeLayout()` (called by `toggleHelp()`) only updated
+`m.table.SetHeight` and the watcher viewport — it never applied the new
+`IncidentViewerHeight` to `m.incidentViewer` or `m.logViewer`.
+
+## Fix
+
+1. Subtract `helpLines` from the incident viewer height calculation so
+   the viewport shrinks when help expands.
+2. Update `recomputeLayout()` to apply the new dimensions to both
+   `m.incidentViewer` and `m.logViewer` on every recompute.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `pkg/tui/layout.go` | Subtract helpLines from incident viewer height; apply viewer dimensions in recomputeLayout |
+| `pkg/tui/layout_test.go` | Two new tests: help reduces incident viewer height, recomputeLayout updates viewer dimensions |

--- a/pkg/ocm/client.go
+++ b/pkg/ocm/client.go
@@ -185,15 +185,20 @@ func (c *Client) GetCluster(ctx context.Context, key string) (*ClusterInfo, erro
 		log.Debug("ocm.GetCluster", "msg", "subscription search failed, trying cluster search", "error", err)
 	}
 
+	var orgID string
 	if err == nil {
 		log.Debug("ocm.GetCluster", "msg", "subscription search completed", "total", subsResponse.Total())
 		if subsResponse.Total() == 1 && len(subsResponse.Items().Slice()) > 0 {
-			internalID, ok := subsResponse.Items().Slice()[0].GetClusterID()
-			log.Debug("ocm.GetCluster", "msg", "subscription found", "has_cluster_id", ok)
+			sub := subsResponse.Items().Slice()[0]
+			orgID, _ = sub.GetOrganizationID()
+			internalID, ok := sub.GetClusterID()
+			log.Debug("ocm.GetCluster", "msg", "subscription found", "has_cluster_id", ok, "org_id", orgID)
 			if ok {
 				clusterResponse, clusterErr := clustersResource.Cluster(internalID).Get().SendContext(ctx)
 				if clusterErr == nil {
-					return clusterFromResponse(clusterResponse.Body()), nil
+					info := clusterFromResponse(clusterResponse.Body())
+					c.enrichOrganization(ctx, info, orgID)
+					return info, nil
 				}
 				log.Debug("ocm.GetCluster", "msg", "cluster get by sub ID failed", "error", clusterErr)
 			}
@@ -217,7 +222,9 @@ func (c *Client) GetCluster(ctx context.Context, key string) (*ClusterInfo, erro
 		return nil, fmt.Errorf("cluster %q not found via subscription or cluster search", key)
 	}
 
-	return clusterFromResponse(clustersResponse.Items().Slice()[0]), nil
+	info := clusterFromResponse(clustersResponse.Items().Slice()[0])
+	c.enrichOrganization(ctx, info, orgID)
+	return info, nil
 }
 
 func clusterFromResponse(cluster *cmv1.Cluster) *ClusterInfo {
@@ -245,11 +252,22 @@ func clusterFromResponse(cluster *cmv1.Cluster) *ClusterInfo {
 	if cluster.CCS() != nil {
 		info.CCS = cluster.CCS().Enabled()
 	}
-	if cluster.Subscription() != nil {
-		info.Organization = cluster.Subscription().ID()
-	}
 
 	return info
+}
+
+func (c *Client) enrichOrganization(ctx context.Context, info *ClusterInfo, orgID string) {
+	if orgID == "" {
+		return
+	}
+	info.OrganizationID = orgID
+	resp, err := c.conn.AccountsMgmt().V1().Organizations().Organization(orgID).Get().SendContext(ctx)
+	if err != nil {
+		log.Debug("ocm.enrichOrganization", "msg", "organization lookup failed", "org_id", orgID, "error", err)
+		return
+	}
+	info.Organization = resp.Body().Name()
+	log.Debug("ocm.enrichOrganization", "org_id", orgID, "org_name", info.Organization)
 }
 
 func (c *Client) GetServiceLogs(ctx context.Context, clusterID, externalID string) ([]ServiceLog, error) {

--- a/pkg/ocm/client_test.go
+++ b/pkg/ocm/client_test.go
@@ -212,6 +212,7 @@ func TestClusterFromResponse(t *testing.T) {
 		assert.False(t, info.Hypershift)
 		assert.False(t, info.CCS)
 		assert.Empty(t, info.Organization)
+		assert.Empty(t, info.OrganizationID)
 	})
 
 	t.Run("cloud provider extraction", func(t *testing.T) {

--- a/pkg/ocm/fixtures.go
+++ b/pkg/ocm/fixtures.go
@@ -8,17 +8,18 @@ import (
 )
 
 type fixtureCluster struct {
-	ID            string `json:"id"`
-	ExternalID    string `json:"external_id"`
-	Name          string `json:"name"`
-	DisplayName   string `json:"display_name"`
-	State         string `json:"state"`
-	Region        string `json:"region"`
-	CloudProvider string `json:"cloud_provider"`
-	Version       string `json:"version"`
-	Hypershift    bool   `json:"hypershift"`
-	CCS           bool   `json:"ccs"`
-	Organization  string `json:"organization"`
+	ID             string `json:"id"`
+	ExternalID     string `json:"external_id"`
+	Name           string `json:"name"`
+	DisplayName    string `json:"display_name"`
+	State          string `json:"state"`
+	Region         string `json:"region"`
+	CloudProvider  string `json:"cloud_provider"`
+	Version        string `json:"version"`
+	Hypershift     bool   `json:"hypershift"`
+	CCS            bool   `json:"ccs"`
+	Organization   string `json:"organization"`
+	OrganizationID string `json:"organization_id"`
 }
 
 type fixtureServiceLog struct {
@@ -71,17 +72,18 @@ func loadClusterFixtures(path string, mock *MockClient) error {
 	}
 	for id, fc := range clusters {
 		mock.Clusters[id] = &ClusterInfo{
-			ID:            fc.ID,
-			ExternalID:    fc.ExternalID,
-			Name:          fc.Name,
-			DisplayName:   fc.DisplayName,
-			State:         fc.State,
-			Region:        fc.Region,
-			CloudProvider: fc.CloudProvider,
-			Version:       fc.Version,
-			Hypershift:    fc.Hypershift,
-			CCS:           fc.CCS,
-			Organization:  fc.Organization,
+			ID:             fc.ID,
+			ExternalID:     fc.ExternalID,
+			Name:           fc.Name,
+			DisplayName:    fc.DisplayName,
+			State:          fc.State,
+			Region:         fc.Region,
+			CloudProvider:  fc.CloudProvider,
+			Version:        fc.Version,
+			Hypershift:     fc.Hypershift,
+			CCS:            fc.CCS,
+			Organization:   fc.Organization,
+			OrganizationID: fc.OrganizationID,
 		}
 	}
 	return nil

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -4,17 +4,18 @@ import "context"
 
 // ClusterInfo contains enriched cluster data from the OCM API.
 type ClusterInfo struct {
-	ID            string
-	ExternalID    string
-	Name          string
-	DisplayName   string
-	State         string
-	Region        string
-	CloudProvider string
-	Version       string
-	Hypershift    bool
-	CCS           bool
-	Organization  string
+	ID             string
+	ExternalID     string
+	Name           string
+	DisplayName    string
+	State          string
+	Region         string
+	CloudProvider  string
+	Version        string
+	Hypershift     bool
+	CCS            bool
+	Organization   string
+	OrganizationID string
 }
 
 // ServiceLog represents a single service log entry.

--- a/pkg/ocm/ocm_test.go
+++ b/pkg/ocm/ocm_test.go
@@ -14,17 +14,18 @@ func TestMockClient_GetCluster(t *testing.T) {
 	t.Run("returns cluster info for known cluster", func(t *testing.T) {
 		mock := NewMockClient()
 		mock.Clusters["1q2w3e4rfakeidtest9o0p1a2s3d4f5g"] = &ClusterInfo{
-			ID:            "1q2w3e4rfakeidtest9o0p1a2s3d4f5g",
-			ExternalID:    "00000000-fake-uuid-test-999999999999",
-			Name:          "fake-osd-webapp",
-			DisplayName:   "fake-osd-webapp.7x9k.p1.example.org",
-			State:         "ready",
-			Region:        "us-east-1",
-			CloudProvider: "aws",
-			Version:       "4.16.5",
-			Hypershift:    false,
-			CCS:           true,
-			Organization:  "Fake Aeronautical Ltd",
+			ID:             "1q2w3e4rfakeidtest9o0p1a2s3d4f5g",
+			ExternalID:     "00000000-fake-uuid-test-999999999999",
+			Name:           "fake-osd-webapp",
+			DisplayName:    "fake-osd-webapp.7x9k.p1.example.org",
+			State:          "ready",
+			Region:         "us-east-1",
+			CloudProvider:  "aws",
+			Version:        "4.16.5",
+			Hypershift:     false,
+			CCS:            true,
+			Organization:   "Fake Aeronautical Ltd",
+			OrganizationID: "1a2b3c4d5e6f7g8h9i0j",
 		}
 
 		info, err := mock.GetCluster(context.Background(), "1q2w3e4rfakeidtest9o0p1a2s3d4f5g")

--- a/pkg/tui/flags.go
+++ b/pkg/tui/flags.go
@@ -126,8 +126,11 @@ func matchClusterID(pattern string, clusterIDs []string, clusterCache map[string
 
 func matchOrgName(pattern string, clusterIDs []string, clusterCache map[string]*ocm.ClusterInfo) bool {
 	for _, cid := range clusterIDs {
-		if info, ok := clusterCache[cid]; ok && info.Organization != "" {
-			if matchGlob(pattern, info.Organization) {
+		if info, ok := clusterCache[cid]; ok {
+			if info.Organization != "" && matchGlob(pattern, info.Organization) {
+				return true
+			}
+			if info.OrganizationID != "" && matchGlob(pattern, info.OrganizationID) {
 				return true
 			}
 		}

--- a/pkg/tui/flags_test.go
+++ b/pkg/tui/flags_test.go
@@ -211,6 +211,57 @@ func TestEvaluateFlags_NoOCMData(t *testing.T) {
 	})
 }
 
+func TestEvaluateFlags_OrgIDMatch(t *testing.T) {
+	t.Run("matches by organization ID", func(t *testing.T) {
+		conditions := []FlagCondition{
+			{ID: 1, Type: FlagOrgName, Pattern: "1a2b3c4d5e", CreatedAt: time.Now()},
+		}
+		result := evaluateFlags(
+			[]string{"INC001"},
+			conditions,
+			map[string][]string{"INC001": {"cluster1"}},
+			map[string]*ocm.ClusterInfo{
+				"cluster1": {ID: "cluster1", Organization: "Fake Aeronautical Ltd", OrganizationID: "1a2b3c4d5e6f7g8h9i0j"},
+			},
+		)
+		assert.Equal(t, []int{1}, result["INC001"])
+	})
+}
+
+func TestEvaluateFlags_OrgIDExactMatch(t *testing.T) {
+	t.Run("matches org ID exactly when no org name present", func(t *testing.T) {
+		conditions := []FlagCondition{
+			{ID: 1, Type: FlagOrgName, Pattern: "1a2b3c4d5e6f7g8h9i0j", CreatedAt: time.Now()},
+		}
+		result := evaluateFlags(
+			[]string{"INC001"},
+			conditions,
+			map[string][]string{"INC001": {"cluster1"}},
+			map[string]*ocm.ClusterInfo{
+				"cluster1": {ID: "cluster1", OrganizationID: "1a2b3c4d5e6f7g8h9i0j"},
+			},
+		)
+		assert.Equal(t, []int{1}, result["INC001"])
+	})
+}
+
+func TestEvaluateFlags_OrgNameMatchesButNotID(t *testing.T) {
+	t.Run("matches org name even when org ID does not match", func(t *testing.T) {
+		conditions := []FlagCondition{
+			{ID: 1, Type: FlagOrgName, Pattern: "Aeronautical", CreatedAt: time.Now()},
+		}
+		result := evaluateFlags(
+			[]string{"INC001"},
+			conditions,
+			map[string][]string{"INC001": {"cluster1"}},
+			map[string]*ocm.ClusterInfo{
+				"cluster1": {ID: "cluster1", Organization: "Fake Aeronautical Ltd", OrganizationID: "zzzzzzzzz"},
+			},
+		)
+		assert.Equal(t, []int{1}, result["INC001"])
+	})
+}
+
 func TestEvaluateFlags_MultipleConditions(t *testing.T) {
 	t.Run("returns multiple matching condition IDs", func(t *testing.T) {
 		conditions := []FlagCondition{

--- a/pkg/tui/layout.go
+++ b/pkg/tui/layout.go
@@ -132,7 +132,7 @@ func computeLayout(ws tea.WindowSizeMsg, styles Styles, helpView string, watcher
 
 	tabWindowBorders := styles.TabWindow.GetHorizontalBorderSize()
 	incidentViewerWidth := ws.Width - mainHOverhead - tabWindowBorders
-	incidentViewerHeight := ws.Height - incidentViewerFixedOverhead
+	incidentViewerHeight := ws.Height - incidentViewerFixedOverhead - helpLines
 	if incidentViewerHeight < layoutMinIncidentViewerHeight {
 		incidentViewerHeight = layoutMinIncidentViewerHeight
 	}
@@ -199,6 +199,11 @@ func (m *model) recomputeLayout() {
 
 	m.layout = computeLayout(windowSize, m.styles, helpView, m.watcherExpanded)
 	m.table.SetHeight(m.layout.TableHeight)
+
+	m.incidentViewer.Width = m.layout.IncidentViewerWidth
+	m.incidentViewer.Height = m.layout.IncidentViewerHeight
+	m.logViewer.Width = m.layout.IncidentViewerWidth
+	m.logViewer.Height = m.layout.IncidentViewerHeight
 
 	if m.watcherExpanded {
 		m.watcherViewport.Width = m.layout.WatcherWidth

--- a/pkg/tui/layout_test.go
+++ b/pkg/tui/layout_test.go
@@ -234,6 +234,40 @@ func TestWindowResize_IncidentViewMode(t *testing.T) {
 	})
 }
 
+func TestComputeLayout_HelpExpandedReducesIncidentViewerHeight(t *testing.T) {
+	t.Run("expanded help produces shorter incident viewer", func(t *testing.T) {
+		ws := tea.WindowSizeMsg{Width: 80, Height: 24}
+		styles := defaultStyles()
+
+		compactLayout := computeLayout(ws, styles, shortHelp(), false)
+		expandedLayout := computeLayout(ws, styles, longHelp(), false)
+
+		assert.Greater(t, compactLayout.IncidentViewerHeight, expandedLayout.IncidentViewerHeight,
+			"compact help should yield taller incident viewer than expanded help")
+	})
+}
+
+func TestRecomputeLayout_UpdatesIncidentViewer(t *testing.T) {
+	t.Run("recomputeLayout updates incidentViewer and logViewer heights", func(t *testing.T) {
+		m := createTestModel()
+		m.help = newHelp()
+		windowSize = tea.WindowSizeMsg{Width: 80, Height: 40}
+
+		m.help.ShowAll = false
+		m.recomputeLayout()
+		collapsedHeight := m.incidentViewer.Height
+
+		m.help.ShowAll = true
+		m.recomputeLayout()
+		expandedHeight := m.incidentViewer.Height
+
+		assert.Greater(t, collapsedHeight, expandedHeight,
+			"incident viewer should shrink when help is expanded")
+		assert.Equal(t, m.incidentViewer.Height, m.logViewer.Height,
+			"logViewer height should match incidentViewer height")
+	})
+}
+
 func TestComputeLayout_WatcherReducesTableHeight(t *testing.T) {
 	t.Run("watcher expanded reduces table height", func(t *testing.T) {
 		ws := tea.WindowSizeMsg{Width: 80, Height: 60}

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -449,6 +449,7 @@ func (m model) renderClusterTab() (string, error) {
 		fmt.Fprintf(&content, "* Hypershift: %v\n", info.Hypershift)
 		fmt.Fprintf(&content, "* CCS: %v\n", info.CCS)
 		fmt.Fprintf(&content, "* Organization: %s\n", info.Organization)
+		fmt.Fprintf(&content, "* Organization ID: %s\n", info.OrganizationID)
 		if i < len(clusters)-1 {
 			content.WriteString("\n---\n")
 		}

--- a/testdata/fixtures/clusters.json
+++ b/testdata/fixtures/clusters.json
@@ -10,7 +10,8 @@
     "version": "4.16.5",
     "hypershift": false,
     "ccs": true,
-    "organization": "Fake Aeronautical Ltd"
+    "organization": "Fake Aeronautical Ltd",
+    "organization_id": "1a2b3c4d5e6f7g8h9i0j"
   },
   "b2d4e6f8-fake-uuid-test-def012345678": {
     "id": "cluster-osd-002",
@@ -23,7 +24,8 @@
     "version": "4.17.1",
     "hypershift": false,
     "ccs": false,
-    "organization": "Fake Bank Ltd"
+    "organization": "Fake Bank Ltd",
+    "organization_id": "2b3c4d5e6f7g8h9i0j1k"
   },
   "a4ba96fe-fake-uuid-test-17d38eeaab99": {
     "id": "cluster-hcp-001",
@@ -36,7 +38,8 @@
     "version": "4.16.3",
     "hypershift": true,
     "ccs": true,
-    "organization": "Fake United Airways"
+    "organization": "Fake United Airways",
+    "organization_id": "3c4d5e6f7g8h9i0j1k2l"
   },
   "1b20416f-fake-uuid-test-5a6e450114eb": {
     "id": "cluster-hcp-002",
@@ -49,7 +52,8 @@
     "version": "4.16.3",
     "hypershift": true,
     "ccs": true,
-    "organization": "Fake Co Industries"
+    "organization": "Fake Co Industries",
+    "organization_id": "4d5e6f7g8h9i0j1k2l3m"
   },
   "06f058a0-fake-uuid-test-f39184fee819": {
     "id": "cluster-dms-001",
@@ -62,7 +66,8 @@
     "version": "4.15.8",
     "hypershift": false,
     "ccs": true,
-    "organization": "Fake Logistics Corp"
+    "organization": "Fake Logistics Corp",
+    "organization_id": "5e6f7g8h9i0j1k2l3m4n"
   },
   "c1d2e3f4-fake-uuid-test-123456789001": {
     "id": "cluster-large-001",
@@ -75,7 +80,8 @@
     "version": "4.16.5",
     "hypershift": false,
     "ccs": true,
-    "organization": "Fake Enterprise Co"
+    "organization": "Fake Enterprise Co",
+    "organization_id": "6f7g8h9i0j1k2l3m4n5o"
   },
   "fakeid0000000000000000000000002": {
     "id": "cluster-appsre-001",
@@ -88,7 +94,8 @@
     "version": "4.21.16",
     "hypershift": false,
     "ccs": false,
-    "organization": "Fake Telecom Inc"
+    "organization": "Fake Telecom Inc",
+    "organization_id": "7g8h9i0j1k2l3m4n5o6p"
   },
   "3a7b9c1d-fake-uuid-test-8e4f2a6b0c3d": {
     "id": "cluster-multi-001",
@@ -101,7 +108,8 @@
     "version": "4.16.5",
     "hypershift": false,
     "ccs": true,
-    "organization": "Fake Global Services"
+    "organization": "Fake Global Services",
+    "organization_id": "8h9i0j1k2l3m4n5o6p7q"
   },
   "7f2e8d4a-fake-uuid-test-1b9c3a5d7e0f": {
     "id": "cluster-multi-002",
@@ -114,7 +122,8 @@
     "version": "4.16.5",
     "hypershift": false,
     "ccs": true,
-    "organization": "Fake Global Services"
+    "organization": "Fake Global Services",
+    "organization_id": "8h9i0j1k2l3m4n5o6p7q"
   },
   "5d1a8f3e-fake-uuid-test-9c2b4e6d0a7f": {
     "id": "cluster-multi-003",
@@ -127,7 +136,8 @@
     "version": "4.16.5",
     "hypershift": false,
     "ccs": true,
-    "organization": "Fake Global Services"
+    "organization": "Fake Global Services",
+    "organization_id": "8h9i0j1k2l3m4n5o6p7q"
   },
   "2c4b6a8d-fake-uuid-test-7e3f1a9d5b0c": {
     "id": "cluster-acked-001",
@@ -140,7 +150,8 @@
     "version": "4.16.5",
     "hypershift": false,
     "ccs": true,
-    "organization": "Fake Retail Group"
+    "organization": "Fake Retail Group",
+    "organization_id": "9i0j1k2l3m4n5o6p7q8r"
   },
   "8e1d3c5b-fake-uuid-test-4a6f2d8e0b7c": {
     "id": "cluster-mutated-001",
@@ -153,6 +164,7 @@
     "version": "4.16.5",
     "hypershift": false,
     "ccs": true,
-    "organization": "Fake Healthcare Ltd"
+    "organization": "Fake Healthcare Ltd",
+    "organization_id": "0j1k2l3m4n5o6p7q8r9s"
   }
 }


### PR DESCRIPTION
## Summary

- Fixed `:flag org` never matching — `info.Organization` was storing the subscription UUID instead of the customer name
- Added `OrganizationID` field to `ClusterInfo` and `enrichOrganization` helper that resolves the org name via the accounts management organizations API
- `:flag org` now matches against both `Organization` (name) and `OrganizationID` transparently
- Cluster tab now displays both Organization and Organization ID

## Test plan

- [x] All existing tests pass (`make test-all`)
- [x] Three new flag test cases: org ID match, org ID exact match, org name match when ID differs
- [x] Race detection clean
- [x] Lint clean
- [ ] Manual: run srepd, set `:flag org <customer-name>`, verify incidents are flagged
- [ ] Manual: verify Cluster tab shows both Organization and Organization ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)