### PR TITLE
Fix colon command prefix in error messages and docs

### DIFF
--- a/docs/plans/055-claude-cli-integration.md
+++ b/docs/plans/055-claude-cli-integration.md
@@ -119,7 +119,7 @@ that verify typing every printable character in input mode.
 (Fixed by: [093-agent-slash-command.md](093-agent-slash-command.md))
 
 Bare text in the input field fell through to Claude dispatch. When flag
-conditions (PR #304) added `/flag` slash commands, the dispatch model
+conditions (PR #304) added `:flag` colon commands, the dispatch model
 became inconsistent: some commands used slash prefixes and others did
 not.
 

--- a/docs/plans/061-configurable-agent-cli.md
+++ b/docs/plans/061-configurable-agent-cli.md
@@ -5,7 +5,7 @@
 
 ## Goal
 
-Replace the hardcoded `claude --print` command in `/agent` queries with a
+Replace the hardcoded `claude --print` command in `:agent` queries with a
 configurable `agent_cli_command` config key. This fixes the bug where
 `exec.CommandContext(ctx, "claude", "--print")` fails when `claude` is a
 shell alias/function or not on PATH.

--- a/docs/plans/062-ambient-watcher.md
+++ b/docs/plans/062-ambient-watcher.md
@@ -19,7 +19,7 @@ collapsible pane below the incident table.
 - Provider status merged into footer line
 
 ### Phase 2: Claude CLI responses refactored into watcher pane
-- `/agent` responses redirect from incident viewer to watcher pane
+- `:agent` responses redirect from incident viewer to watcher pane
 - Ring buffer for observation history (50 entries)
 - Configurable emoji/text markers (emoji config toggle)
 - Per-line marker prefixing, word wrap at viewport width

--- a/docs/plans/091-flag-conditions.md
+++ b/docs/plans/091-flag-conditions.md
@@ -20,11 +20,11 @@ be saved/loaded to JSON for persistence.
 |------|--------|
 | `pkg/tui/flags.go` | New: FlagCondition types, matchGlob, evaluateFlags, matchClusterID, matchOrgName, renderFlagConditionsSection, formatFlagsList, rebuildFlagMatchCache |
 | `pkg/tui/flags_test.go` | New: 50+ tests for glob matching, flag evaluation, message handlers, display |
-| `pkg/tui/flag_commands.go` | New: Slash command parsing (/flag, /flags, /unflag), save/load, dispatch |
+| `pkg/tui/flag_commands.go` | New: Colon command parsing (:flag, :flags, :unflag), save/load, dispatch |
 | `pkg/tui/flag_commands_test.go` | New: 23 tests for command parsing and isFlagCommand |
 | `pkg/tui/model.go` | Add flagConditions, flagNextID, flagMarker, flagMatchCache fields |
 | `pkg/tui/tui.go` | Add message handlers, row annotation with flag marker, cache rebuild triggers |
-| `pkg/tui/msgHandlers.go` | Add f key handler, slash command routing in input mode |
+| `pkg/tui/msgHandlers.go` | Add f key handler, colon command routing in input mode |
 | `pkg/tui/keymap.go` | Add Flag key binding on f |
 | `pkg/tui/views.go` | Add flag conditions section to renderDetailsTab |
 | `pkg/config/config.go` | Add flag_marker optional config key |

--- a/docs/plans/093-agent-slash-command.md
+++ b/docs/plans/093-agent-slash-command.md
@@ -1,4 +1,4 @@
-# Plan: Require /agent prefix for Claude queries (#309)
+# Plan: Require :agent prefix for Claude queries (#309)
 
 **Status:** Complete
 **Issue:** #309
@@ -6,24 +6,24 @@
 
 ## Problem
 
-With flag conditions (PR #304), the input field supports `/flag` slash
+With flag conditions (PR #304), the input field supports `:flag` colon
 commands. Bare text still falls through to Claude dispatch, which is
 inconsistent. All input commands should use explicit prefixes.
 
 ## Solution
 
-Require `/agent <query>` prefix for Claude queries. Bare text without a
-recognized slash command shows an error with available commands.
+Require `:agent <query>` prefix for Claude queries. Bare text without a
+recognized colon command shows an error with available commands.
 
 The `i`/`:` keys open a blank input prompt (no pre-fill) so users can
-type any command: `/agent`, `/flag`, `/flags`, `/unflag`.
+type any command: `:agent`, `:flag`, `:flags`, `:unflag`.
 
 ## Files changed
 
 - `pkg/tui/claude.go` — add `isAgentCommand()`, `parseAgentQuery()`
 - `pkg/tui/claude_test.go` — 11 new tests, 2 updated existing tests
 - `pkg/tui/msgHandlers.go` — update Enter dispatch to require prefix
-- `pkg/tui/msgHandlers_test.go` — update 1 existing test for /agent
+- `pkg/tui/msgHandlers_test.go` — update 1 existing test for :agent
 - `pkg/tui/keymap.go` — update help text to "command input"
 - `README.md` — update key binding table
 

--- a/docs/plans/356-fix-command-prefix-docs.md
+++ b/docs/plans/356-fix-command-prefix-docs.md
@@ -1,0 +1,30 @@
+# Plan 356: Fix `/` → `:` command prefix in error messages and docs
+
+**Status:** Complete
+
+## Problem
+
+All colon commands (`:flag`, `:unflag`, `:flags`, `:agent`, `:watcher`) are
+dispatched with the `:` prefix in code, but several error messages, help text,
+config descriptions, and plan docs still referenced the old `/` slash prefix.
+This caused user-visible confusion — e.g., the `:flags` list view told users
+to type `/unflag all` which doesn't work.
+
+## Solution
+
+Replace every remaining `/` command prefix with `:` across error messages,
+help text, config descriptions, test inputs, and plan docs.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `pkg/tui/flags.go` | Fix help text: `/unflag` → `:unflag` |
+| `pkg/tui/flag_commands.go` | Fix 5 error messages: `/flags`, `/flag`, `/unflag` → `:` prefix |
+| `pkg/config/config.go` | Fix config description: `/agent` → `:agent` |
+| `pkg/tui/claude_test.go` | Fix negative test input: `/flag` → `:flag` |
+| `docs/plans/093-agent-slash-command.md` | Fix title and body: `/` → `:` prefix throughout |
+| `docs/plans/091-flag-conditions.md` | Fix file table descriptions |
+| `docs/plans/062-ambient-watcher.md` | Fix `/agent` → `:agent` |
+| `docs/plans/061-configurable-agent-cli.md` | Fix `/agent` → `:agent` |
+| `docs/plans/055-claude-cli-integration.md` | Fix `/flag` → `:flag` |

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -46,7 +46,7 @@ var (
 		"toolbox_mode":                       fmt.Sprintf("Toolbox detection mode: auto, true, false (default: %v)", DefaultOptionalKeys["toolbox_mode"]),
 		"chord_prefix":                       fmt.Sprintf("Chord prefix key for multi-key commands (default: %v)", DefaultOptionalKeys["chord_prefix"]),
 		"flag_marker":                        fmt.Sprintf("Prefix marker for flagged incidents (default: %v, alt: |►)", DefaultOptionalKeys["flag_marker"]),
-		"agent_cli_command":                  fmt.Sprintf("CLI agent command for /agent queries (default: %v)", DefaultOptionalKeys["agent_cli_command"]),
+		"agent_cli_command":                  fmt.Sprintf("CLI agent command for :agent queries (default: %v)", DefaultOptionalKeys["agent_cli_command"]),
 		"emoji":                              "Use emoji markers for flags/agent/watcher (default: true, set false for text fallbacks)",
 		"reescalate_level":                   fmt.Sprintf("Escalation level ctrl+e re-escalates to, skipping lower tiers (default: %v)", DefaultOptionalKeys["reescalate_level"]),
 		"stream_responses":                   "Stream :watcher/LLM responses token-by-token when the provider supports it (default: true)",

--- a/pkg/tui/claude_test.go
+++ b/pkg/tui/claude_test.go
@@ -622,7 +622,7 @@ func TestIsAgentCommand_WithLeadingSpace(t *testing.T) {
 }
 
 func TestIsAgentCommand_NotAgent(t *testing.T) {
-	assert.False(t, isAgentCommand("/flag cluster abc"))
+	assert.False(t, isAgentCommand(":flag cluster abc"))
 }
 
 func TestIsAgentCommand_PlainText(t *testing.T) {

--- a/pkg/tui/flag_commands.go
+++ b/pkg/tui/flag_commands.go
@@ -90,13 +90,13 @@ func parseFlagsSubcommand(args []string) (*parsedFlagCommand, error) {
 		}
 		return cmd, nil
 	default:
-		return nil, fmt.Errorf("unknown /flags subcommand: %s (use: save, load)", args[0])
+		return nil, fmt.Errorf("unknown :flags subcommand: %s (use: save, load)", args[0])
 	}
 }
 
 func parseFlagAdd(args []string) (*parsedFlagCommand, error) {
 	if len(args) == 0 {
-		return nil, fmt.Errorf("usage: /flag <cluster|org> <value>")
+		return nil, fmt.Errorf("usage: :flag <cluster|org> <value>")
 	}
 
 	flagType := args[0]
@@ -105,7 +105,7 @@ func parseFlagAdd(args []string) (*parsedFlagCommand, error) {
 	switch flagType {
 	case "cluster":
 		if value == "" {
-			return nil, fmt.Errorf("usage: /flag cluster <cluster-id>")
+			return nil, fmt.Errorf("usage: :flag cluster <cluster-id>")
 		}
 		return &parsedFlagCommand{
 			action: flagCmdAdd,
@@ -117,7 +117,7 @@ func parseFlagAdd(args []string) (*parsedFlagCommand, error) {
 		}, nil
 	case "org":
 		if value == "" {
-			return nil, fmt.Errorf("usage: /flag org <pattern>")
+			return nil, fmt.Errorf("usage: :flag org <pattern>")
 		}
 		return &parsedFlagCommand{
 			action: flagCmdAdd,
@@ -134,7 +134,7 @@ func parseFlagAdd(args []string) (*parsedFlagCommand, error) {
 
 func parseUnflag(args []string) (*parsedFlagCommand, error) {
 	if len(args) == 0 {
-		return nil, fmt.Errorf("usage: /unflag <id|all>")
+		return nil, fmt.Errorf("usage: :unflag <id|all>")
 	}
 
 	if args[0] == "all" {

--- a/pkg/tui/flags.go
+++ b/pkg/tui/flags.go
@@ -182,7 +182,7 @@ func formatFlagsList(conditions []FlagCondition) string {
 		}
 		fmt.Fprintf(&b, "* **#%d** [%s] %s\n", c.ID, typeName, c.Label)
 	}
-	b.WriteString("\nUse `/unflag <id>` to remove, `/unflag all` to clear.")
+	b.WriteString("\nUse `:unflag <id>` to remove, `:unflag all` to clear.")
 	return b.String()
 }
 


### PR DESCRIPTION
## Summary
- Fix user-visible error messages, help text, and config descriptions that still used `/` prefix instead of `:` for colon commands (`:flag`, `:unflag`, `:flags`, `:agent`, `:watcher`)
- Fix test input in `claude_test.go` to use realistic `:flag` input instead of invalid `/flag`
- Update 5 plan docs to consistently use `:` prefix terminology

## Test plan
- [x] `make test-all` passes (fmt, vet, lint, tests, race detection, fixtures)
- [x] Verified all colon command error messages now show `:` prefix
- [x] Verified `:flags` list help text now says `:unflag` instead of `/unflag`

🤖 Generated with [Claude Code](https://claude.com/claude-code)