### PR TITLE
Bump Go to 1.26.5 to fix GO-2026-5856 (crypto/tls)

### DIFF
--- a/docs/plans/107-go-1.26.5-vuln-fix.md
+++ b/docs/plans/107-go-1.26.5-vuln-fix.md
@@ -1,0 +1,39 @@
+# Plan 107: Bump Go to 1.26.5 to fix GO-2026-5856 (crypto/tls)
+
+**Branch:** `srepd/go-1.26.5-vuln-fix`
+
+## Problem
+
+`govulncheck` reports **GO-2026-5856** — "Invoking Encrypted Client Hello privacy
+leak in crypto/tls" — a **Go standard-library** vulnerability affecting
+`crypto/tls@go1.26.4`, **fixed in go1.26.5**. It is reachable transitively: every
+outbound HTTPS call (PagerDuty, OCM, backplane, AI providers) uses `crypto/tls`.
+
+This advisory is new (post-dating the review-remediation series), so the CI
+`Vulnerability Scan` job (`make test-vuln` → `govulncheck`) now **fails on every
+branch** until the Go version is bumped. It is blocking all other merges.
+
+## Solution
+
+Bump the `go` directive in `go.mod` from `1.26.4` to `1.26.5`. CI's
+`setup-go-from-mod` action reads `go X.Y.Z` from `go.mod` and installs exactly that
+version, so this single change makes CI build and scan with 1.26.5, which includes the
+crypto/tls fix. No source changes required.
+
+## Files Modified
+
+- `go.mod` — `go 1.26.4` → `go 1.26.5`.
+
+## Verification
+
+Run with the go1.26.5 toolchain locally:
+- `govulncheck ./...` → **"No vulnerabilities found"** (was 1: GO-2026-5856).
+- `go build ./...`, `gofmt -s`, `go vet ./...`, `go test ./...` all pass.
+
+## Lessons Learned
+
+- Standard-library CVEs are fixed by bumping the Go toolchain, not a module dependency.
+  Because `setup-go-from-mod` derives the version from the `go` directive, the `go.mod`
+  bump is the whole fix.
+- A new stdlib advisory can turn the CI vuln-scan red across every open PR at once —
+  when that happens, land the toolchain bump first to unblock the rest.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/clcollins/srepd
 
-go 1.26.4
+go 1.26.5
 
 require (
 	charm.land/glamour/v2 v2.0.1


### PR DESCRIPTION
## Summary

`govulncheck` reports **GO-2026-5856** ("Encrypted Client Hello privacy leak" in
`crypto/tls`), affecting `crypto/tls@go1.26.4`, **fixed in go1.26.5**. Reachable via
every outbound HTTPS call (PagerDuty/OCM/backplane/AI). The CI Vulnerability Scan job
fails on every branch until the toolchain is bumped.

`setup-go-from-mod` installs the exact version from the `go` directive, so bumping
`go.mod` to `1.26.5` is the whole fix — no source changes.

## Test plan

- [x] Verified with the go1.26.5 toolchain: `govulncheck ./...` → **"No vulnerabilities found"**
- [x] `go build`, `gofmt -s`, `go vet`, `go test ./...` all pass on 1.26.5

Priority: unblocks the CI Vulnerability Scan on all other open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)