### PR TITLE
Enable glob and name matching for cluster flags

### DIFF
--- a/docs/plans/355-cluster-flag-glob-matching.md
+++ b/docs/plans/355-cluster-flag-glob-matching.md
@@ -1,0 +1,36 @@
+# 355: Enable glob matching for cluster flags
+
+## Problem
+
+`:flag cluster lk3-dev` did nothing when the cluster's display name was
+`lk3-dev-use2-a.vbah.p1.openshiftapps.com`. The `matchClusterID` function
+only did exact equality checks against the raw cluster ID, internal OCM ID,
+and external ID. It did not check the cluster name or display name, and it
+did not support partial/glob matching.
+
+SREs commonly use partial cluster names or substrings from the PD service
+name (e.g., `osd-lk3-dev`) to identify clusters, so the flag system needs
+to support this.
+
+## Fix
+
+Changed `matchClusterID` to:
+1. Use `matchGlob` instead of exact equality for all fields (raw ID,
+   internal ID, external ID)
+2. Also match against `info.Name` and `info.DisplayName` from the cluster
+   cache
+
+Since `matchGlob` treats a plain pattern as a contains match, `:flag cluster
+lk3-dev` now matches any cluster whose name, display name, or ID contains
+`"lk3-dev"`. Glob patterns (`*`, `^`, `$`) also work.
+
+Updated the flag label from "cluster ID matches" to "cluster matches" to
+reflect the broader matching.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `pkg/tui/flags.go` | Rewrite `matchClusterID` to use `matchGlob` and check Name/DisplayName |
+| `pkg/tui/flag_commands.go` | Update label text |
+| `pkg/tui/flags_test.go` | Add 4 new test cases, update label references |

--- a/pkg/tui/flag_commands.go
+++ b/pkg/tui/flag_commands.go
@@ -112,7 +112,7 @@ func parseFlagAdd(args []string) (*parsedFlagCommand, error) {
 			condition: FlagCondition{
 				Type:    FlagClusterID,
 				Pattern: value,
-				Label:   fmt.Sprintf("cluster ID matches %q", value),
+				Label:   fmt.Sprintf("cluster matches %q", value),
 			},
 		}, nil
 	case "org":

