### PR TITLE
Add ctrl+h docs viewer with auto-generated quickstart

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -44,6 +44,20 @@ jobs:
       - name: Check README update
         run: make readme-check
 
+  quickstart-check:
+    name: Quickstart Update Check
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && !contains(github.event.pull_request.labels.*.name, 'skip-quickstart')
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check quickstart update
+        run: make quickstart-check
+
   fmt:
     name: Format Check
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,50 @@ readme-check: ## Ensure README is updated when config/keys/flags change
 		echo "No config/key/flag changes detected - README check skipped"; \
 	fi
 
+.PHONY: generate-quickstart
+generate-quickstart: ## Regenerate docs/quickstart.md from keybindings
+	@echo "Generating docs/quickstart.md..."
+	go run ./cmd/gen-quickstart > docs/quickstart.md
+	@echo "docs/quickstart.md generated."
+
+.PHONY: quickstart-check
+quickstart-check: ## Ensure quickstart.md is updated when keybindings change
+	@echo "Checking if quickstart.md update is needed..."
+	@MERGE_BASE=$$(git merge-base HEAD origin/main 2>/dev/null || echo ""); \
+	if [ -z "$$MERGE_BASE" ]; then exit 0; fi; \
+	CHANGED=$$(git diff --name-only "$$MERGE_BASE"...HEAD); \
+	NEEDS_QS=false; \
+	for f in $$CHANGED; do \
+		case "$$f" in \
+			pkg/tui/keymap.go|pkg/tui/chords.go|pkg/tui/flag_commands.go|pkg/tui/quickstart_data.go) NEEDS_QS=true ;; \
+		esac; \
+	done; \
+	if [ "$$NEEDS_QS" = "true" ]; then \
+		if ! echo "$$CHANGED" | grep -q "docs/quickstart.md"; then \
+			echo "ERROR: Changes to keymap.go, chords.go, flag_commands.go, or quickstart_data.go require docs/quickstart.md update"; \
+			echo "Run: make generate-quickstart"; \
+			exit 1; \
+		fi; \
+		echo "docs/quickstart.md update found - OK"; \
+	else \
+		echo "No keybinding changes detected - quickstart check skipped"; \
+	fi
+
+.PHONY: quickstart-verify
+quickstart-verify: ## Verify docs/quickstart.md matches generated output
+	@echo "Verifying docs/quickstart.md is up to date..."
+	@TMPFILE=$$(mktemp); \
+	go run ./cmd/gen-quickstart > "$$TMPFILE"; \
+	if ! diff -q docs/quickstart.md "$$TMPFILE" > /dev/null 2>&1; then \
+		echo "ERROR: docs/quickstart.md is stale"; \
+		echo "Run: make generate-quickstart"; \
+		diff docs/quickstart.md "$$TMPFILE" || true; \
+		rm -f "$$TMPFILE"; \
+		exit 1; \
+	fi; \
+	rm -f "$$TMPFILE"; \
+	echo "docs/quickstart.md is up to date."
+
 .PHONY: test-race
 test-race: ## Run tests with race detector
 	@echo "Running tests with race detector..."
@@ -219,7 +263,7 @@ test-fixtures: ## Check that fixture data contains no real UUIDs, domains, or or
 	echo "All fixture data is properly sanitized."
 
 .PHONY: test-all
-test-all: fmt-check vet lint test test-race test-fixtures ## Run all checks
+test-all: fmt-check vet lint test test-race test-fixtures quickstart-verify ## Run all checks
 	@echo "All checks passed."
 
 .PHONY: ensure-goreleaser

--- a/cmd/gen-quickstart/main.go
+++ b/cmd/gen-quickstart/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/clcollins/srepd/pkg/tui"
+)
+
+func main() {
+	keys := tui.KeyBindingEntries()
+	chords := tui.ChordEntries()
+	inputs := tui.InputCommandEntries()
+
+	md := tui.GenerateQuickstartMarkdown(keys, chords, inputs)
+
+	if _, err := fmt.Fprint(os.Stdout, md); err != nil {
+		os.Exit(1)
+	}
+}

