### PR TITLE
Fix watcher pane missing right border

### DIFF
--- a/docs/plans/357-fix-watcher-right-border.md
+++ b/docs/plans/357-fix-watcher-right-border.md
@@ -1,0 +1,30 @@
+# Fix watcher pane missing right border
+
+## Problem
+
+The watcher pane (toggled with `w`) is missing its right border. The
+incident table above it renders all four borders correctly, but the
+watcher box's right border is clipped off-screen at any terminal width.
+
+## Root cause
+
+In `layout.go`, `watcherWidth` was computed using `containerHOverhead`
+derived from `TableContainer` (which has no padding). The watcher
+content is rendered inside `WatcherContainer`, which has
+`Padding(0, 1)` -- 2 extra horizontal characters. This made the
+viewport 2 chars too wide, pushing the right border past the terminal
+edge.
+
+## Fix
+
+Add a separate `watcherHOverhead` variable computed from
+`WatcherContainer`'s own margins, padding, and border size, and use
+it for `watcherWidth` instead of reusing `containerHOverhead`.
+
+## Files changed
+
+- `pkg/tui/layout.go` -- compute `watcherHOverhead` from
+  `WatcherContainer` style; use it for `watcherWidth`
+- `pkg/tui/layout_test.go` -- add
+  `TestComputeLayout_WatcherWidthAccountsForPadding` verifying the
+  watcher width fits within the terminal at multiple widths

--- a/pkg/tui/layout.go
+++ b/pkg/tui/layout.go
@@ -83,6 +83,10 @@ func computeLayout(ws tea.WindowSizeMsg, styles Styles, helpView string, watcher
 		styles.TableContainer.GetHorizontalPadding() +
 		styles.TableContainer.GetHorizontalBorderSize()
 
+	watcherHOverhead := styles.WatcherContainer.GetHorizontalMargins() +
+		styles.WatcherContainer.GetHorizontalPadding() +
+		styles.WatcherContainer.GetHorizontalBorderSize()
+
 	cellStyle := styles.Table.Cell
 	cellHOverhead := (cellStyle.GetHorizontalPadding() +
 		cellStyle.GetHorizontalMargins() +
@@ -93,7 +97,7 @@ func computeLayout(ws tea.WindowSizeMsg, styles Styles, helpView string, watcher
 	helpLines := strings.Count(helpView, "\n") + 1
 
 	tableWidth := ws.Width - mainHOverhead - containerHOverhead - cellHOverhead
-	watcherWidth := ws.Width - mainHOverhead - containerHOverhead
+	watcherWidth := ws.Width - mainHOverhead - watcherHOverhead
 
 	// Total available rows for table + watcher content
 	availableRows := ws.Height - mainVOverhead - containerVOverhead - tableFixedOverhead - helpLines

--- a/pkg/tui/layout_test.go
+++ b/pkg/tui/layout_test.go
@@ -312,6 +312,28 @@ func TestComputeLayout_WatcherReducesTableHeight(t *testing.T) {
 	})
 }
 
+func TestComputeLayout_WatcherWidthAccountsForPadding(t *testing.T) {
+	styles := defaultStyles()
+	watcherHOverhead := styles.WatcherContainer.GetHorizontalMargins() +
+		styles.WatcherContainer.GetHorizontalPadding() +
+		styles.WatcherContainer.GetHorizontalBorderSize()
+	mainHOverhead := styles.Main.GetHorizontalMargins() +
+		styles.Main.GetHorizontalPadding() +
+		styles.Main.GetHorizontalBorderSize()
+
+	widths := []int{60, 80, 120, 200}
+	for _, w := range widths {
+		ws := tea.WindowSizeMsg{Width: w, Height: 40}
+		l := computeLayout(ws, styles, shortHelp(), true)
+
+		expected := w - mainHOverhead - watcherHOverhead
+		assert.Equal(t, expected, l.WatcherWidth,
+			"width %d: watcher width must account for WatcherContainer overhead", w)
+		assert.LessOrEqual(t, l.WatcherWidth+watcherHOverhead+mainHOverhead, w,
+			"width %d: watcher + chrome must fit within terminal", w)
+	}
+}
+
 func TestRecomputeLayout_WatcherExpanded(t *testing.T) {
 	t.Run("watcher expanded reduces table height", func(t *testing.T) {
 		m := createTestModel()


### PR DESCRIPTION
## Summary
- Watcher pane (`w` toggle) was missing its right border at any terminal width
- Root cause: `watcherWidth` used `TableContainer` horizontal overhead (no padding) instead of `WatcherContainer` overhead (has `Padding(0,1)`), making the viewport 2 chars too wide
- Added separate `watcherHOverhead` computed from `WatcherContainer`'s own style

## Test plan
- [x] Added `TestComputeLayout_WatcherWidthAccountsForPadding` verifying watcher width fits within terminal at widths 60, 80, 120, 200
- [x] All existing tests pass
- [x] `gofmt`, `go vet`, `golangci-lint`, race detector all clean
- [ ] Visual verification: toggle watcher with `w`, resize terminal horizontally and vertically — right border should always be visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)