--- a/pkg/tui/flags.go
+++ b/pkg/tui/flags.go
@@ -110,13 +110,18 @@ func matchCondition(cond FlagCondition, clusterIDs []string, clusterCache map[st
 }
 
 func matchClusterID(pattern string, clusterIDs []string, clusterCache map[string]*ocm.ClusterInfo) bool {
-	lowerPattern := strings.ToLower(pattern)
 	for _, cid := range clusterIDs {
-		if strings.ToLower(cid) == lowerPattern {
+		if matchGlob(pattern, cid) {
 			return true
 		}
 		if info, ok := clusterCache[cid]; ok {
-			if strings.ToLower(info.ID) == lowerPattern || strings.ToLower(info.ExternalID) == lowerPattern {
+			if matchGlob(pattern, info.ID) || matchGlob(pattern, info.ExternalID) {
+				return true
+			}
+			if info.Name != "" && matchGlob(pattern, info.Name) {
+				return true
+			}
+			if info.DisplayName != "" && matchGlob(pattern, info.DisplayName) {
 				return true
 			}
 		}

--- a/pkg/tui/flags_test.go
+++ b/pkg/tui/flags_test.go
@@ -130,6 +130,94 @@ func TestEvaluateFlags_ClusterIDInternalViaCache(t *testing.T) {
 	})
 }
 
+func TestEvaluateFlags_ClusterNameGlob(t *testing.T) {
+	t.Run("matches cluster name by glob pattern", func(t *testing.T) {
+		conditions := []FlagCondition{
+			{ID: 1, Type: FlagClusterID, Pattern: "lk3-dev*", CreatedAt: time.Now()},
+		}
+		result := evaluateFlags(
+			[]string{"INC001"},
+			conditions,
+			map[string][]string{"INC001": {"1q2w3e4rfakeidtest9o0p1a2s3d4f5g"}},
+			map[string]*ocm.ClusterInfo{
+				"1q2w3e4rfakeidtest9o0p1a2s3d4f5g": {
+					ID:          "internal-id-fake",
+					ExternalID:  "00000000-fake-uuid-test-999999999999",
+					Name:        "lk3-dev-use2-a",
+					DisplayName: "lk3-dev-use2-a.vbah.p1.openshiftapps.com",
+				},
+			},
+		)
+		assert.Equal(t, []int{1}, result["INC001"])
+	})
+}
+
+func TestEvaluateFlags_ClusterDisplayNameContains(t *testing.T) {
+	t.Run("matches cluster display name by contains", func(t *testing.T) {
+		conditions := []FlagCondition{
+			{ID: 1, Type: FlagClusterID, Pattern: "vbah.p1", CreatedAt: time.Now()},
+		}
+		result := evaluateFlags(
+			[]string{"INC001"},
+			conditions,
+			map[string][]string{"INC001": {"1q2w3e4rfakeidtest9o0p1a2s3d4f5g"}},
+			map[string]*ocm.ClusterInfo{
+				"1q2w3e4rfakeidtest9o0p1a2s3d4f5g": {
+					ID:          "internal-id-fake",
+					ExternalID:  "00000000-fake-uuid-test-999999999999",
+					Name:        "lk3-dev-use2-a",
+					DisplayName: "lk3-dev-use2-a.vbah.p1.openshiftapps.com",
+				},
+			},
+		)
+		assert.Equal(t, []int{1}, result["INC001"])
+	})
+}
+
+func TestEvaluateFlags_ClusterNameSubstring(t *testing.T) {
+	t.Run("matches cluster name by substring in middle of service name", func(t *testing.T) {
+		conditions := []FlagCondition{
+			{ID: 1, Type: FlagClusterID, Pattern: "lk3-dev", CreatedAt: time.Now()},
+		}
+		result := evaluateFlags(
+			[]string{"INC001"},
+			conditions,
+			map[string][]string{"INC001": {"1q2w3e4rfakeidtest9o0p1a2s3d4f5g"}},
+			map[string]*ocm.ClusterInfo{
+				"1q2w3e4rfakeidtest9o0p1a2s3d4f5g": {
+					ID:          "internal-id-fake",
+					ExternalID:  "00000000-fake-uuid-test-999999999999",
+					Name:        "lk3-dev-use2-a",
+					DisplayName: "lk3-dev-use2-a.vbah.p1.openshiftapps.com",
+				},
+			},
+		)
+		assert.Equal(t, []int{1}, result["INC001"])
+	})
+}
+
+func TestEvaluateFlags_ClusterIDExactStillWorks(t *testing.T) {
+	t.Run("exact cluster ID match still works with glob logic", func(t *testing.T) {
+		conditions := []FlagCondition{
+			{ID: 1, Type: FlagClusterID, Pattern: "internal-id-fake", CreatedAt: time.Now()},
+		}
+		result := evaluateFlags(
+			[]string{"INC001"},
+			conditions,
+			map[string][]string{"INC001": {"1q2w3e4rfakeidtest9o0p1a2s3d4f5g"}},
+			map[string]*ocm.ClusterInfo{
+				"1q2w3e4rfakeidtest9o0p1a2s3d4f5g": {
+					ID:          "internal-id-fake",
+					ExternalID:  "00000000-fake-uuid-test-999999999999",
+					Name:        "lk3-dev-use2-a",
+					DisplayName: "lk3-dev-use2-a.vbah.p1.openshiftapps.com",
+				},
+			},
+		)
+		assert.Equal(t, []int{1}, result["INC001"])
+	})
+}
+
 func TestEvaluateFlags_ClusterIDNoMatch(t *testing.T) {
 	t.Run("no match returns empty for that incident", func(t *testing.T) {
 		conditions := []FlagCondition{
@@ -325,7 +413,7 @@ func TestAddFlagConditionMsg(t *testing.T) {
 		cond := FlagCondition{
 			Type:      FlagClusterID,
 			Pattern:   "cluster1",
-			Label:     "cluster ID matches \"cluster1\"",
+			Label:     "cluster matches \"cluster1\"",
 			CreatedAt: time.Now(),
 		}
 
@@ -457,7 +545,7 @@ func TestRenderFlagConditionsSection(t *testing.T) {
 		m := createTestModel()
 		m.flagMarker = emojiFlagMarker
 		m.flagConditions = []FlagCondition{
-			{ID: 1, Type: FlagClusterID, Pattern: "cluster1", Label: "cluster ID matches \"cluster1\""},
+			{ID: 1, Type: FlagClusterID, Pattern: "cluster1", Label: "cluster matches \"cluster1\""},
 			{ID: 2, Type: FlagOrgName, Pattern: "Acme", Label: "org name matches \"Acme\""},
 		}
 		m.flagMatchCache = map[string][]int{"INC001": {1, 2}}
@@ -467,7 +555,7 @@ func TestRenderFlagConditionsSection(t *testing.T) {
 
 		content := m.renderFlagConditionsSection()
 		assert.Contains(t, content, "Flag Conditions")
-		assert.Contains(t, content, "cluster ID matches")
+		assert.Contains(t, content, "cluster matches")
 		assert.Contains(t, content, "org name matches")
 	})
 }
@@ -498,14 +586,14 @@ func TestRenderFlagConditionsSection_NoIncident(t *testing.T) {
 func TestFormatFlagsList(t *testing.T) {
 	t.Run("formats list of active flags", func(t *testing.T) {
 		conditions := []FlagCondition{
-			{ID: 1, Type: FlagClusterID, Pattern: "cluster1", Label: "cluster ID matches \"cluster1\""},
+			{ID: 1, Type: FlagClusterID, Pattern: "cluster1", Label: "cluster matches \"cluster1\""},
 			{ID: 2, Type: FlagOrgName, Pattern: "^Acme*", Label: "org name matches \"^Acme*\""},
 		}
 
 		content := formatFlagsList(conditions)
 		assert.Contains(t, content, "#1")
 		assert.Contains(t, content, "#2")
-		assert.Contains(t, content, "cluster ID matches")
+		assert.Contains(t, content, "cluster matches")
 		assert.Contains(t, content, "org name matches")
 	})
 }


### PR DESCRIPTION
## Summary

- `:flag cluster` now uses `matchGlob` instead of exact equality, and checks `Name` and `DisplayName` in addition to raw/internal/external IDs
- Plain patterns like `:flag cluster lk3-dev` match any cluster whose name, display name, or ID contains `"lk3-dev"` (substring match)
- Glob patterns (`*`, `^`, `$`) also work: `:flag cluster ^lk3-dev*` matches prefix, `:flag cluster openshiftapps.com$` matches suffix
- Updated label from "cluster ID matches" to "cluster matches"

## Test plan

- [x] All existing cluster flag tests still pass
- [x] New tests: glob pattern match, display name contains, substring match in middle, exact ID still works
- [x] Full CI suite passes (fmt, vet, lint, test, race)
- [ ] Manual: `:flag cluster lk3-dev` flags incidents for `lk3-dev-use2-a.vbah.p1.openshiftapps.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)