--- a/docs/plans/357-ctrl-h-docs-view.md
+++ b/docs/plans/357-ctrl-h-docs-view.md
@@ -1,0 +1,44 @@
+# 357: Ctrl+H Docs View with Auto-Generated Quickstart
+
+## Problem
+
+SREPD has no in-app documentation. Users must leave the TUI to read
+the README or docs. There's also no quick reference for keybindings,
+chord commands, or input commands.
+
+## Approach
+
+Add a docs viewer mode triggered by `ctrl+h` that embeds `README.md`
+and all `docs/*.md` files at build time using `go:embed`. The first
+tab is an auto-generated `quickstart.md` containing tables of all
+keybindings, chord commands, and input commands. README is the second
+tab, remaining docs sorted alphabetically by H1 title.
+
+### Key decisions
+
+- **go:embed at root level**: The embed directive lives in `main.go`
+  since `go:embed` can only reference files in or below the package
+  directory. Content is injected into `pkg/docs` via
+  `SetEmbeddedContent()` before the TUI starts.
+- **Auto-generated quickstart**: A standalone generator at
+  `cmd/gen-quickstart/main.go` reads keybinding data from exported
+  functions in `pkg/tui/quickstart_data.go` and writes markdown.
+- **CI enforcement**: `quickstart-check` (triggers when keybinding
+  files change) and `quickstart-verify` (diffs generated output
+  against committed file) catch staleness. `quickstart-verify` is
+  part of `test-all`.
+- **Tab paging**: Tabs are paged in groups of 8. When all tabs fit on
+  one page, no indicator is shown. Paging indicator renders inside
+  the gap border when needed.
+- **Toggle behavior**: `ctrl+h` toggles the docs view — pressing it
+  again returns to the previous view, same as `esc`.
+
+## Testing
+
+All new code is TDD with pure functions and full mocking:
+
+- `pkg/docs/docs_test.go` — ExtractTitle, TruncateTitle, BuildDocList
+  using `fstest.MapFS`
+- `pkg/tui/quickstart_data_test.go` — KeyBindingEntries, ChordEntries,
+  InputCommandEntries, GenerateQuickstartMarkdown
+- `pkg/tui/docs_test.go` — paging, tab labels, navigation, clearing

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,55 @@
+# Quickstart
+
+## Key Bindings
+
+| Key | Action |
+|-----|--------|
+| h | help |
+| ↑/k | up |
+| ↓/j | down |
+| g | jump to top |
+| G | jump to bottom |
+| enter | view |
+| esc | back |
+| ctrl+q/ctrl+c | quit |
+| t | toggle team/individual |
+| r | refresh |
+| ctrl+r | toggle auto-refresh |
+| n | add note |
+| ctrl+s | silence |
+| a | acknowledge |
+| ctrl+e | re-escalate |
+| ctrl+a | toggle auto-acknowledge |
+| u | toggle urgency filter |
+| :/ | command input |
+| l | login to cluster |
+| o | open in browser |
+| s | open SOP |
+| ctrl+l | view debug log |
+| m | merge incident |
+| w | toggle watcher |
+| tab/→ | next tab |
+| shift+tab/← | prev tab |
+| ctrl+h | docs |
+
+## Chord Commands (ctrl+x + key)
+
+| Key | Action |
+|-----|--------|
+| ? | show chord help |
+| b | rosa-boundary login |
+| d | view debug log |
+
+## Input Commands
+
+| Command | Action |
+|---------|--------|
+| :agent <query> | ask Claude AI |
+| :watcher <query> | query AI watcher |
+| :flag cluster <id> | flag incidents by cluster ID |
+| :flag org <pattern> | flag incidents by org name |
+| :unflag <id> | remove a flag condition by ID |
+| :unflag all | clear all flag conditions |
+| :flags | list all flag conditions |
+| :flags save [path] | save flags to file |
+| :flags load [path] | load flags from file |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -28,6 +28,7 @@
 | ctrl+l | view debug log |
 | m | merge incident |
 | w | toggle watcher |
+| ctrl+t | add tags |
 | tab/→ | next tab |
 | shift+tab/← | prev tab |
 | ctrl+h | docs |

--- a/main.go
+++ b/main.go
@@ -22,9 +22,22 @@ THE SOFTWARE.
 package main
 
 import (
+	"embed"
+
 	"github.com/clcollins/srepd/cmd"
+	"github.com/clcollins/srepd/pkg/docs"
 )
 
+//go:embed README.md
+var readmeContent string
+
+//go:embed docs/quickstart.md
+var quickstartContent string
+
+//go:embed docs/*.md
+var docsFS embed.FS
+
 func main() {
+	docs.SetEmbeddedContent(readmeContent, quickstartContent, docsFS)
 	cmd.Execute()
 }

--- a/pkg/docs/docs.go
+++ b/pkg/docs/docs.go
@@ -1,0 +1,116 @@
+package docs
+
+import (
+	"embed"
+	"io/fs"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+var embeddedReadme string
+var embeddedQuickstart string
+var embeddedDocsFS embed.FS
+var embeddedDocsFSSet bool
+
+func SetEmbeddedContent(readme, quickstart string, docsFS embed.FS) {
+	embeddedReadme = readme
+	embeddedQuickstart = quickstart
+	embeddedDocsFS = docsFS
+	embeddedDocsFSSet = true
+}
+
+func EmbeddedDocs() []Doc {
+	if !embeddedDocsFSSet {
+		return []Doc{
+			{Title: "Quickstart", Content: "# Quickstart\n\nNo embedded docs available."},
+			{Title: "SREPD", Content: "# SREPD\n\nNo embedded docs available."},
+		}
+	}
+	subFS, err := fs.Sub(embeddedDocsFS, "docs")
+	if err != nil {
+		return []Doc{
+			{Title: "Quickstart", Content: embeddedQuickstart},
+			{Title: "SREPD", Content: embeddedReadme},
+		}
+	}
+	result, _ := BuildDocList(embeddedQuickstart, embeddedReadme, subFS)
+	return result
+}
+
+type Doc struct {
+	Title   string
+	Content string
+}
+
+func ExtractTitle(content string) string {
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "# ") {
+			return strings.TrimSpace(strings.TrimPrefix(trimmed, "#"))
+		}
+	}
+	return ""
+}
+
+func TruncateTitle(title string, maxLen int) string {
+	if title == "" {
+		return ""
+	}
+	runes := []rune(title)
+	if len(runes) <= maxLen {
+		return title
+	}
+	return string(runes[:maxLen]) + "..."
+}
+
+func BuildDocList(quickstartContent, readmeContent string, docsFS fs.FS) ([]Doc, error) {
+	var docs []Doc
+
+	quickstartTitle := ExtractTitle(quickstartContent)
+	if quickstartTitle == "" {
+		quickstartTitle = "Quickstart"
+	}
+	docs = append(docs, Doc{Title: quickstartTitle, Content: quickstartContent})
+
+	readmeTitle := ExtractTitle(readmeContent)
+	if readmeTitle == "" {
+		readmeTitle = "README"
+	}
+	docs = append(docs, Doc{Title: readmeTitle, Content: readmeContent})
+
+	entries, err := fs.ReadDir(docsFS, ".")
+	if err != nil {
+		return docs, nil
+	}
+
+	var remaining []Doc
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if filepath.Ext(entry.Name()) != ".md" {
+			continue
+		}
+		if entry.Name() == "quickstart.md" {
+			continue
+		}
+		data, err := fs.ReadFile(docsFS, entry.Name())
+		if err != nil {
+			continue
+		}
+		content := string(data)
+		title := ExtractTitle(content)
+		if title == "" {
+			title = entry.Name()
+		}
+		remaining = append(remaining, Doc{Title: title, Content: content})
+	}
+
+	slices.SortFunc(remaining, func(a, b Doc) int {
+		return strings.Compare(strings.ToLower(a.Title), strings.ToLower(b.Title))
+	})
+
+	docs = append(docs, remaining...)
+	return docs, nil
+}

