### PR TITLE
Add incident tags via ctrl+t

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Press `h` to toggle the help overlay inside srepd.
 | `ctrl+a` | Toggle auto-acknowledge | `ctrl+l` | View debug log |
 | `ctrl+q`/`ctrl+c` | Quit | `1`-`9` | Select cluster |
 | `:`/`/` | Command input | `m` | Merge incident |
-| `w` | Toggle watcher pane | | |
+| `w` | Toggle watcher pane | `ctrl+t` | Add tags to incident |
 | `ctrl+x` + key | Chord commands | `ctrl+x ?` | Show chord help |
 | `Tab`/`Shift+Tab`/`←`/`→` | Switch tabs (incident view) | `↑`/`↓` | Scroll within tab |
 

--- a/docs/plans/357-incident-tags.md
+++ b/docs/plans/357-incident-tags.md
@@ -1,0 +1,51 @@
+# 357: Add incident tags via ctrl+t
+
+## Problem
+
+Incident summaries in PagerDuty sometimes have bracket-delimited tags at the
+front (e.g., `[HCP] [RHOBS] (Warning) SomeAlert...`). SREs need to add or
+modify these tags from within SREPD to track incident state without leaving
+the TUI.
+
+## Approach
+
+Added `ctrl+t` keybinding that opens the command input with a custom prompt
+(`enter tags (comma-sep) > `). The user types comma-separated tags, presses
+Enter, and the tags are parsed, formatted as `[tag1][tag2]...`, and prepended
+to the incident title via the PagerDuty ManageIncidents API.
+
+### Tag parsing rules
+
+1. Comma is the primary delimiter — split on `,`, trim whitespace
+2. Brackets are stripped then re-added — `foo` and `[foo]` both produce `[foo]`
+3. Best-effort bracket-delimited input — `[FOO] [Bar]` splits on `] [`
+4. Spaces are NOT delimiters — `foo bar baz` becomes `[foo bar baz]`
+5. Duplicate tags (case-insensitive) already in the title are skipped
+
+### Design decisions
+
+- Pure functions for all parsing logic (`ParseTags`, `FormatTags`,
+  `PrependTags`, `ExtractExistingTags`) — fully testable without TUI state
+- Tags modify the actual PD incident title via `ManageIncidentsWithContext`
+  (not a local-only visual marker like flags)
+- `tagInputActive` boolean on the model distinguishes tag input from regular
+  `:` command input in `switchInputFocusMode`
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `pkg/tui/tags.go` | New — pure parsing functions, message types, command |
+| `pkg/tui/tags_test.go` | New — 48 tests (parsing + TUI integration) |
+| `pkg/tui/keymap.go` | Added `Tag` binding (`ctrl+t`) |
+| `pkg/tui/model.go` | Added `tagInputActive` field |
+| `pkg/tui/msgHandlers.go` | `ctrl+t` handler + tag processing in input mode |
+| `pkg/tui/tui.go` | `updatedIncidentTitleMsg` handler |
+| `pkg/pd/pd.go` | `UpdateIncidentTitle` function |
+| `pkg/pd/dev.go` | Title mutation in dev client |
+| `pkg/pd/pd_test.go` | 5 tests for `UpdateIncidentTitle` |
+
+## Testing
+
+- 48 tests covering all parsing edge cases and TUI integration
+- All pre-commit checks pass (fmt, vet, lint, test, race)

--- a/pkg/pd/dev.go
+++ b/pkg/pd/dev.go
@@ -564,6 +564,12 @@ func (d *DevPagerDutyClient) ManageIncidentsWithContext(_ context.Context, _ str
 			return nil, fmt.Errorf("DevPagerDutyClient: incident %q not found", opt.ID)
 		}
 
