### PR TITLE
Enrich dev mode test fixtures with realistic SRE data

### DIFF
--- a/docs/plans/138-enrich-test-fixtures.md
+++ b/docs/plans/138-enrich-test-fixtures.md
@@ -1,0 +1,47 @@
+# Plan 138: Enrich test fixtures with realistic data
+
+## Problem
+
+The dev mode test fixtures had minimal enrichment data. Most incident
+view tabs (Service Logs, Limited Support, PD History, Notes, Cluster
+Reports) were empty or had data for only one or two incidents, making
+the dev demo less useful for testing the full incident view UI.
+
+## Approach
+
+1. Queried real PagerDuty alerts from the PASPK4G team over the past
+   30 days to get authentic alert structures (etcdDatabaseQuotaLowSpace,
+   ClusterOperatorDown, console-ErrorBudgetBurn, cluster missing, etc.)
+2. Sanitized all customer data: cluster IDs → `fake-uuid-test` format,
+   service names → `example.org`, IPs → `10.X.X.X`, URLs → `example.org`
+3. Populated enrichment fixtures (service logs, limited support, cluster
+   reports, notes) keyed by the correct internal cluster IDs so the
+   MockClient returns them during dev mode enrichment
+4. Added 8 resolved historical incidents with `first_trigger_log_entry`
+   channel data so the PD History tab can match them to current incidents
+   via cluster ID
+5. Extended `fixtureIncident` with an optional `first_trigger_log_entry`
+   field so fixture incidents can carry the channel metadata that the
+   prior-alert scanner reads
+
+## Key design decisions
+
+- Fixture `servicelogs.json` and `limitedsupport.json` are keyed by
+  OCM internal ID (e.g. `cluster-osd-001`) because `MockClient.GetServiceLogs`
+  receives the internal ID from the phase-2 enrichment flow
+- Historical incidents carry `first_trigger_log_entry.channel.details.cluster_id`
+  so `matchIncidentToCluster` can match non-HCP incidents (HCP incidents
+  already match via UUID in the title)
+- Alert names and structures preserved from real PD data; only identifiers
+  and URLs sanitized
+
+## Files changed
+
+- `testdata/fixtures/incidents.json` — added 8 resolved historical incidents
+- `testdata/fixtures/alerts.json` — unchanged (already had good data)
+- `testdata/fixtures/notes.json` — notes for INC_001, 003, 009, 010, 012
+- `testdata/fixtures/servicelogs.json` — service logs for 5 clusters
+- `testdata/fixtures/limitedsupport.json` — LS reasons for 3 clusters
+- `testdata/fixtures/clusterreports.json` — CORA reports for 5 clusters
+- `pkg/pd/dev.go` — `fixtureFirstTriggerEntry` struct, wiring in converter
+- `pkg/pd/dev_test.go` — updated counts for new fixture data

--- a/pkg/pd/dev.go
+++ b/pkg/pd/dev.go
@@ -49,21 +49,26 @@ type fixtureEscalationPolicy struct {
 // fixtureIncident is a simplified incident for JSON unmarshaling.
 // Fields match the PagerDuty API JSON structure.
 type fixtureIncident struct {
-	ID                 string              `json:"id"`
-	Type               string              `json:"type"`
-	Self               string              `json:"self"`
-	HTMLURL            string              `json:"html_url"`
-	IncidentNumber     uint                `json:"incident_number"`
-	Title              string              `json:"title"`
-	Status             string              `json:"status"`
-	Urgency            string              `json:"urgency"`
-	CreatedAt          string              `json:"created_at"`
-	LastStatusChangeAt string              `json:"last_status_change_at"`
-	Service            fixtureServiceRef   `json:"service"`
-	EscalationPolicy   fixtureAPIRef       `json:"escalation_policy"`
-	Assignments        []fixtureAssignment `json:"assignments"`
-	Acknowledgements   []fixtureAck        `json:"acknowledgements"`
-	Teams              []fixtureAPIRef     `json:"teams"`
+	ID                   string                    `json:"id"`
+	Type                 string                    `json:"type"`
+	Self                 string                    `json:"self"`
+	HTMLURL              string                    `json:"html_url"`
+	IncidentNumber       uint                      `json:"incident_number"`
+	Title                string                    `json:"title"`
+	Status               string                    `json:"status"`
+	Urgency              string                    `json:"urgency"`
+	CreatedAt            string                    `json:"created_at"`
+	LastStatusChangeAt   string                    `json:"last_status_change_at"`
+	Service              fixtureServiceRef         `json:"service"`
+	EscalationPolicy     fixtureAPIRef             `json:"escalation_policy"`
+	Assignments          []fixtureAssignment       `json:"assignments"`
+	Acknowledgements     []fixtureAck              `json:"acknowledgements"`
+	Teams                []fixtureAPIRef           `json:"teams"`
+	FirstTriggerLogEntry *fixtureFirstTriggerEntry `json:"first_trigger_log_entry,omitempty"`
+}
+
+type fixtureFirstTriggerEntry struct {
+	Channel map[string]interface{} `json:"channel,omitempty"`
 }
 
 type fixtureServiceRef struct {
@@ -330,6 +335,17 @@ func convertFixtureIncident(fi fixtureIncident) *pagerduty.Incident {
 			Type:    ft.Type,
 			Summary: ft.Summary,
 		})
+	}
+
+	if fi.FirstTriggerLogEntry != nil && fi.FirstTriggerLogEntry.Channel != nil {
+		incident.FirstTriggerLogEntry = pagerduty.FirstTriggerLogEntry{
+			CommonLogEntryField: pagerduty.CommonLogEntryField{
+				Channel: pagerduty.Channel{
+					Type: "trigger",
+					Raw:  fi.FirstTriggerLogEntry.Channel,
+				},
+			},
+		}
 	}
 
 	return incident