--- a/pkg/docs/docs_test.go
+++ b/pkg/docs/docs_test.go
@@ -1,0 +1,164 @@
+package docs
+
+import (
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractTitle(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected string
+	}{
+		{
+			name:     "standard title",
+			content:  "# My Document\n\nSome content.",
+			expected: "My Document",
+		},
+		{
+			name:     "title with leading whitespace",
+			content:  "#   Spaced Title  \n\nContent.",
+			expected: "Spaced Title",
+		},
+		{
+			name:     "no title",
+			content:  "Just some text without a heading.",
+			expected: "",
+		},
+		{
+			name:     "multiple titles uses first",
+			content:  "# First Title\n\n# Second Title\n",
+			expected: "First Title",
+		},
+		{
+			name:     "h2 not matched",
+			content:  "## Not A Title\n\n# Real Title\n",
+			expected: "Real Title",
+		},
+		{
+			name:     "empty content",
+			content:  "",
+			expected: "",
+		},
+		{
+			name:     "title is only line",
+			content:  "# Solo",
+			expected: "Solo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, ExtractTitle(tt.content))
+		})
+	}
+}
+
+func TestTruncateTitle(t *testing.T) {
+	tests := []struct {
+		name     string
+		title    string
+		maxLen   int
+		expected string
+	}{
+		{
+			name:     "short title no truncation",
+			title:    "Hi",
+			maxLen:   8,
+			expected: "Hi",
+		},
+		{
+			name:     "exactly max length",
+			title:    "12345678",
+			maxLen:   8,
+			expected: "12345678",
+		},
+		{
+			name:     "longer than max",
+			title:    "Configuration Reference",
+			maxLen:   8,
+			expected: "Configur...",
+		},
+		{
+			name:     "empty title",
+			title:    "",
+			maxLen:   8,
+			expected: "",
+		},
+		{
+			name:     "one over max",
+			title:    "123456789",
+			maxLen:   8,
+			expected: "12345678...",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, TruncateTitle(tt.title, tt.maxLen))
+		})
+	}
+}
+
+func TestBuildDocList(t *testing.T) {
+	docsFS := fstest.MapFS{
+		"colors.md":         {Data: []byte("# Color Palettes\n\nColors info.")},
+		"ai-agents.md":      {Data: []byte("# AI Agents\n\nAgent info.")},
+		"configuration.md":  {Data: []byte("# Configuration Reference\n\nConfig info.")},
+		"quickstart.md":     {Data: []byte("# Quickstart\n\nDuplicate that should be excluded.")},
+		"subdir/ignored.md": {Data: []byte("# Ignored\n\nShould not appear.")},
+		"not-markdown.txt":  {Data: []byte("Not markdown")},
+	}
+	readme := "# SREPD\n\nA PagerDuty TUI."
+	quickstart := "# Quickstart\n\nKey bindings."
+
+	docs, err := BuildDocList(quickstart, readme, docsFS)
+	assert.NoError(t, err)
+
+	assert.GreaterOrEqual(t, len(docs), 5, "should include quickstart + readme + 3 docs files")
+
+	assert.Equal(t, "Quickstart", docs[0].Title, "first doc should be Quickstart")
+	assert.Contains(t, docs[0].Content, "Key bindings")
+
+	assert.Equal(t, "SREPD", docs[1].Title, "second doc should be README")
+	assert.Contains(t, docs[1].Content, "PagerDuty TUI")
+
+	remainingTitles := make([]string, 0)
+	for _, d := range docs[2:] {
+		remainingTitles = append(remainingTitles, d.Title)
+	}
+	assert.Equal(t, []string{"AI Agents", "Color Palettes", "Configuration Reference"}, remainingTitles,
+		"remaining docs should be sorted alphabetically by title")
+
+	for _, d := range docs {
+		assert.NotEqual(t, "Ignored", d.Title, "should not include files from subdirectories")
+	}
+}
+
+func TestBuildDocListEmptyFS(t *testing.T) {
+	docsFS := fstest.MapFS{}
+	readme := "# SREPD\n\nReadme content."
+	quickstart := "# Quickstart\n\nQuickstart content."
+
+	docs, err := BuildDocList(quickstart, readme, docsFS)
+	assert.NoError(t, err)
+	assert.Len(t, docs, 2, "should have quickstart and readme only")
+	assert.Equal(t, "Quickstart", docs[0].Title)
+	assert.Equal(t, "SREPD", docs[1].Title)
+}
+
+func TestBuildDocListNoTitle(t *testing.T) {
+	docsFS := fstest.MapFS{
+		"untitled.md": {Data: []byte("No heading here, just content.")},
+	}
+	readme := "# SREPD\n\nReadme."
+	quickstart := "# Quickstart\n\nQuickstart."
+
+	docs, err := BuildDocList(quickstart, readme, docsFS)
+	assert.NoError(t, err)
+	assert.Len(t, docs, 3)
+	assert.Equal(t, "untitled.md", docs[2].Title, "untitled docs should use filename as title")
+}

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -396,6 +396,26 @@ type renderedIncidentMsg struct {
 	err     error
 }
 