+		// Handle title change (tags)
+		if opt.Title != "" {
+			log.Debug("DevPagerDutyClient.ManageIncidents", "action", "title_change", "id", opt.ID, "new_title", opt.Title)
+			incident.Title = opt.Title
+		}
+
 		// Handle status change (acknowledge)
 		if opt.Status != "" {
 			log.Debug("DevPagerDutyClient.ManageIncidents", "action", "status_change", "id", opt.ID, "new_status", opt.Status)

--- a/pkg/pd/pd.go
+++ b/pkg/pd/pd.go
@@ -503,6 +503,31 @@ func ReEscalateIncidents(client PagerDutyClient, incidents []pagerduty.Incident,
 	return loopManageIncidents(client, ctx, user.Email, opts)
 }
 
+func UpdateIncidentTitle(client PagerDutyClient, incidentID string, newTitle string, currentUser *pagerduty.User) ([]pagerduty.Incident, error) {
+	if currentUser == nil {
+		return nil, fmt.Errorf("pd.UpdateIncidentTitle(): user is nil")
+	}
+	if incidentID == "" {
+		return nil, fmt.Errorf("pd.UpdateIncidentTitle(): incident ID is empty")
+	}
+	if newTitle == "" {
+		return nil, fmt.Errorf("pd.UpdateIncidentTitle(): title is empty")
+	}
+
+	ctx, cancel := contextWithTimeout()
+	defer cancel()
+
+	opts := []pagerduty.ManageIncidentsOptions{
+		{
+			ID:    incidentID,
+			Type:  "incident",
+			Title: newTitle,
+		},
+	}
+
+	return loopManageIncidents(client, ctx, currentUser.Email, opts)
+}
+
 func PostNote(client PagerDutyClient, id string, user *pagerduty.User, content string) (*pagerduty.IncidentNote, error) {
 	ctx, cancel := contextWithTimeout()
 	defer cancel()

--- a/pkg/pd/pd_test.go
+++ b/pkg/pd/pd_test.go
@@ -1370,3 +1370,68 @@ func TestGetTeamEscalationPolicies_EmptyTeams(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Empty(t, policies)
 }
+
+func TestUpdateIncidentTitle_Success(t *testing.T) {
+	mockClient := &MockPagerDutyClient{}
+	currentUser := &pagerduty.User{
+		APIObject: pagerduty.APIObject{ID: "USER1"},
+		Email:     "user@example.com",
+	}
+
+	result, err := UpdateIncidentTitle(mockClient, "INCIDENT1", "[HCP] SomeAlert", currentUser)
+
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	require.NotNil(t, mockClient.LastManageIncidentsOpts)
+	assert.Len(t, mockClient.LastManageIncidentsOpts, 1)
+	assert.Equal(t, "INCIDENT1", mockClient.LastManageIncidentsOpts[0].ID)
+	assert.Equal(t, "[HCP] SomeAlert", mockClient.LastManageIncidentsOpts[0].Title)
+}
+
+func TestUpdateIncidentTitle_Error(t *testing.T) {
+	mockClient := &MockPagerDutyClient{}
+	currentUser := &pagerduty.User{
+		APIObject: pagerduty.APIObject{ID: "USER1"},
+		Email:     "user@example.com",
+	}
+
+	result, err := UpdateIncidentTitle(mockClient, "err", "[HCP] SomeAlert", currentUser)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestUpdateIncidentTitle_NilUser(t *testing.T) {
+	mockClient := &MockPagerDutyClient{}
+
+	result, err := UpdateIncidentTitle(mockClient, "INCIDENT1", "[HCP] SomeAlert", nil)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestUpdateIncidentTitle_EmptyTitle(t *testing.T) {
+	mockClient := &MockPagerDutyClient{}
+	currentUser := &pagerduty.User{
+		APIObject: pagerduty.APIObject{ID: "USER1"},
+		Email:     "user@example.com",
+	}
+
+	result, err := UpdateIncidentTitle(mockClient, "INCIDENT1", "", currentUser)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestUpdateIncidentTitle_EmptyIncidentID(t *testing.T) {
+	mockClient := &MockPagerDutyClient{}
+	currentUser := &pagerduty.User{
+		APIObject: pagerduty.APIObject{ID: "USER1"},
+		Email:     "user@example.com",
+	}
+
+	result, err := UpdateIncidentTitle(mockClient, "", "[HCP] SomeAlert", currentUser)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}

--- a/pkg/tui/keymap.go
+++ b/pkg/tui/keymap.go
@@ -17,7 +17,7 @@ func (k keymap) FullHelp() [][]key.Binding {
 		// Column 1: Help at top, navigation
 		{k.Help, k.Up, k.Down, k.Top, k.Bottom, k.Enter, k.Back},
 		// Column 2: Primary incident actions
-		{k.Ack, k.Note, k.Login, k.Open, k.SOP, k.UnAck, k.Silence, k.Merge, k.Input},
+		{k.Ack, k.Note, k.Login, k.Open, k.SOP, k.UnAck, k.Silence, k.Merge, k.Tag, k.Input},
 		// Column 3: Settings & toggles, Quit at bottom
 		{k.Team, k.Refresh, k.AutoRefresh, k.AutoAck, k.Urgency, k.Watcher, k.ViewLog, k.Quit},
 		// Column 4: Tab navigation (incident viewer)
@@ -58,6 +58,7 @@ type keymap struct {
 	ViewLog     key.Binding
 	Merge       key.Binding
 	Watcher     key.Binding
+	Tag         key.Binding
 	TabNext     key.Binding
 	TabPrev     key.Binding
 }
@@ -191,6 +192,10 @@ var defaultKeyMap = keymap{
 	Watcher: key.NewBinding(
 		key.WithKeys("w"),
 		key.WithHelp("w", "toggle watcher"),
+	),
+	Tag: key.NewBinding(
+		key.WithKeys("ctrl+t"),
+		key.WithHelp("ctrl+t", "add tags"),
 	),
 	TabNext: key.NewBinding(
 		key.WithKeys("tab", "right"),

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -69,8 +69,9 @@ type model struct {
 	launcher             launcher.ClusterLauncher
 	rosaBoundaryLauncher launcher.ClusterLauncher
 
-	table table.Model
-	input textinput.Model
+	table          table.Model
+	input          textinput.Model
+	tagInputActive bool
 	// This is a hack since viewport.Model doesn't have a Focused() method
 	viewingIncident  bool
 	incidentViewer   viewport.Model

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -166,6 +166,18 @@ func (m model) keyMsgHandler(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	// Tag input: ctrl+t opens input with tag prompt
+	if key.Matches(msg.(tea.KeyMsg), defaultKeyMap.Tag) {
+		if m.table.SelectedRow() == nil {
+			m.setStatus("no incident highlighted")
+			return m, nil
+		}
+		m.tagInputActive = true
+		m.input.SetValue(tagInputPrompt)
+		m.input.SetCursor(len(tagInputPrompt))
+		return m, tea.Sequence(m.input.Focus())
+	}
+
 	// Commands for any focus mode
 	if key.Matches(msg.(tea.KeyMsg), defaultKeyMap.Input) {
 		keyStr := msg.(tea.KeyMsg).String()
@@ -712,11 +724,40 @@ func switchInputFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Esc exits input mode
 			m.input.Blur()
 			m.table.Focus()
-			m.input.Reset() // Clear the input text
+			m.input.Reset()
+			m.tagInputActive = false
 			return m, nil
 
 		case key.Matches(msg, defaultKeyMap.Enter):
 			prompt := m.input.Value()
+
+			if m.tagInputActive {
+				m.tagInputActive = false
+				m.input.Reset()
+				m.input.Blur()
+				m.table.Focus()
+
+				rawInput := strings.TrimPrefix(prompt, tagInputPrompt)
+				tags := ParseTags(rawInput)
+				if len(tags) == 0 {
+					m.setStatus("no tags entered")
+					return m, nil
+				}
+
+				formatted := FormatTags(tags)
+				if m.selectedIncident == nil {
+					m.setStatus("no incident selected")
+					return m, nil
+				}
+
+				newTitle := PrependTags(formatted, m.selectedIncident.Title)
+				if newTitle == m.selectedIncident.Title {
+					m.setStatus("tags already present")
+					return m, nil
+				}
+
+				return m, updateIncidentTitle(m.config, m.selectedIncident.ID, newTitle)
+			}
 
 			if prompt == "" {
 				m.input.Blur()

--- a/pkg/tui/tags.go
+++ b/pkg/tui/tags.go
@@ -1,0 +1,195 @@
+package tui
+
+import (
+	"strings"
+
+	"github.com/clcollins/srepd/pkg/pd"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+const tagInputPrompt = "enter tags (comma-sep) > "
+
+func ParseTags(input string) []string {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return []string{}
+	}
+
+	if strings.Contains(input, ",") {
+		return parseCommaSeparated(input)
+	}
+
+	if isSingleBracketedValue(input) {
+		tag := stripBrackets(input)
+		if tag == "" {
+			return []string{}
+		}
+		return []string{tag}
+	}
+
+	if isBracketDelimited(input) {
+		return parseBracketDelimited(input)
+	}
+
+	tag := strings.TrimSpace(input)
+	if tag == "" {
+		return []string{}
+	}
+	return []string{tag}
+}
+
+func FormatTags(tags []string) string {
+	if len(tags) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, tag := range tags {
+		b.WriteByte('[')
+		b.WriteString(tag)
+		b.WriteByte(']')
+	}
+	return b.String()
+}
+
+func PrependTags(formattedTags string, existingTitle string) string {
+	if formattedTags == "" {
+		return existingTitle
+	}
+
+	newTags := parseBracketDelimited(formattedTags)
+	existingTags := ExtractExistingTags(existingTitle)
+
+	existingSet := make(map[string]struct{}, len(existingTags))
+	for _, t := range existingTags {
+		existingSet[strings.ToLower(t)] = struct{}{}
+	}
+
+	var novel []string
+	for _, t := range newTags {
+		if _, dup := existingSet[strings.ToLower(t)]; !dup {
+			novel = append(novel, t)
+		}
+	}
+
+	if len(novel) == 0 {
+		return existingTitle
+	}
+
+	prefix := FormatTags(novel)
+	if existingTitle == "" {
+		return prefix
+	}
+	if existingTitle[0] == '[' {
+		return prefix + existingTitle
+	}
+	return prefix + " " + existingTitle
+}
+
+func ExtractExistingTags(title string) []string {
+	var tags []string
+	i := 0
+	for i < len(title) {
+		for i < len(title) && title[i] == ' ' {
+			i++
+		}
+		if i >= len(title) || title[i] != '[' {
+			break
+		}
+		close := strings.IndexByte(title[i+1:], ']')
+		if close < 0 {
+			break
+		}
+		tag := title[i+1 : i+1+close]
+		tags = append(tags, tag)
+		i = i + 1 + close + 1
+	}
+	if len(tags) == 0 {
+		return []string{}
+	}
+	return tags
+}
+
+func parseCommaSeparated(input string) []string {
+	parts := strings.Split(input, ",")
+	var tags []string
+	for _, p := range parts {
+		tag := stripBrackets(strings.TrimSpace(p))
+		if tag != "" {
+			tags = append(tags, tag)
+		}
+	}
+	if tags == nil {
+		return []string{}
+	}
+	return tags
+}
+
+func isSingleBracketedValue(input string) bool {
+	if len(input) < 2 || input[0] != '[' {
+		return false
+	}
+	last := strings.LastIndexByte(input, ']')
+	if last < 0 || last != len(input)-1 {
+		return false
+	}
+	inner := input[1:last]
+	return !strings.Contains(inner, "] [") && !strings.Contains(inner, "][")
+}
+
+func isBracketDelimited(input string) bool {
+	return strings.Contains(input, "[") && strings.Contains(input, "]")
+}
+
+func parseBracketDelimited(input string) []string {
+	var tags []string
+	i := 0
+	for i < len(input) {
+		open := strings.IndexByte(input[i:], '[')
+		if open < 0 {
+			break
+		}
+		open += i
+		close := strings.IndexByte(input[open+1:], ']')
+		if close < 0 {
+			break
+		}
+		tag := strings.TrimSpace(input[open+1 : open+1+close])
+		if tag != "" {
+			tags = append(tags, tag)
+		}
+		i = open + 1 + close + 1
+	}
+	if tags == nil {
+		return []string{}
+	}
+	return tags
+}
+
+func stripBrackets(s string) string {
+	for len(s) >= 2 && s[0] == '[' && s[len(s)-1] == ']' {
+		inner := strings.TrimSpace(s[1 : len(s)-1])
+		if inner == s {
+			break
+		}
+		s = inner
+	}
+	return s
+}
+
+type updatedIncidentTitleMsg struct {
+	incidentID string
+	newTitle   string
+	err        error
+}
+
+func updateIncidentTitle(config *pd.Config, incidentID string, newTitle string) tea.Cmd {
+	return func() tea.Msg {
+		_, err := pd.UpdateIncidentTitle(config.Client, incidentID, newTitle, config.CurrentUser)
+		return updatedIncidentTitleMsg{
+			incidentID: incidentID,
+			newTitle:   newTitle,
+			err:        err,
+		}
+	}
+}

--- a/pkg/tui/tags_test.go
+++ b/pkg/tui/tags_test.go
@@ -1,0 +1,454 @@
+package tui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/PagerDuty/go-pagerduty"
+	"github.com/charmbracelet/bubbles/table"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseTags(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "comma-separated bare words",
+			input:    "foo, bar, baz",
+			expected: []string{"foo", "bar", "baz"},
+		},
+		{
+			name:     "comma-separated with brackets",
+			input:    "[foo],[bar],[baz]",
+			expected: []string{"foo", "bar", "baz"},
+		},
+		{
+			name:     "single tag with colon",
+			input:    "firing:1",
+			expected: []string{"firing:1"},
+		},
+		{
+			name:     "single tag with space",
+			input:    "SL Sent",
+			expected: []string{"SL Sent"},
+		},
+		{
+			name:     "bracket-delimited no commas",
+			input:    "[FOO] [Bar] [baz]",
+			expected: []string{"FOO", "Bar", "baz"},
+		},
+		{
+			name:     "bare words no commas no brackets",
+			input:    "foo bar baz",
+			expected: []string{"foo bar baz"},
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: []string{},
+		},
+		{
+			name:     "all-empty tokens from commas",
+			input:    "  ,  , ",
+			expected: []string{},
+		},
+		{
+			name:     "single bracketed tag",
+			input:    "[already-bracketed]",
+			expected: []string{"already-bracketed"},
+		},
+		{
+			name:     "mixed bracketed and bare with commas",
+			input:    "[HCP], RHOBS, [SL Sent]",
+			expected: []string{"HCP", "RHOBS", "SL Sent"},
+		},
+		{
+			name:     "whitespace only",
+			input:    "   ",
+			expected: []string{},
+		},
+		{
+			name:     "single comma",
+			input:    ",",
+			expected: []string{},
+		},
+		{
+			name:     "brackets with extra whitespace",
+			input:    "  [  HCP  ]  ,  [  RHOBS  ]  ",
+			expected: []string{"HCP", "RHOBS"},
+		},
+		{
+			name:     "bracket-delimited with leading bracket",
+			input:    "[FIRING:1] [HCP]",
+			expected: []string{"FIRING:1", "HCP"},
+		},
+		{
+			name:     "single bracket pair with spaces inside",
+			input:    "[SL Sent]",
+			expected: []string{"SL Sent"},
+		},
+		{
+			name:     "nested brackets stripped to content",
+			input:    "[[nested]]",
+			expected: []string{"nested"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseTags(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFormatTags(t *testing.T) {
+	tests := []struct {
+		name     string
+		tags     []string
+		expected string
+	}{
+		{
+			name:     "multiple tags",
+			tags:     []string{"foo", "bar"},
+			expected: "[foo][bar]",
+		},
+		{
+			name:     "empty slice",
+			tags:     []string{},
+			expected: "",
+		},
+		{
+			name:     "nil slice",
+			tags:     nil,
+			expected: "",
+		},
+		{
+			name:     "single tag",
+			tags:     []string{"single"},
+			expected: "[single]",
+		},
+		{
+			name:     "tag with spaces",
+			tags:     []string{"SL Sent"},
+			expected: "[SL Sent]",
+		},
+		{
+			name:     "tag with colon",
+			tags:     []string{"firing:1"},
+			expected: "[firing:1]",
+		},
+		{
+			name:     "three tags",
+			tags:     []string{"HCP", "RHOBS", "SL Sent"},
+			expected: "[HCP][RHOBS][SL Sent]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FormatTags(tt.tags)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestPrependTags(t *testing.T) {
+	tests := []struct {
+		name     string
+		tags     string
+		title    string
+		expected string
+	}{
+		{
+			name:     "prepend to bare title",
+			tags:     "[HCP][RHOBS]",
+			title:    "ClusterOperatorDown CRITICAL (1)",
+			expected: "[HCP][RHOBS] ClusterOperatorDown CRITICAL (1)",
+		},
+		{
+			name:     "prepend to title with existing tags",
+			tags:     "[SL Sent]",
+			title:    "[HCP] ClusterOperatorDown CRITICAL (1)",
+			expected: "[SL Sent][HCP] ClusterOperatorDown CRITICAL (1)",
+		},
+		{
+			name:     "empty tags returns original title",
+			tags:     "",
+			title:    "ClusterOperatorDown CRITICAL (1)",
+			expected: "ClusterOperatorDown CRITICAL (1)",
+		},
+		{
+			name:     "duplicate tag not added",
+			tags:     "[HCP]",
+			title:    "[HCP] ClusterOperatorDown CRITICAL (1)",
+			expected: "[HCP] ClusterOperatorDown CRITICAL (1)",
+		},
+		{
+			name:     "duplicate among multiple — only new ones added",
+			tags:     "[HCP][RHOBS][SL Sent]",
+			title:    "[HCP][RHOBS] ClusterOperatorDown CRITICAL (1)",
+			expected: "[SL Sent][HCP][RHOBS] ClusterOperatorDown CRITICAL (1)",
+		},
+		{
+			name:     "case-insensitive duplicate detection",
+			tags:     "[hcp]",
+			title:    "[HCP] ClusterOperatorDown CRITICAL (1)",
+			expected: "[HCP] ClusterOperatorDown CRITICAL (1)",
+		},
+		{
+			name:     "empty title with tags",
+			tags:     "[HCP]",
+			title:    "",
+			expected: "[HCP]",
+		},
+		{
+			name:     "all tags are duplicates",
+			tags:     "[HCP][RHOBS]",
+			title:    "[HCP][RHOBS] SomeAlert",
+			expected: "[HCP][RHOBS] SomeAlert",
+		},
+		{
+			name:     "tags with spaces between existing brackets",
+			tags:     "[SL Sent]",
+			title:    "[HCP] [RHOBS] SomeAlert",
+			expected: "[SL Sent][HCP] [RHOBS] SomeAlert",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := PrependTags(tt.tags, tt.title)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExtractExistingTags(t *testing.T) {
+	tests := []struct {
+		name     string
+		title    string
+		expected []string
+	}{
+		{
+			name:     "no tags",
+			title:    "ClusterOperatorDown CRITICAL (1)",
+			expected: []string{},
+		},
+		{
+			name:     "single tag",
+			title:    "[HCP] ClusterOperatorDown",
+			expected: []string{"HCP"},
+		},
+		{
+			name:     "multiple tags no spaces",
+			title:    "[HCP][RHOBS] ClusterOperatorDown",
+			expected: []string{"HCP", "RHOBS"},
+		},
+		{
+			name:     "multiple tags with spaces",
+			title:    "[HCP] [RHOBS] ClusterOperatorDown",
+			expected: []string{"HCP", "RHOBS"},
+		},
+		{
+			name:     "tag with spaces inside",
+			title:    "[SL Sent] ClusterOperatorDown",
+			expected: []string{"SL Sent"},
+		},
+		{
+			name:     "mixed tags",
+			title:    "[SL Sent][OHSS-54318] CannotRetrieveUpdatesSRE",
+			expected: []string{"SL Sent", "OHSS-54318"},
+		},
+		{
+			name:     "FIRING tag",
+			title:    "[FIRING:1] ClusterProvisioningDelay",
+			expected: []string{"FIRING:1"},
+		},
+		{
+			name:     "empty string",
+			title:    "",
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ExtractExistingTags(tt.title)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// tagKeyMsg returns a tea.KeyMsg for ctrl+t.
+func tagKeyMsg() tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyCtrlT}
+}
+
+func createTestModelWithIncidentRows(incidents []pagerduty.Incident) model {
+	m := createTestModel()
+	m.input = newTextInput()
+	m.incidentList = incidents
+
+	cols := []table.Column{
+		{Title: "Status", Width: 2},
+		{Title: "ID", Width: 10},
+		{Title: "Summary", Width: 30},
+		{Title: "Service", Width: 20},
+	}
+
+	var rows []table.Row
+	for _, inc := range incidents {
+		rows = append(rows, table.Row{".", inc.ID, inc.Title, inc.Service.Summary})
+	}
+
+	m.table = table.New(
+		table.WithColumns(cols),
+		table.WithRows(rows),
+		table.WithFocused(true),
+	)
+
+	return m
+}
+
+func TestTagKey_OpensInputWithPrompt(t *testing.T) {
+	incidents := []pagerduty.Incident{
+		{
+			APIObject:          pagerduty.APIObject{ID: "Q111"},
+			Title:              "ClusterOperatorDown CRITICAL (1)",
+			Service:            pagerduty.APIObject{ID: "SVC1", Summary: "test-service"},
+			LastStatusChangeAt: time.Now().Format(time.RFC3339),
+		},
+	}
+	m := createTestModelWithIncidentRows(incidents)
+
+	result, _ := m.Update(tagKeyMsg())
+	updatedModel := result.(model)
+
+	assert.True(t, updatedModel.input.Focused(), "input should be focused after ctrl+t")
+	assert.True(t, updatedModel.tagInputActive, "tagInputActive should be set")
+	assert.Equal(t, tagInputPrompt, updatedModel.input.Value(),
+		"input should be pre-populated with tag prompt")
+}
+
+func TestTagKey_NoIncidentHighlighted(t *testing.T) {
+	m := createTestModel()
+	m.table.Focus()
+
+	result, _ := m.Update(tagKeyMsg())
+	updatedModel := result.(model)
+
+	assert.False(t, updatedModel.input.Focused(), "input should not be focused")
+	assert.False(t, updatedModel.tagInputActive, "tagInputActive should not be set")
+	assert.Contains(t, updatedModel.status, "no incident highlighted")
+}
+
+func TestTagInput_EnterProcessesTags(t *testing.T) {
+	incidents := []pagerduty.Incident{
+		{
+			APIObject:          pagerduty.APIObject{ID: "Q111"},
+			Title:              "ClusterOperatorDown CRITICAL (1)",
+			Service:            pagerduty.APIObject{ID: "SVC1", Summary: "test-service"},
+			LastStatusChangeAt: time.Now().Format(time.RFC3339),
+		},
+	}
+	m := createTestModelWithIncidentRows(incidents)
+	m.selectedIncident = &incidents[0]
+	m.tagInputActive = true
+	m.input.Focus()
+	m.input.SetValue(tagInputPrompt + "HCP, RHOBS")
+
+	result, cmd := m.Update(enterKeyMsg())
+	updatedModel := result.(model)
+
+	assert.False(t, updatedModel.input.Focused(), "input should be blurred after Enter")
+	assert.False(t, updatedModel.tagInputActive, "tagInputActive should be cleared")
+	assert.NotNil(t, cmd, "should return a command to update the title")
+}
+
+func TestTagInput_EmptyTagsAfterPrompt(t *testing.T) {
+	incidents := []pagerduty.Incident{
+		{
+			APIObject:          pagerduty.APIObject{ID: "Q111"},
+			Title:              "ClusterOperatorDown CRITICAL (1)",
+			Service:            pagerduty.APIObject{ID: "SVC1", Summary: "test-service"},
+			LastStatusChangeAt: time.Now().Format(time.RFC3339),
+		},
+	}
+	m := createTestModelWithIncidentRows(incidents)
+	m.selectedIncident = &incidents[0]
+	m.tagInputActive = true
+	m.input.Focus()
+	m.input.SetValue(tagInputPrompt)
+
+	result, cmd := m.Update(enterKeyMsg())
+	updatedModel := result.(model)
+
+	assert.False(t, updatedModel.input.Focused(), "input should be blurred")
+	assert.False(t, updatedModel.tagInputActive, "tagInputActive should be cleared")
+	assert.Nil(t, cmd, "no command when tags are empty")
+	assert.Contains(t, updatedModel.status, "no tags")
+}
+
+func TestTagInput_EscapeCancels(t *testing.T) {
+	m := createTestModel()
+	m.input = newTextInput()
+	m.tagInputActive = true
+	m.input.Focus()
+	m.input.SetValue(tagInputPrompt + "HCP")
+
+	escMsg := tea.KeyMsg{Type: tea.KeyEscape}
+	result, _ := m.Update(escMsg)
+	updatedModel := result.(model)
+
+	assert.False(t, updatedModel.input.Focused(), "input should be blurred after Esc")
+	assert.False(t, updatedModel.tagInputActive, "tagInputActive should be cleared on Esc")
+}
+
+func TestUpdatedIncidentTitleMsg_UpdatesIncidentList(t *testing.T) {
+	incidents := []pagerduty.Incident{
+		{
+			APIObject:          pagerduty.APIObject{ID: "Q111"},
+			Title:              "ClusterOperatorDown CRITICAL (1)",
+			Service:            pagerduty.APIObject{ID: "SVC1", Summary: "test-service"},
+			LastStatusChangeAt: time.Now().Format(time.RFC3339),
+		},
+		{
+			APIObject:          pagerduty.APIObject{ID: "Q222"},
+			Title:              "SomeOtherAlert",
+			Service:            pagerduty.APIObject{ID: "SVC2", Summary: "test-service-2"},
+			LastStatusChangeAt: time.Now().Format(time.RFC3339),
+		},
+	}
+	m := createTestModelWithIncidentRows(incidents)
+
+	msg := updatedIncidentTitleMsg{
+		incidentID: "Q111",
+		newTitle:   "[HCP] ClusterOperatorDown CRITICAL (1)",
+	}
+
+	result, _ := m.Update(msg)
+	updatedModel := result.(model)
+
+	assert.Equal(t, "[HCP] ClusterOperatorDown CRITICAL (1)", updatedModel.incidentList[0].Title)
+	assert.Equal(t, "SomeOtherAlert", updatedModel.incidentList[1].Title)
+}
+
+func TestUpdatedIncidentTitleMsg_Error(t *testing.T) {
+	m := createTestModel()
+
+	msg := updatedIncidentTitleMsg{
+		incidentID: "Q111",
+		newTitle:   "[HCP] SomeAlert",
+		err:        assert.AnError,
+	}
+
+	result, _ := m.Update(msg)
+	updatedModel := result.(model)
+
+	assert.Contains(t, updatedModel.status, "tag update failed")
+}

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -492,6 +492,28 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, tea.Batch(enrichCmds...)
 
+	case updatedIncidentTitleMsg:
+		if msg.err != nil {
+			m.setStatus("tag update failed: " + msg.err.Error())
+			return m, nil
+		}
+		for i, inc := range m.incidentList {
+			if inc.ID == msg.incidentID {
+				m.incidentList[i].Title = msg.newTitle
+				if cached, ok := m.incidentCache[msg.incidentID]; ok && cached.incident != nil {
+					cached.incident.Title = msg.newTitle
+				}
+				if m.selectedIncident != nil && m.selectedIncident.ID == msg.incidentID {
+					m.selectedIncident.Title = msg.newTitle
+				}
+				break
+			}
+		}
+		return m, tea.Batch(
+			m.flashNotification("tags updated"),
+			func() tea.Msg { return updatedIncidentListMsg{m.incidentList, nil} },
+		)
+
 	case spinner.TickMsg:
 		var cmd tea.Cmd
 		m.spinner, cmd = m.spinner.Update(msg)


### PR DESCRIPTION
## Summary

- Add `ctrl+t` keybinding to open a tag input prompt for the selected incident
- Parse comma-separated tags, format as `[tag1][tag2]...`, and prepend to the incident title via PagerDuty API
- Supports bracketed input (`[HCP], [RHOBS]`), best-effort bracket-delimited splitting (`[FOO] [Bar]`), and case-insensitive duplicate detection
- Pure functions for all parsing logic, fully testable without TUI state

## Test plan

- [ ] 48 new tests covering all parsing edge cases and TUI integration
- [ ] All pre-commit checks pass (fmt, vet, lint, test, race)
- [ ] Manual test in dev mode: press `ctrl+t`, type tags, verify title updates in table
- [ ] Verify Esc cancels tag input, empty input shows "no tags" status
- [ ] Verify duplicate tags are not re-added

🤖 Generated with [Claude Code](https://claude.com/claude-code)