--- a/pkg/pd/dev_test.go
+++ b/pkg/pd/dev_test.go
@@ -22,7 +22,7 @@ func TestLoadFixtures(t *testing.T) {
 		assert.NotNil(t, fixtures.Config)
 
 		// Verify incident count matches fixture data (12 scenarios)
-		assert.Equal(t, 12, len(fixtures.Incidents))
+		assert.Equal(t, 20, len(fixtures.Incidents))
 
 		// Verify config has user, teams, team members, and escalation policies
 		assert.NotEmpty(t, fixtures.Config.User.ID)
@@ -45,7 +45,7 @@ func TestDevClient_ListIncidents(t *testing.T) {
 		resp, err := client.ListIncidentsWithContext(ctx, pagerduty.ListIncidentsOptions{})
 		require.NoError(t, err)
 
-		assert.Equal(t, 12, len(resp.Incidents))
+		assert.Equal(t, 20, len(resp.Incidents))
 		assert.False(t, resp.More)
 	})
 
@@ -278,7 +278,7 @@ func TestDevClient_ListIncidentNotes(t *testing.T) {
 	})
 
 	t.Run("returns empty notes for incident without notes", func(t *testing.T) {
-		notes, err := client.ListIncidentNotesWithContext(ctx, "PDEV_INC_001")
+		notes, err := client.ListIncidentNotesWithContext(ctx, "PDEV_INC_002")
 		require.NoError(t, err)
 		assert.Equal(t, 0, len(notes))
 	})

--- a/testdata/fixtures/clusterreports.json
+++ b/testdata/fixtures/clusterreports.json
@@ -2,20 +2,46 @@
   "cluster-osd-001": [
     {
       "report_id": "rpt-cora-001",
-      "summary": "CORA automated triage: ClusterOperatorDown (monitoring)",
-      "created_at": "2026-06-01T14:30:00Z"
+      "summary": "CORA automated triage: ClusterOperatorDown (ingress)",
+      "created_at": "2026-05-28T14:32:00Z"
     },
     {
-      "report_id": "rpt-cora-002",
+      "report_id": "rpt-cora-007",
       "summary": "CORA automated triage: KubePersistentVolumeFillingUp",
-      "created_at": "2026-05-28T09:15:00Z"
+      "created_at": "2026-05-27T09:15:00Z"
     }
   ],
-  "cluster-osd-002": [
+  "cluster-appsre-001": [
+    {
+      "report_id": "rpt-cora-002",
+      "summary": "CORA automated triage: ClusterProvisioningDelay (ProvisionFailed/UnknownError)",
+      "created_at": "2026-05-28T12:18:00Z"
+    }
+  ],
+  "cluster-multi-001": [
     {
       "report_id": "rpt-cora-003",
-      "summary": "CORA automated triage: PodDisruptionBudgetLimitSRE",
-      "created_at": "2026-06-02T11:00:00Z"
+      "summary": "CORA automated triage: console-ErrorBudgetBurn (probe failure)",
+      "created_at": "2026-05-28T06:02:00Z"
+    }
+  ],
+  "cluster-acked-001": [
+    {
+      "report_id": "rpt-cora-004",
+      "summary": "CORA automated triage: api-ErrorBudgetBurn (elevated latency)",
+      "created_at": "2026-05-28T05:05:00Z"
+    },
+    {
+      "report_id": "rpt-cora-005",
+      "summary": "CORA automated triage: KubePersistentVolumeFillingUp",
+      "created_at": "2026-05-27T09:15:00Z"
+    }
+  ],
+  "cluster-hcp-002": [
+    {
+      "report_id": "rpt-cora-006",
+      "summary": "CORA automated triage: KubeAPIErrorBudgetBurn (HCP control plane)",
+      "created_at": "2026-05-28T03:05:00Z"
     }
   ]
 }