+type renderDocsMsg string
+
+type renderedDocsMsg struct {
+	content string
+	err     error
+}
+
+func renderDocsContent(m *model) tea.Cmd {
+	return func() tea.Msg {
+		content := m.renderDocsTabContent()
+
+		rendered, err := renderIncidentMarkdown(m, content)
+		if err != nil {
+			return renderedDocsMsg{content, err}
+		}
+
+		return renderedDocsMsg{rendered, nil}
+	}
+}
+
 func renderIncident(m *model) tea.Cmd {
 	return func() tea.Msg {
 		t, err := m.renderTabContent()

--- a/pkg/tui/docs.go
+++ b/pkg/tui/docs.go
@@ -1,0 +1,178 @@
+package tui
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/clcollins/srepd/pkg/docs"
+)
+
+const defaultDocsTabsPerPage = 8
+
+func newDocsViewer() viewport.Model {
+	return viewport.New(100, 100)
+}
+
+func docsTabPage(activeTab, tabsPerPage int) int {
+	return activeTab / tabsPerPage
+}
+
+func docsPageStartEnd(activeTab, tabsPerPage, totalTabs int) (int, int) {
+	page := docsTabPage(activeTab, tabsPerPage)
+	start := page * tabsPerPage
+	end := start + tabsPerPage
+	if end > totalTabs {
+		end = totalTabs
+	}
+	return start, end
+}
+
+func docsTabLabel(title string) string {
+	return docs.TruncateTitle(title, 8)
+}
+
+func docsNextTab(current, total int) int {
+	if total <= 1 {
+		return 0
+	}
+	return (current + 1) % total
+}
+
+func docsPrevTab(current, total int) int {
+	if total <= 1 {
+		return 0
+	}
+	return (current + total - 1) % total
+}
+
+func docsPagingIndicator(activeTab, tabsPerPage, total int) string {
+	totalPages := (total + tabsPerPage - 1) / tabsPerPage
+	if totalPages <= 1 {
+		return ""
+	}
+	currentPage := docsTabPage(activeTab, tabsPerPage) + 1
+	return fmt.Sprintf(" [%d/%d]", currentPage, totalPages)
+}
+
+func buildDocsPageLabels(pages []docs.Doc, activeTab, tabsPerPage int) []string {
+	start, end := docsPageStartEnd(activeTab, tabsPerPage, len(pages))
+	labels := make([]string, 0, end-start)
+	for i := start; i < end; i++ {
+		labels = append(labels, docsTabLabel(pages[i].Title))
+	}
+	return labels
+}
+
+func (m *model) clearDocsView() {
+	m.viewingDocs = false
+	m.docsActiveTab = 0
+}
+
+func (m model) renderDocsTabBar() string {
+	if len(m.docsPages) == 0 {
+		return ""
+	}
+
+	labels := buildDocsPageLabels(m.docsPages, m.docsActiveTab, m.docsTabsPerPage)
+	start, _ := docsPageStartEnd(m.docsActiveTab, m.docsTabsPerPage, len(m.docsPages))
+
+	var renderedTabs []string
+	for i, label := range labels {
+		globalIdx := start + i
+		var style lipgloss.Style
+		isFirst := i == 0
+		isActive := globalIdx == m.docsActiveTab
+		if isActive {
+			style = m.styles.ActiveTab
+		} else {
+			style = m.styles.InactiveTab
+		}
+		border, _, _, _, _ := style.GetBorder()
+		if isFirst && isActive {
+			border.BottomLeft = "│"
+		} else if isFirst && !isActive {
+			border.BottomLeft = "├"
+		}
+		style = style.Border(border)
+		renderedTabs = append(renderedTabs, style.Render(label))
+	}
+
+	tabRow := lipgloss.JoinHorizontal(lipgloss.Top, renderedTabs...)
+	tabWidth := lipgloss.Width(tabRow)
+	indicator := docsPagingIndicator(m.docsActiveTab, m.docsTabsPerPage, len(m.docsPages))
+	remainingWidth := windowSize.Width - tabWidth - 1
+	if remainingWidth > 0 {
+		gapContent := indicator
+		if gapContent == "" {
+			gapContent = " "
+		}
+		gapBorder := lipgloss.Border{Bottom: "─", Right: " ", BottomRight: "┐"}
+		gap := lipgloss.NewStyle().
+			BorderForeground(m.theme.Border).
+			Border(gapBorder, false, true, true, false).
+			Width(remainingWidth).
+			Render(gapContent)
+		tabRow = lipgloss.JoinHorizontal(lipgloss.Bottom, tabRow, gap)
+	}
+
+	return tabRow
+}
+
+func (m model) renderDocsTabContent() string {
+	if len(m.docsPages) == 0 {
+		return ""
+	}
+	if m.docsActiveTab >= len(m.docsPages) {
+		return ""
+	}
+	return m.docsPages[m.docsActiveTab].Content
+}
+
+func switchDocsFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	var cmds []tea.Cmd
+
+	handledKey := false
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch {
+		case key.Matches(msg, defaultKeyMap.Help):
+			m.toggleHelp()
+			handledKey = true
+
+		case key.Matches(msg, defaultKeyMap.Back), key.Matches(msg, defaultKeyMap.ViewDocs):
+			m.clearDocsView()
+			m.table.Focus()
+			return m, nil
+
+		case key.Matches(msg, defaultKeyMap.Up):
+			m.docsViewer, _ = m.docsViewer.Update(msg)
+			return m, nil
+
+		case key.Matches(msg, defaultKeyMap.Down):
+			m.docsViewer, _ = m.docsViewer.Update(msg)
+			return m, nil
+
+		case key.Matches(msg, defaultKeyMap.TabNext):
+			m.docsActiveTab = docsNextTab(m.docsActiveTab, len(m.docsPages))
+			m.docsViewer.GotoTop()
+			return m, func() tea.Msg { return renderDocsMsg("tab switch") }
+
+		case key.Matches(msg, defaultKeyMap.TabPrev):
+			m.docsActiveTab = docsPrevTab(m.docsActiveTab, len(m.docsPages))
+			m.docsViewer.GotoTop()
+			return m, func() tea.Msg { return renderDocsMsg("tab switch") }
+		}
+	}
+
+	if !handledKey {
+		m.docsViewer, cmd = m.docsViewer.Update(msg)
+		cmds = append(cmds, cmd)
+	}
+
+	return m, tea.Batch(cmds...)
+}

--- a/pkg/tui/docs_test.go
+++ b/pkg/tui/docs_test.go
@@ -1,0 +1,171 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/clcollins/srepd/pkg/docs"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDocsTabPage(t *testing.T) {
+	tests := []struct {
+		name        string
+		activeTab   int
+		tabsPerPage int
+		expected    int
+	}{
+		{"first page start", 0, 8, 0},
+		{"first page end", 7, 8, 0},
+		{"second page start", 8, 8, 1},
+		{"second page middle", 10, 8, 1},
+		{"third page", 16, 8, 2},
+		{"small pages", 3, 2, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, docsTabPage(tt.activeTab, tt.tabsPerPage))
+		})
+	}
+}
+
+func TestDocsPageStartEnd(t *testing.T) {
+	tests := []struct {
+		name      string
+		activeTab int
+		perPage   int
+		total     int
+		wantStart int
+		wantEnd   int
+	}{
+		{"first page full", 0, 8, 16, 0, 8},
+		{"second page full", 8, 8, 16, 8, 16},
+		{"partial last page", 8, 8, 10, 8, 10},
+		{"single page", 0, 8, 5, 0, 5},
+		{"exact fit", 0, 8, 8, 0, 8},
+		{"small page size", 2, 3, 7, 0, 3},
+		{"last small page", 6, 3, 7, 6, 7},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			start, end := docsPageStartEnd(tt.activeTab, tt.perPage, tt.total)
+			assert.Equal(t, tt.wantStart, start, "start index")
+			assert.Equal(t, tt.wantEnd, end, "end index")
+		})
+	}
+}
+
+func TestDocsTabLabel(t *testing.T) {
+	tests := []struct {
+		name     string
+		title    string
+		expected string
+	}{
+		{"short title", "Colors", "Colors"},
+		{"exactly 8", "12345678", "12345678"},
+		{"long title", "Configuration Reference", "Configur..."},
+		{"empty", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, docsTabLabel(tt.title))
+		})
+	}
+}
+
+func TestDocsNextTab(t *testing.T) {
+	tests := []struct {
+		name     string
+		current  int
+		total    int
+		expected int
+	}{
+		{"advance within page", 0, 10, 1},
+		{"wrap at end", 9, 10, 0},
+		{"single tab", 0, 1, 0},
+		{"cross page boundary", 7, 16, 8},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, docsNextTab(tt.current, tt.total))
+		})
+	}
+}
+
+func TestDocsPrevTab(t *testing.T) {
+	tests := []struct {
+		name     string
+		current  int
+		total    int
+		expected int
+	}{
+		{"go back within page", 5, 10, 4},
+		{"wrap at start", 0, 10, 9},
+		{"single tab", 0, 1, 0},
+		{"cross page boundary back", 8, 16, 7},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, docsPrevTab(tt.current, tt.total))
+		})
+	}
+}
+
+func TestDocsPagingIndicator(t *testing.T) {
+	tests := []struct {
+		name      string
+		activeTab int
+		perPage   int
+		total     int
+		expected  string
+	}{
+		{"single page", 0, 8, 5, ""},
+		{"first of two pages", 0, 8, 16, " [1/2]"},
+		{"second of two pages", 8, 8, 16, " [2/2]"},
+		{"middle page", 8, 8, 24, " [2/3]"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, docsPagingIndicator(tt.activeTab, tt.perPage, tt.total))
+		})
+	}
+}
+
+func TestClearDocsView(t *testing.T) {
+	m := model{
+		viewingDocs:   true,
+		docsActiveTab: 5,
+	}
+	m.clearDocsView()
+	assert.False(t, m.viewingDocs)
+	assert.Equal(t, 0, m.docsActiveTab)
+}
+
+func TestBuildDocsPageLabels(t *testing.T) {
+	pages := []docs.Doc{
+		{Title: "Quickstart", Content: ""},
+		{Title: "SREPD", Content: ""},
+		{Title: "AI Agents", Content: ""},
+		{Title: "Color Palettes", Content: ""},
+		{Title: "Configuration Reference", Content: ""},
+		{Title: "Flag Conditions", Content: ""},
+		{Title: "LLM Provider Configuration", Content: ""},
+		{Title: "Escalation Policies", Content: ""},
+		{Title: "Extra Doc One", Content: ""},
+		{Title: "Extra Doc Two", Content: ""},
+	}
+
+	labels := buildDocsPageLabels(pages, 0, 8)
+	assert.Len(t, labels, 8, "should show 8 tabs on first page")
+	assert.Equal(t, "Quicksta...", labels[0])
+	assert.Equal(t, "SREPD", labels[1])
+
+	labels2 := buildDocsPageLabels(pages, 8, 8)
+	assert.Len(t, labels2, 2, "second page should show remaining 2 tabs")
+	assert.Equal(t, "Extra Do...", labels2[0])
+}