--- a/testdata/fixtures/incidents.json
+++ b/testdata/fixtures/incidents.json
@@ -538,5 +538,317 @@
         "summary": "Dev Platform SRE"
       }
     ]
+  },
+  {
+    "id": "PDEV_INC_H01",
+    "type": "incident",
+    "self": "https://api.example.pagerduty.com/incidents/PDEV_INC_H01",
+    "html_url": "https://example.pagerduty.com/incidents/PDEV_INC_H01",
+    "incident_number": 49901,
+    "title": "ClusterOperatorDown CRITICAL (1)",
+    "status": "resolved",
+    "urgency": "high",
+    "created_at": "2026-05-21T09:30:00Z",
+    "last_status_change_at": "2026-05-21T10:45:00Z",
+    "first_trigger_log_entry": {
+      "channel": {
+        "details": {
+          "alert_name": "ClusterOperatorDown",
+          "cluster_id": "e7c5363a-fake-uuid-test-edf99fc3ea25"
+        }
+      }
+    },
+    "service": {
+      "id": "PDEV_SVC_001",
+      "type": "service_reference",
+      "summary": "osd-fake-webapp.p1.example.org-hive-cluster",
+      "self": "https://api.example.pagerduty.com/services/PDEV_SVC_001",
+      "html_url": "https://example.pagerduty.com/services/PDEV_SVC_001"
+    },
+    "escalation_policy": {
+      "id": "PDEV_POLICY_DEFAULT",
+      "type": "escalation_policy_reference",
+      "summary": "SREP Default Escalation"
+    },
+    "assignments": [],
+    "acknowledgements": [],
+    "teams": [
+      {
+        "id": "PDEV_TEAM_001",
+        "type": "team_reference",
+        "summary": "Dev Platform SRE"
+      }
+    ]
+  },
+  {
+    "id": "PDEV_INC_H02",
+    "type": "incident",
+    "self": "https://api.example.pagerduty.com/incidents/PDEV_INC_H02",
+    "html_url": "https://example.pagerduty.com/incidents/PDEV_INC_H02",
+    "incident_number": 49902,
+    "title": "etcdDatabaseQuotaLowSpace WARNING (1)",
+    "status": "resolved",
+    "urgency": "high",
+    "created_at": "2026-05-15T16:00:00Z",
+    "last_status_change_at": "2026-05-15T16:45:00Z",
+    "first_trigger_log_entry": {
+      "channel": {
+        "details": {
+          "alert_name": "etcdDatabaseQuotaLowSpace",
+          "cluster_id": "e7c5363a-fake-uuid-test-edf99fc3ea25"
+        }
+      }
+    },
+    "service": {
+      "id": "PDEV_SVC_001",
+      "type": "service_reference",
+      "summary": "osd-fake-webapp.p1.example.org-hive-cluster",
+      "self": "https://api.example.pagerduty.com/services/PDEV_SVC_001",
+      "html_url": "https://example.pagerduty.com/services/PDEV_SVC_001"
+    },
+    "escalation_policy": {
+      "id": "PDEV_POLICY_DEFAULT",
+      "type": "escalation_policy_reference",
+      "summary": "SREP Default Escalation"
+    },
+    "assignments": [],
+    "acknowledgements": [],
+    "teams": [
+      {
+        "id": "PDEV_TEAM_001",
+        "type": "team_reference",
+        "summary": "Dev Platform SRE"
+      }
+    ]
+  },
+  {
+    "id": "PDEV_INC_H03",
+    "type": "incident",
+    "self": "https://api.example.pagerduty.com/incidents/PDEV_INC_H03",
+    "html_url": "https://example.pagerduty.com/incidents/PDEV_INC_H03",
+    "incident_number": 49903,
+    "title": "console-ErrorBudgetBurn CRITICAL (1)",
+    "status": "resolved",
+    "urgency": "high",
+    "created_at": "2026-05-20T11:00:00Z",
+    "last_status_change_at": "2026-05-20T11:30:00Z",
+    "first_trigger_log_entry": {
+      "channel": {
+        "details": {
+          "alert_name": "console-ErrorBudgetBurn",
+          "cluster_id": "3a7b9c1d-fake-uuid-test-8e4f2a6b0c3d"
+        }
+      }
+    },
+    "service": {
+      "id": "PDEV_SVC_009",
+      "type": "service_reference",
+      "summary": "osd-fake-multi2.def3.p1.example.org-hive-cluster",
+      "self": "https://api.example.pagerduty.com/services/PDEV_SVC_009",
+      "html_url": "https://example.pagerduty.com/services/PDEV_SVC_009"
+    },
+    "escalation_policy": {
+      "id": "PDEV_POLICY_DEFAULT",
+      "type": "escalation_policy_reference",
+      "summary": "SREP Default Escalation"
+    },
+    "assignments": [],
+    "acknowledgements": [],
+    "teams": [
+      {
+        "id": "PDEV_TEAM_001",
+        "type": "team_reference",
+        "summary": "Dev Platform SRE"
+      }
+    ]
+  },
+  {
+    "id": "PDEV_INC_H04",
+    "type": "incident",
+    "self": "https://api.example.pagerduty.com/incidents/PDEV_INC_H04",
+    "html_url": "https://example.pagerduty.com/incidents/PDEV_INC_H04",
+    "incident_number": 49904,
+    "title": "api-ErrorBudgetBurn CRITICAL (1)",
+    "status": "resolved",
+    "urgency": "high",
+    "created_at": "2026-05-10T03:00:00Z",
+    "last_status_change_at": "2026-05-10T04:00:00Z",
+    "first_trigger_log_entry": {
+      "channel": {
+        "details": {
+          "alert_name": "api-ErrorBudgetBurn",
+          "cluster_id": "3a7b9c1d-fake-uuid-test-8e4f2a6b0c3d"
+        }
+      }
+    },
+    "service": {
+      "id": "PDEV_SVC_009",
+      "type": "service_reference",
+      "summary": "osd-fake-multi2.def3.p1.example.org-hive-cluster",
+      "self": "https://api.example.pagerduty.com/services/PDEV_SVC_009",
+      "html_url": "https://example.pagerduty.com/services/PDEV_SVC_009"
+    },
+    "escalation_policy": {
+      "id": "PDEV_POLICY_DEFAULT",
+      "type": "escalation_policy_reference",
+      "summary": "SREP Default Escalation"
+    },
+    "assignments": [],
+    "acknowledgements": [],
+    "teams": [
+      {
+        "id": "PDEV_TEAM_001",
+        "type": "team_reference",
+        "summary": "Dev Platform SRE"
+      }
+    ]
+  },
+  {
+    "id": "PDEV_INC_H05",
+    "type": "incident",
+    "self": "https://api.example.pagerduty.com/incidents/PDEV_INC_H05",
+    "html_url": "https://example.pagerduty.com/incidents/PDEV_INC_H05",
+    "incident_number": 49905,
+    "title": "[HCP] [RHOBS] (Warning) KubeAPIErrorBudgetBurn for HCP: 1b20416f-fake-uuid-test-5a6e450114eb",
+    "status": "resolved",
+    "urgency": "high",
+    "created_at": "2026-05-18T22:00:00Z",
+    "last_status_change_at": "2026-05-18T23:15:00Z",
+    "service": {
+      "id": "PDEV_SVC_012",
+      "type": "service_reference",
+      "summary": "rhobs-hcp-prod-critical-us-west-2",
+      "self": "https://api.example.pagerduty.com/services/PDEV_SVC_012",
+      "html_url": "https://example.pagerduty.com/services/PDEV_SVC_012"
+    },
+    "escalation_policy": {
+      "id": "PDEV_POLICY_DEFAULT",
+      "type": "escalation_policy_reference",
+      "summary": "SREP Default Escalation"
+    },
+    "assignments": [],
+    "acknowledgements": [],
+    "teams": [
+      {
+        "id": "PDEV_TEAM_001",
+        "type": "team_reference",
+        "summary": "Dev Platform SRE"
+      }
+    ]
+  },
+  {
+    "id": "PDEV_INC_H06",
+    "type": "incident",
+    "self": "https://api.example.pagerduty.com/incidents/PDEV_INC_H06",
+    "html_url": "https://example.pagerduty.com/incidents/PDEV_INC_H06",
+    "incident_number": 49906,
+    "title": "[HCP] [RHOBS] (Critical) ClusterOperatorDown for HCP: 1b20416f-fake-uuid-test-5a6e450114eb",
+    "status": "resolved",
+    "urgency": "high",
+    "created_at": "2026-05-12T07:30:00Z",
+    "last_status_change_at": "2026-05-12T08:00:00Z",
+    "service": {
+      "id": "PDEV_SVC_012",
+      "type": "service_reference",
+      "summary": "rhobs-hcp-prod-critical-us-west-2",
+      "self": "https://api.example.pagerduty.com/services/PDEV_SVC_012",
+      "html_url": "https://example.pagerduty.com/services/PDEV_SVC_012"
+    },
+    "escalation_policy": {
+      "id": "PDEV_POLICY_DEFAULT",
+      "type": "escalation_policy_reference",
+      "summary": "SREP Default Escalation"
+    },
+    "assignments": [],
+    "acknowledgements": [],
+    "teams": [
+      {
+        "id": "PDEV_TEAM_001",
+        "type": "team_reference",
+        "summary": "Dev Platform SRE"
+      }
+    ]
+  },
+  {
+    "id": "PDEV_INC_H07",
+    "type": "incident",
+    "self": "https://api.example.pagerduty.com/incidents/PDEV_INC_H07",
+    "html_url": "https://example.pagerduty.com/incidents/PDEV_INC_H07",
+    "incident_number": 49907,
+    "title": "ClusterOperatorDown CRITICAL (1)",
+    "status": "resolved",
+    "urgency": "high",
+    "created_at": "2026-05-05T14:00:00Z",
+    "last_status_change_at": "2026-05-05T15:30:00Z",
+    "first_trigger_log_entry": {
+      "channel": {
+        "details": {
+          "alert_name": "ClusterOperatorDown",
+          "cluster_id": "e7c5363a-fake-uuid-test-edf99fc3ea25"
+        }
+      }
+    },
+    "service": {
+      "id": "PDEV_SVC_001",
+      "type": "service_reference",
+      "summary": "osd-fake-webapp.p1.example.org-hive-cluster",
+      "self": "https://api.example.pagerduty.com/services/PDEV_SVC_001",
+      "html_url": "https://example.pagerduty.com/services/PDEV_SVC_001"
+    },
+    "escalation_policy": {
+      "id": "PDEV_POLICY_DEFAULT",
+      "type": "escalation_policy_reference",
+      "summary": "SREP Default Escalation"
+    },
+    "assignments": [],
+    "acknowledgements": [],
+    "teams": [
+      {
+        "id": "PDEV_TEAM_001",
+        "type": "team_reference",
+        "summary": "Dev Platform SRE"
+      }
+    ]
+  },
+  {
+    "id": "PDEV_INC_H08",
+    "type": "incident",
+    "self": "https://api.example.pagerduty.com/incidents/PDEV_INC_H08",
+    "html_url": "https://example.pagerduty.com/incidents/PDEV_INC_H08",
+    "incident_number": 49908,
+    "title": "console-ErrorBudgetBurn CRITICAL (2)",
+    "status": "resolved",
+    "urgency": "high",
+    "created_at": "2026-05-08T19:00:00Z",
+    "last_status_change_at": "2026-05-08T19:45:00Z",
+    "first_trigger_log_entry": {
+      "channel": {
+        "details": {
+          "alert_name": "console-ErrorBudgetBurn",
+          "cluster_id": "3a7b9c1d-fake-uuid-test-8e4f2a6b0c3d"
+        }
+      }
+    },
+    "service": {
+      "id": "PDEV_SVC_009",
+      "type": "service_reference",
+      "summary": "osd-fake-multi2.def3.p1.example.org-hive-cluster",
+      "self": "https://api.example.pagerduty.com/services/PDEV_SVC_009",
+      "html_url": "https://example.pagerduty.com/services/PDEV_SVC_009"
+    },
+    "escalation_policy": {
+      "id": "PDEV_POLICY_DEFAULT",
+      "type": "escalation_policy_reference",
+      "summary": "SREP Default Escalation"
+    },
+    "assignments": [],
+    "acknowledgements": [],
+    "teams": [
+      {
+        "id": "PDEV_TEAM_001",
+        "type": "team_reference",
+        "summary": "Dev Platform SRE"
+      }
+    ]
   }
 ]