--- a/pkg/tui/keymap.go
+++ b/pkg/tui/keymap.go
@@ -15,7 +15,7 @@ func (k keymap) FullHelp() [][]key.Binding {
 
 	columns := [][]key.Binding{
 		// Column 1: Help at top, navigation
-		{k.Help, k.Up, k.Down, k.Top, k.Bottom, k.Enter, k.Back},
+		{k.Help, k.ViewDocs, k.Up, k.Down, k.Top, k.Bottom, k.Enter, k.Back},
 		// Column 2: Primary incident actions
 		{k.Ack, k.Note, k.Login, k.Open, k.SOP, k.UnAck, k.Silence, k.Merge, k.Tag, k.Input},
 		// Column 3: Settings & toggles, Quit at bottom
@@ -61,6 +61,7 @@ type keymap struct {
 	Tag         key.Binding
 	TabNext     key.Binding
 	TabPrev     key.Binding
+	ViewDocs    key.Binding
 }
 
 type inputKeymap struct {
@@ -204,6 +205,10 @@ var defaultKeyMap = keymap{
 	TabPrev: key.NewBinding(
 		key.WithKeys("shift+tab", "left"),
 		key.WithHelp("shift+tab/←", "prev tab"),
+	),
+	ViewDocs: key.NewBinding(
+		key.WithKeys("ctrl+h"),
+		key.WithHelp("ctrl+h", "docs"),
 	),
 }
 

--- a/pkg/tui/layout.go
+++ b/pkg/tui/layout.go
@@ -208,6 +208,8 @@ func (m *model) recomputeLayout() {
 	m.incidentViewer.Height = m.layout.IncidentViewerHeight
 	m.logViewer.Width = m.layout.IncidentViewerWidth
 	m.logViewer.Height = m.layout.IncidentViewerHeight
+	m.docsViewer.Width = m.layout.IncidentViewerWidth
+	m.docsViewer.Height = m.layout.IncidentViewerHeight
 
 	if m.watcherExpanded {
 		m.watcherViewport.Width = m.layout.WatcherWidth

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -22,6 +22,7 @@ import (
 	"github.com/clcollins/srepd/pkg/ai"
 	"github.com/clcollins/srepd/pkg/backplane"
 	pkgconfig "github.com/clcollins/srepd/pkg/config"
+	"github.com/clcollins/srepd/pkg/docs"
 	"github.com/clcollins/srepd/pkg/launcher"
 	"github.com/clcollins/srepd/pkg/ocm"
 	"github.com/clcollins/srepd/pkg/pd"
@@ -168,6 +169,13 @@ type model struct {
 
 	// Incident viewer tab state
 	activeTab int // 0=details, 1=alerts, 2=notes
+
+	// Docs viewer state
+	viewingDocs     bool
+	docsViewer      viewport.Model
+	docsPages       []docs.Doc
+	docsActiveTab   int
+	docsTabsPerPage int
 
 	// Merge mode state
 	mergeMode           bool
@@ -349,6 +357,9 @@ func InitialModel(
 		cmdExecutor:           &execCommandExecutor{},
 		watcherViewport:       newWatcherViewport(),
 		watcherBuffer:         newWatcherBuffer(50),
+		docsViewer:            newDocsViewer(),
+		docsPages:             docs.EmbeddedDocs(),
+		docsTabsPerPage:       defaultDocsTabsPerPage,
 	}
 
 	mk := resolveMarkers(viper.GetBool("emoji"))
@@ -464,6 +475,9 @@ func InitialModelWithConfig(
 		cmdExecutor:           &execCommandExecutor{},
 		watcherViewport:       newWatcherViewport(),
 		watcherBuffer:         newWatcherBuffer(50),
+		docsViewer:            newDocsViewer(),
+		docsPages:             docs.EmbeddedDocs(),
+		docsTabsPerPage:       defaultDocsTabsPerPage,
 	}
 
 	mk2 := resolveMarkers(viper.GetBool("emoji"))

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -76,6 +76,13 @@ func (m model) windowSizeMsgHandler(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.mergeTable.SetHeight(m.layout.TableHeight)
 	}
 
+	m.docsViewer.Width = m.layout.IncidentViewerWidth
+	m.docsViewer.Height = m.layout.IncidentViewerHeight
+
+	if m.viewingDocs {
+		return m, func() tea.Msg { return renderDocsMsg("window resized") }
+	}
+
 	if m.viewingIncident {
 		return m, func() tea.Msg { return renderIncidentMsg("window resized") }
 	}
@@ -212,6 +219,9 @@ func (m model) keyMsgHandler(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case m.viewingLog:
 		return switchLogFocusMode(m, msg)
+
+	case m.viewingDocs:
+		return switchDocsFocusMode(m, msg)
 
 	case m.viewingIncident:
 		return switchIncidentFocusMode(m, msg)
@@ -707,6 +717,12 @@ func switchTableFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(msg, defaultKeyMap.ViewLog):
 			return m, m.readLog()
 
+		case key.Matches(msg, defaultKeyMap.ViewDocs):
+			m.viewingDocs = true
+			m.docsActiveTab = 0
+			m.docsViewer.GotoTop()
+			return m, func() tea.Msg { return renderDocsMsg("open docs") }
+
 		}
 	}
 	return m, tea.Batch(cmds...)
@@ -936,6 +952,12 @@ func switchIncidentFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			return m, func() tea.Msg { return openSOPMsg("sop") }
+
+		case key.Matches(msg, defaultKeyMap.ViewDocs):
+			m.viewingDocs = true
+			m.docsActiveTab = 0
+			m.docsViewer.GotoTop()
+			return m, func() tea.Msg { return renderDocsMsg("open docs") }
 
 		}
 	}

--- a/pkg/tui/quickstart_data.go
+++ b/pkg/tui/quickstart_data.go
@@ -1,0 +1,117 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+)
+
+type KeyBindingEntry struct {
+	Keys string
+	Help string
+}
+
+type ChordEntry struct {
+	Key         string
+	Description string
+}
+
+type InputCommandEntry struct {
+	Command     string
+	Description string
+}
+
+func KeyBindingEntries() []KeyBindingEntry {
+	km := defaultKeyMap
+	bindings := []struct {
+		keys string
+		help string
+	}{
+		{km.Help.Help().Key, km.Help.Help().Desc},
+		{km.Up.Help().Key, km.Up.Help().Desc},
+		{km.Down.Help().Key, km.Down.Help().Desc},
+		{km.Top.Help().Key, km.Top.Help().Desc},
+		{km.Bottom.Help().Key, km.Bottom.Help().Desc},
+		{km.Enter.Help().Key, km.Enter.Help().Desc},
+		{km.Back.Help().Key, km.Back.Help().Desc},
+		{km.Quit.Help().Key, km.Quit.Help().Desc},
+		{km.Team.Help().Key, km.Team.Help().Desc},
+		{km.Refresh.Help().Key, km.Refresh.Help().Desc},
+		{km.AutoRefresh.Help().Key, km.AutoRefresh.Help().Desc},
+		{km.Note.Help().Key, km.Note.Help().Desc},
+		{km.Silence.Help().Key, km.Silence.Help().Desc},
+		{km.Ack.Help().Key, km.Ack.Help().Desc},
+		{km.UnAck.Help().Key, km.UnAck.Help().Desc},
+		{km.AutoAck.Help().Key, km.AutoAck.Help().Desc},
+		{km.Urgency.Help().Key, km.Urgency.Help().Desc},
+		{km.Input.Help().Key, km.Input.Help().Desc},
+		{km.Login.Help().Key, km.Login.Help().Desc},
+		{km.Open.Help().Key, km.Open.Help().Desc},
+		{km.SOP.Help().Key, km.SOP.Help().Desc},
+		{km.ViewLog.Help().Key, km.ViewLog.Help().Desc},
+		{km.Merge.Help().Key, km.Merge.Help().Desc},
+		{km.Watcher.Help().Key, km.Watcher.Help().Desc},
+		{km.TabNext.Help().Key, km.TabNext.Help().Desc},
+		{km.TabPrev.Help().Key, km.TabPrev.Help().Desc},
+		{km.ViewDocs.Help().Key, km.ViewDocs.Help().Desc},
+	}
+
+	entries := make([]KeyBindingEntry, 0, len(bindings))
+	for _, b := range bindings {
+		entries = append(entries, KeyBindingEntry{Keys: b.keys, Help: b.help})
+	}
+	return entries
+}
+
+func ChordEntries() []ChordEntry {
+	var entries []ChordEntry
+	for _, r := range chordRegistry {
+		if r.Hidden {
+			continue
+		}
+		entries = append(entries, ChordEntry{Key: r.Key, Description: r.Description})
+	}
+	return entries
+}
+
+func InputCommandEntries() []InputCommandEntry {
+	return []InputCommandEntry{
+		{Command: ":agent <query>", Description: "ask Claude AI"},
+		{Command: ":watcher <query>", Description: "query AI watcher"},
+		{Command: ":flag cluster <id>", Description: "flag incidents by cluster ID"},
+		{Command: ":flag org <pattern>", Description: "flag incidents by org name"},
+		{Command: ":unflag <id>", Description: "remove a flag condition by ID"},
+		{Command: ":unflag all", Description: "clear all flag conditions"},
+		{Command: ":flags", Description: "list all flag conditions"},
+		{Command: ":flags save [path]", Description: "save flags to file"},
+		{Command: ":flags load [path]", Description: "load flags from file"},
+	}
+}
+
+func GenerateQuickstartMarkdown(keys []KeyBindingEntry, chords []ChordEntry, inputs []InputCommandEntry) string {
+	var b strings.Builder
+
+	b.WriteString("# Quickstart\n\n")
+
+	b.WriteString("## Key Bindings\n\n")
+	b.WriteString("| Key | Action |\n")
+	b.WriteString("|-----|--------|\n")
+	for _, e := range keys {
+		fmt.Fprintf(&b, "| %s | %s |\n", e.Keys, e.Help)
+	}
+
+	b.WriteString("\n## Chord Commands (ctrl+x + key)\n\n")
+	b.WriteString("| Key | Action |\n")
+	b.WriteString("|-----|--------|\n")
+	for _, e := range chords {
+		fmt.Fprintf(&b, "| %s | %s |\n", e.Key, e.Description)
+	}
+
+	b.WriteString("\n## Input Commands\n\n")
+	b.WriteString("| Command | Action |\n")
+	b.WriteString("|---------|--------|\n")
+	for _, e := range inputs {
+		fmt.Fprintf(&b, "| %s | %s |\n", e.Command, e.Description)
+	}
+
+	return b.String()
+}

--- a/pkg/tui/quickstart_data.go
+++ b/pkg/tui/quickstart_data.go
@@ -50,6 +50,7 @@ func KeyBindingEntries() []KeyBindingEntry {
 		{km.ViewLog.Help().Key, km.ViewLog.Help().Desc},
 		{km.Merge.Help().Key, km.Merge.Help().Desc},
 		{km.Watcher.Help().Key, km.Watcher.Help().Desc},
+		{km.Tag.Help().Key, km.Tag.Help().Desc},
 		{km.TabNext.Help().Key, km.TabNext.Help().Desc},
 		{km.TabPrev.Help().Key, km.TabPrev.Help().Desc},
 		{km.ViewDocs.Help().Key, km.ViewDocs.Help().Desc},

--- a/pkg/tui/quickstart_data_test.go
+++ b/pkg/tui/quickstart_data_test.go
@@ -99,4 +99,3 @@ func TestGenerateQuickstartMarkdown(t *testing.T) {
 	assert.Contains(t, result, ":agent <query>")
 	assert.Contains(t, result, "ask Claude AI")
 }
-

--- a/pkg/tui/quickstart_data_test.go
+++ b/pkg/tui/quickstart_data_test.go
@@ -1,0 +1,102 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKeyBindingEntries(t *testing.T) {
+	entries := KeyBindingEntries()
+
+	assert.NotEmpty(t, entries, "should return at least one key binding entry")
+
+	for _, e := range entries {
+		assert.NotEmpty(t, e.Keys, "Keys should not be empty for entry with Help=%q", e.Help)
+		assert.NotEmpty(t, e.Help, "Help should not be empty for entry with Keys=%q", e.Keys)
+	}
+
+	helpTexts := make(map[string]bool)
+	for _, e := range entries {
+		helpTexts[e.Help] = true
+	}
+	assert.True(t, helpTexts["help"], "should include help binding")
+	assert.True(t, helpTexts["acknowledge"], "should include acknowledge binding")
+	assert.True(t, helpTexts["quit"], "should include quit binding")
+	assert.True(t, helpTexts["view"], "should include enter/view binding")
+	assert.True(t, helpTexts["next tab"], "should include tab navigation")
+	assert.True(t, helpTexts["docs"], "should include docs binding")
+}
+
+func TestChordEntries(t *testing.T) {
+	entries := ChordEntries()
+
+	assert.NotEmpty(t, entries, "should return at least one chord entry")
+
+	for _, e := range entries {
+		assert.NotEmpty(t, e.Key, "Key should not be empty for entry with Description=%q", e.Description)
+		assert.NotEmpty(t, e.Description, "Description should not be empty for entry with Key=%q", e.Key)
+	}
+
+	descriptions := make(map[string]bool)
+	for _, e := range entries {
+		descriptions[e.Description] = true
+	}
+	assert.True(t, descriptions["show chord help"], "should include chord help")
+	assert.True(t, descriptions["rosa-boundary login"], "should include rosa-boundary login")
+
+	for _, e := range entries {
+		assert.NotEqual(t, "bulk silence", e.Description, "should not include hidden chord commands")
+	}
+}
+
+func TestInputCommandEntries(t *testing.T) {
+	entries := InputCommandEntries()
+
+	assert.NotEmpty(t, entries, "should return at least one input command entry")
+
+	for _, e := range entries {
+		assert.NotEmpty(t, e.Command, "Command should not be empty for entry with Description=%q", e.Description)
+		assert.NotEmpty(t, e.Description, "Description should not be empty for entry with Command=%q", e.Command)
+	}
+
+	commands := make(map[string]bool)
+	for _, e := range entries {
+		commands[e.Command] = true
+	}
+	assert.True(t, commands[":agent <query>"], "should include agent command")
+	assert.True(t, commands[":watcher <query>"], "should include watcher command")
+	assert.True(t, commands[":flag cluster <id>"], "should include flag cluster command")
+	assert.True(t, commands[":flag org <pattern>"], "should include flag org command")
+	assert.True(t, commands[":unflag <id>"], "should include unflag command")
+	assert.True(t, commands[":unflag all"], "should include unflag all command")
+	assert.True(t, commands[":flags"], "should include flags list command")
+	assert.True(t, commands[":flags save [path]"], "should include flags save command")
+	assert.True(t, commands[":flags load [path]"], "should include flags load command")
+}
+
+func TestGenerateQuickstartMarkdown(t *testing.T) {
+	keys := []KeyBindingEntry{
+		{Keys: "h", Help: "help"},
+		{Keys: "a", Help: "acknowledge"},
+	}
+	chords := []ChordEntry{
+		{Key: "?", Description: "show chord help"},
+	}
+	inputs := []InputCommandEntry{
+		{Command: ":agent <query>", Description: "ask Claude AI"},
+	}
+
+	result := GenerateQuickstartMarkdown(keys, chords, inputs)
+
+	assert.Contains(t, result, "# Quickstart")
+	assert.Contains(t, result, "## Key Bindings")
+	assert.Contains(t, result, "help")
+	assert.Contains(t, result, "acknowledge")
+	assert.Contains(t, result, "## Chord Commands (ctrl+x + key)")
+	assert.Contains(t, result, "show chord help")
+	assert.Contains(t, result, "## Input Commands")
+	assert.Contains(t, result, ":agent <query>")
+	assert.Contains(t, result, "ask Claude AI")
+}
+

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -1415,6 +1415,20 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.viewingLog = true
 		return m, nil
 
+	case renderDocsMsg:
+		if len(m.docsPages) == 0 {
+			m.viewingDocs = false
+			return m, nil
+		}
+		cmds = append(cmds, renderDocsContent(&m))
+
+	case renderedDocsMsg:
+		if msg.err != nil {
+			return m, func() tea.Msg { return errMsg{msg.err} }
+		}
+		m.docsViewer.SetContent(msg.content)
+		m.viewingDocs = true
+
 	case renderIncidentMsg:
 		if m.selectedIncident == nil {
 			m.setStatus("failed render incidents - no incidents provided")

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -78,6 +78,14 @@ func (m model) View() string {
 		fmt.Fprintf(&s, "  Select incident to merge %s into (Enter=select, Esc=cancel, t=toggle team):\n", m.mergeSourceIncident.ID)
 		s.WriteString(m.styles.TableContainer.Render(m.mergeTable.View()))
 
+	case m.viewingDocs:
+		tabBar := m.renderDocsTabBar()
+		s.WriteString(tabBar)
+		s.WriteString("\n")
+		tabWindowBorders := m.styles.TabWindow.GetHorizontalBorderSize()
+		tabWindowWidth := windowSize.Width - m.styles.Main.GetHorizontalBorderSize() - m.styles.Main.GetHorizontalMargins() - tabWindowBorders
+		s.WriteString(m.styles.TabWindow.Width(tabWindowWidth).Render(m.docsViewer.View()))
+
 	case m.viewingIncident:
 		tabBar := m.renderTabBar()
 		s.WriteString(tabBar)


### PR DESCRIPTION
## Summary

- Adds a new docs viewer mode triggered by `ctrl+h` that embeds `README.md` and all `docs/*.md` at build time via `go:embed`
- First tab is an auto-generated `quickstart.md` with tables of all keybindings, chord commands (ctrl+x + key), and input commands (:agent, :watcher, :flag family)
- Tabs paged in groups of 8 with indicator when multiple pages exist; `ctrl+h` toggles the view (press again to close)

## Test plan

- [x] All new pure functions tested with table-driven tests (no real FS/API access)
- [x] `make test` — all tests pass
- [x] `make lint` / `make vet` / `make fmt-check` — clean
- [x] `make test-race` — no race conditions
- [x] `make quickstart-verify` — generated output matches committed file
- [x] Manual: built binary, verified ctrl+h opens docs, tabs work, paging works, esc/ctrl+h returns

🤖 Generated with [Claude Code](https://claude.com/claude-code)