--- a/testdata/fixtures/limitedsupport.json
+++ b/testdata/fixtures/limitedsupport.json
@@ -1,11 +1,29 @@
 {
-  "e7c5363a-fake-uuid-test-edf99fc3ea25": [
+  "cluster-osd-001": [
     {
       "id": "ls-001",
       "summary": "Customer modified ingress configuration",
-      "details": "Customer replaced default IngressController with custom configuration that removed required annotations.",
+      "details": "Customer replaced default IngressController with custom configuration that removed required annotations. Cluster operator unable to reconcile.",
       "detection_type": "manual",
       "created_at": "2026-05-27T09:00:00Z"
+    }
+  ],
+  "cluster-multi-001": [
+    {
+      "id": "ls-002",
+      "summary": "Custom NetworkPolicy blocking monitoring",
+      "details": "Customer applied NetworkPolicy in openshift-route-monitor-operator namespace that blocks egress to monitoring endpoints. Console SLO probes may produce false positives.",
+      "detection_type": "automated",
+      "created_at": "2026-05-27T22:00:00Z"
+    }
+  ],
+  "cluster-acked-001": [
+    {
+      "id": "ls-003",
+      "summary": "Customer modified API server flags",
+      "details": "Customer modified kube-apiserver configuration via unsupported mechanism. API server audit logging and admission webhook chain may be impacted.",
+      "detection_type": "automated",
+      "created_at": "2026-05-26T16:30:00Z"
     }
   ]
 }

--- a/testdata/fixtures/notes.json
+++ b/testdata/fixtures/notes.json
@@ -1,9 +1,9 @@
 {
-  "PDEV_INC_012": [
+  "PDEV_INC_001": [
     {
       "id": "PDEV_NOTE_001",
-      "content": "Investigating HCP cluster 1b20416f - checking management cluster logs and hosted control plane pod health.",
-      "created_at": "2026-05-28T03:15:00Z",
+      "content": "ClusterOperatorDown alert for e7c5363a-fake-uuid-test-edf99fc3ea25. Ingress operator unavailable for 10 minutes. Checking pod status in openshift-ingress-operator namespace.",
+      "created_at": "2026-05-28T14:35:00Z",
       "user": {
         "id": "PDEV_USER_001",
         "type": "user_reference",
@@ -12,7 +12,105 @@
     },
     {
       "id": "PDEV_NOTE_002",
-      "content": "Found ingress operator pods CrashLooping on the management cluster. Checking subnet tags and worker node availability.",
+      "content": "Ingress operator pods are CrashLooping. Customer modified IngressController removing required annotations. Sent service log to customer. Cluster placed in limited support.",
+      "created_at": "2026-05-28T14:50:00Z",
+      "user": {
+        "id": "PDEV_USER_002",
+        "type": "user_reference",
+        "summary": "Alice Engineer"
+      }
+    }
+  ],
+  "PDEV_INC_003": [
+    {
+      "id": "PDEV_NOTE_003",
+      "content": "ClusterProvisioningDelay for edf-mas on GCP. Cluster has been in ProvisionFailed for over 4 hours. Checking installer logs and GCP project quotas.",
+      "created_at": "2026-05-28T12:20:00Z",
+      "user": {
+        "id": "PDEV_USER_001",
+        "type": "user_reference",
+        "summary": "Dev User"
+      }
+    },
+    {
+      "id": "PDEV_NOTE_004",
+      "content": "Installer logs show GCP API rate limiting during bootstrap. Retrying provision with backoff. Customer org has high cluster churn causing quota pressure.",
+      "created_at": "2026-05-28T12:45:00Z",
+      "user": {
+        "id": "PDEV_USER_003",
+        "type": "user_reference",
+        "summary": "Bob Oncall"
+      }
+    }
+  ],
+  "PDEV_INC_009": [
+    {
+      "id": "PDEV_NOTE_005",
+      "content": "Console error budget burn detected on cluster 3a7b9c1d-fake-uuid-test-8e4f2a6b0c3d. Current 30min error rate: 6.7%. Checking probe failures and route monitor operator.",
+      "created_at": "2026-05-28T06:05:00Z",
+      "user": {
+        "id": "PDEV_USER_002",
+        "type": "user_reference",
+        "summary": "Alice Engineer"
+      }
+    },
+    {
+      "id": "PDEV_NOTE_006",
+      "content": "Customer has NetworkPolicy blocking egress from route-monitor-operator namespace. Probe failures are false positives. Cluster in limited support. Sent SL with remediation steps.",
+      "created_at": "2026-05-28T06:20:00Z",
+      "user": {
+        "id": "PDEV_USER_002",
+        "type": "user_reference",
+        "summary": "Alice Engineer"
+      }
+    },
+    {
+      "id": "PDEV_NOTE_007",
+      "content": "Also seeing same console-ErrorBudgetBurn on 7f2e8d4a-fake-uuid-test-1b9c3a5d7e0f and 5d1a8f3e-fake-uuid-test-9c2b4e6d0a7f in the same org. All three clusters share the same NetworkPolicy template.",
+      "created_at": "2026-05-28T06:30:00Z",
+      "user": {
+        "id": "PDEV_USER_002",
+        "type": "user_reference",
+        "summary": "Alice Engineer"
+      }
+    }
+  ],
+  "PDEV_INC_010": [
+    {
+      "id": "PDEV_NOTE_008",
+      "content": "api-ErrorBudgetBurn on cluster 2c4b6a8d-fake-uuid-test-7e3f1a9d5b0c. KubeAPI latency p99 elevated to 1.2s. Checking etcd health and API server pod resources.",
+      "created_at": "2026-05-28T05:10:00Z",
+      "user": {
+        "id": "PDEV_USER_001",
+        "type": "user_reference",
+        "summary": "Dev User"
+      }
+    },
+    {
+      "id": "PDEV_NOTE_009",
+      "content": "Customer modified kube-apiserver flags via unsupported mechanism. Audit logging overhead causing API latency. Cluster in limited support. Customer aware, working on reverting.",
+      "created_at": "2026-05-28T05:25:00Z",
+      "user": {
+        "id": "PDEV_USER_001",
+        "type": "user_reference",
+        "summary": "Dev User"
+      }
+    }
+  ],
+  "PDEV_INC_012": [
+    {
+      "id": "PDEV_NOTE_010",
+      "content": "Investigating HCP cluster 1b20416f-fake-uuid-test-5a6e450114eb - KubeAPI error budget burning. Checking management cluster logs and hosted control plane pod health.",
+      "created_at": "2026-05-28T03:15:00Z",
+      "user": {
+        "id": "PDEV_USER_001",
+        "type": "user_reference",
+        "summary": "Dev User"
+      }
+    },
+    {
+      "id": "PDEV_NOTE_011",
+      "content": "kube-apiserver pod on management cluster showing elevated memory usage. Found customer admission webhooks causing increased API server load. Investigating webhook configuration.",
       "created_at": "2026-05-28T03:30:00Z",
       "user": {
         "id": "PDEV_USER_002",
@@ -21,8 +119,8 @@
       }
     },
     {
-      "id": "PDEV_NOTE_003",
-      "content": "Root cause identified: customer deleted required subnet tags. Sent service log to customer with remediation steps. Monitoring for recovery.",
+      "id": "PDEV_NOTE_012",
+      "content": "Root cause identified: customer webhook with 30s timeout on all API requests. Sent service log recommending webhook optimization. Error budget recovering.",
       "created_at": "2026-05-28T03:45:00Z",
       "user": {
         "id": "PDEV_USER_003",

--- a/testdata/fixtures/servicelogs.json
+++ b/testdata/fixtures/servicelogs.json
@@ -1,5 +1,5 @@
 {
-  "e7c5363a-fake-uuid-test-edf99fc3ea25": [
+  "cluster-osd-001": [
     {
       "timestamp": "2026-05-28T14:00:00Z",
       "severity": "Warning",
@@ -7,7 +7,8 @@
       "summary": "Customer notified of ClusterOperatorDown",
       "description": "SRE team contacted customer regarding ingress operator unavailability. Customer acknowledged and is investigating network configuration changes.",
       "cluster_id": "cluster-osd-001",
-      "cluster_uuid": "e7c5363a-fake-uuid-test-edf99fc3ea25"
+      "cluster_uuid": "e7c5363a-fake-uuid-test-edf99fc3ea25",
+      "internal_only": false
     },
     {
       "timestamp": "2026-05-28T12:30:00Z",
@@ -16,29 +17,106 @@
       "summary": "Cluster entered limited support",
       "description": "Cluster entered limited support due to customer modification of ingress configuration.",
       "cluster_id": "cluster-osd-001",
-      "cluster_uuid": "e7c5363a-fake-uuid-test-edf99fc3ea25"
+      "cluster_uuid": "e7c5363a-fake-uuid-test-edf99fc3ea25",
+      "internal_only": false
+    },
+    {
+      "timestamp": "2026-05-28T10:15:00Z",
+      "severity": "Info",
+      "service_name": "ClusterService",
+      "summary": "Cluster Delete Protection updated",
+      "description": "Cluster Delete Protection has been updated to 'true'",
+      "cluster_id": "cluster-osd-001",
+      "cluster_uuid": "e7c5363a-fake-uuid-test-edf99fc3ea25",
+      "internal_only": false
     }
   ],
-  "b2d4e6f8-fake-uuid-test-def012345678": [
+  "cluster-appsre-001": [
     {
-      "timestamp": "2026-05-28T13:00:00Z",
+      "timestamp": "2026-05-28T12:00:00Z",
       "severity": "Error",
-      "service_name": "etcdHealthCheck",
-      "summary": "etcd cluster health degraded",
-      "description": "etcd members reporting high commit durations. Disk I/O may be constrained. Investigating storage performance.",
-      "cluster_id": "cluster-osd-002",
-      "cluster_uuid": "b2d4e6f8-fake-uuid-test-def012345678"
+      "service_name": "ClusterProvisioningMonitor",
+      "summary": "Cluster provisioning failed: UnknownError",
+      "description": "Cluster edf-mas has been in ProvisionFailed condition for over 4 hours. Platform: GCP, image: openshift-v4.21.16. SRE investigating installer logs for root cause.",
+      "cluster_id": "cluster-appsre-001",
+      "cluster_uuid": "fakeid0000000000000000000000002",
+      "internal_only": false
+    },
+    {
+      "timestamp": "2026-05-28T11:30:00Z",
+      "severity": "Info",
+      "service_name": "ClusterService",
+      "summary": "Provision attempt initiated",
+      "description": "Cluster provision attempt started. Target platform: GCP, region: us-east-1, version: 4.21.16.",
+      "cluster_id": "cluster-appsre-001",
+      "cluster_uuid": "fakeid0000000000000000000000002",
+      "internal_only": true
     }
   ],
-  "a4ba96fe-fake-uuid-test-17d38eeaab99": [
+  "cluster-multi-001": [
     {
-      "timestamp": "2026-05-28T10:30:00Z",
+      "timestamp": "2026-05-28T05:45:00Z",
       "severity": "Warning",
+      "service_name": "SLOMonitoring",
+      "summary": "Console SLO error budget burn rate elevated",
+      "description": "Console availability SLO is burning error budget faster than normal rate. Current 30min error rate: 6.7%. Probe URL showing intermittent timeouts.",
+      "cluster_id": "cluster-multi-001",
+      "cluster_uuid": "3a7b9c1d-fake-uuid-test-8e4f2a6b0c3d",
+      "internal_only": false
+    },
+    {
+      "timestamp": "2026-05-28T05:30:00Z",
+      "severity": "Info",
+      "service_name": "RoutemonitorOperator",
+      "summary": "Route monitor probe failure detected",
+      "description": "BlackboxExporter detected probe failures for console health endpoint. Investigating HAProxy and router pod status.",
+      "cluster_id": "cluster-multi-001",
+      "cluster_uuid": "3a7b9c1d-fake-uuid-test-8e4f2a6b0c3d",
+      "internal_only": false
+    }
+  ],
+  "cluster-acked-001": [
+    {
+      "timestamp": "2026-05-28T04:45:00Z",
+      "severity": "Warning",
+      "service_name": "SLOMonitoring",
+      "summary": "API SLO error budget burn rate critical",
+      "description": "API availability SLO is burning error budget at critical rate. KubeAPI latency p99 elevated to 1.2s. Checking etcd health and API server pod resources.",
+      "cluster_id": "cluster-acked-001",
+      "cluster_uuid": "2c4b6a8d-fake-uuid-test-7e3f1a9d5b0c",
+      "internal_only": false
+    },
+    {
+      "timestamp": "2026-05-28T04:30:00Z",
+      "severity": "Info",
+      "service_name": "ClusterService",
+      "summary": "Minor version for automatic upgrades enabled",
+      "description": "Cluster 'cluster-acked-001' enabled for minor version of automatic upgrades",
+      "cluster_id": "cluster-acked-001",
+      "cluster_uuid": "2c4b6a8d-fake-uuid-test-7e3f1a9d5b0c",
+      "internal_only": false
+    }
+  ],
+  "cluster-hcp-002": [
+    {
+      "timestamp": "2026-05-28T02:45:00Z",
+      "severity": "Error",
       "service_name": "HCPHealthCheck",
-      "summary": "HCP control plane ingress degraded",
-      "description": "The hosted control plane ingress operator has been unavailable for 10 minutes. Automated remediation in progress.",
-      "cluster_id": "cluster-hcp-001",
-      "cluster_uuid": "a4ba96fe-fake-uuid-test-17d38eeaab99"
+      "summary": "KubeAPI error budget burning for HCP",
+      "description": "KubeAPI error budget is burning for hosted control plane. API server pod on management cluster showing elevated error rates. Checking management cluster node resources.",
+      "cluster_id": "cluster-hcp-002",
+      "cluster_uuid": "1b20416f-fake-uuid-test-5a6e450114eb",
+      "internal_only": false
+    },
+    {
+      "timestamp": "2026-05-28T02:30:00Z",
+      "severity": "Info",
+      "service_name": "SREManualAction",
+      "summary": "Investigating HCP pod health on management cluster",
+      "description": "SRE checking kube-apiserver pod in ocm-production namespace on management cluster. Memory usage elevated, investigating potential memory leak in custom admission webhooks.",
+      "cluster_id": "cluster-hcp-002",
+      "cluster_uuid": "1b20416f-fake-uuid-test-5a6e450114eb",
+      "internal_only": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Populated all incident view tabs (Service Logs, Limited Support, PD History, Notes, Cluster Reports) with sanitized data sourced from real PagerDuty alerts from the PASPK4G team
- Added `FirstTriggerLogEntry` fixture support so the PD History scanner can match historical incidents by cluster ID
- Added 8 resolved historical incidents for PD History tab coverage across 4 incident types

## Test plan
- [x] `make test-all` passes locally (fmt, vet, lint, test, race)
- [ ] CI passes all checks
- [ ] Dev mode shows enrichment data in incident view tabs for PDEV_INC_001, 003, 009, 010, 012
- [ ] PD History tab shows prior instances for PDEV_INC_001, 009, 012

🤖 Generated with [Claude Code](https://claude.com/claude-code)