### PR TITLE
Fix mouse wheel scrolling on main table and watcher views

### DIFF
--- a/docs/plans/362-fix-mouse-scroll.md
+++ b/docs/plans/362-fix-mouse-scroll.md
@@ -1,0 +1,44 @@
+# 362: Fix mouse wheel scrolling on main table and watcher views
+
+## Problem
+
+Mouse wheel scrolling stopped working on the main incident table and watcher
+pane. The `tea.MouseMsg` handler in `Update()` only forwarded scroll events to
+the watcher viewport when expanded, and dropped them entirely when collapsed.
+The incident table never received scroll events. Meanwhile, incident view and
+log view scrolling worked because their viewports received events through a
+different code path.
+
+## Approach
+
+Extracted mouse event routing into `pkg/tui/mouse.go` with position-aware
+dispatch based on the mouse Y coordinate and the current view mode.
+
+### Routing logic
+
+1. **Non-wheel events**: no-op (return nil)
+2. **Incident view / log view**: forward unconditionally to the active
+   viewport — no Y computation needed, and any future views added to this
+   switch get mouse scroll for free
+3. **Config / bulk silence / team select / cluster select / merge modes**:
+   no-op (forms don't scroll via mouse)
+4. **Main table view**: compute the Y boundary between the table and watcher
+   using `mouseWatcherStartY()`, which derives the threshold from the current
+   layout (adapts on window resize). Route to watcher viewport or translate
+   wheel events to `MoveUp`/`MoveDown` on the table with incident sync.
+
+### Key design decisions
+
+- `mouseWatcherStartY()` is computed from layout constants and style overhead
+  so it automatically adjusts after `tea.WindowSizeMsg` triggers
+  `recomputeLayout()`
+- Table scrolling translates wheel events to `MoveUp`/`MoveDown` + calls
+  `syncSelectedIncidentToHighlightedRow()` for pre-fetch consistency
+- `tea.MouseMsg` was already in the logging skip list — no change needed
+
+## Testing
+
+12 new tests in `mouse_scroll_test.go` covering: table scroll up/down,
+watcher scroll, table scroll with watcher expanded, incident/log view
+forwarding, non-wheel no-op, resize adaptation, selected incident sync,
+and boundary calculation.

--- a/pkg/tui/mouse.go
+++ b/pkg/tui/mouse.go
@@ -1,0 +1,63 @@
+package tui
+
+import tea "github.com/charmbracelet/bubbletea"
+
+// mouseWatcherStartY returns the Y coordinate where the watcher pane begins.
+// This is computed from the current layout so it stays correct after window resizes.
+// The -4 adjustment accounts for style padding that the layout constants don't capture.
+func (m model) mouseWatcherStartY() int {
+	containerVOverhead := m.styles.TableContainer.GetVerticalBorderSize() +
+		m.styles.TableContainer.GetVerticalPadding() +
+		m.styles.TableContainer.GetVerticalMargins()
+
+	return layoutHeaderLines + containerVOverhead + m.layout.TableHeight + layoutFooterLines + layoutFooterNewline - 4
+}
+
+// handleMouseMsg routes mouse events to the correct component based on the
+// current view mode and the mouse Y position within the window.
+//
+// For non-table views (incident viewer, log viewer, and any future views),
+// mouse events are forwarded unconditionally to the active viewport via the
+// focus-mode dispatch so new views get mouse scroll for free.
+//
+// For the main table view, Y coordinates determine whether the event targets
+// the incident table or the watcher pane.
+func (m model) handleMouseMsg(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	if msg.Button != tea.MouseButtonWheelUp && msg.Button != tea.MouseButtonWheelDown {
+		return m, nil
+	}
+
+	switch {
+	case m.viewingIncident:
+		m.incidentViewer, _ = m.incidentViewer.Update(msg)
+		return m, nil
+
+	case m.viewingLog:
+		m.logViewer, _ = m.logViewer.Update(msg)
+		return m, nil
+
+	case m.configMode, m.bulkSilenceMode, m.teamSelectMode, m.clusterSelectMode, m.mergeMode:
+		return m, nil
+
+	default:
+		return m.handleMouseScrollMainView(msg)
+	}
+}
+
+// handleMouseScrollMainView routes wheel events on the main table+watcher screen.
+func (m model) handleMouseScrollMainView(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	if m.watcherExpanded && msg.Y >= m.mouseWatcherStartY() {
+		var cmd tea.Cmd
+		m.watcherViewport, cmd = m.watcherViewport.Update(msg)
+		return m, cmd
+	}
+
+	switch msg.Button {
+	case tea.MouseButtonWheelDown:
+		m.table.MoveDown(1)
+	case tea.MouseButtonWheelUp:
+		m.table.MoveUp(1)
+	}
+	cmd := m.syncSelectedIncidentToHighlightedRow()
+	return m, cmd
+}

--- a/pkg/tui/mouse_scroll_test.go
+++ b/pkg/tui/mouse_scroll_test.go
@@ -1,0 +1,325 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/PagerDuty/go-pagerduty"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+)
+
+func setupMouseTestModel(incidents []pagerduty.Incident) model {
+	m := createTestModelWithTable(incidents)
+	m.help = newHelp()
+	windowSize = tea.WindowSizeMsg{Width: 80, Height: 60}
+	m.recomputeLayout()
+	m.table.Focus()
+	return m
+}
+
+func testIncidents() []pagerduty.Incident {
+	return []pagerduty.Incident{
+		{
+			APIObject:          pagerduty.APIObject{ID: "Q001"},
+			Title:              "Incident 1",
+			Service:            pagerduty.APIObject{Summary: "svc-1"},
+			LastStatusChangeAt: "2024-01-01T00:00:00Z",
+		},
+		{
+			APIObject:          pagerduty.APIObject{ID: "Q002"},
+			Title:              "Incident 2",
+			Service:            pagerduty.APIObject{Summary: "svc-2"},
+			LastStatusChangeAt: "2024-01-01T00:00:00Z",
+		},
+		{
+			APIObject:          pagerduty.APIObject{ID: "Q003"},
+			Title:              "Incident 3",
+			Service:            pagerduty.APIObject{Summary: "svc-3"},
+			LastStatusChangeAt: "2024-01-01T00:00:00Z",
+		},
+	}
+}
+
+func TestMouseScroll_TableScrollDown(t *testing.T) {
+	t.Run("wheel down on table area moves cursor down", func(t *testing.T) {
+		m := setupMouseTestModel(testIncidents())
+
+		// Table cursor starts at row 0
+		assert.Equal(t, 0, m.table.Cursor())
+
+		msg := tea.MouseMsg{
+			X:      10,
+			Y:      5, // within table area
+			Action: tea.MouseActionPress,
+			Button: tea.MouseButtonWheelDown,
+		}
+		result, _ := m.Update(msg)
+		updated := result.(model)
+
+		assert.Equal(t, 1, updated.table.Cursor())
+	})
+}
+
+func TestMouseScroll_TableScrollUp(t *testing.T) {
+	t.Run("wheel up on table area moves cursor up", func(t *testing.T) {
+		m := setupMouseTestModel(testIncidents())
+
+		// Move to row 2 first
+		m.table.MoveDown(2)
+		assert.Equal(t, 2, m.table.Cursor())
+
+		msg := tea.MouseMsg{
+			X:      10,
+			Y:      5, // within table area
+			Action: tea.MouseActionPress,
+			Button: tea.MouseButtonWheelUp,
+		}
+		result, _ := m.Update(msg)
+		updated := result.(model)
+
+		assert.Equal(t, 1, updated.table.Cursor())
+	})
+}
+
+func TestMouseScroll_TableScrollUpAtTop(t *testing.T) {
+	t.Run("wheel up at top of table stays at row 0", func(t *testing.T) {
+		m := setupMouseTestModel(testIncidents())
+		assert.Equal(t, 0, m.table.Cursor())
+
+		msg := tea.MouseMsg{
+			X:      10,
+			Y:      5,
+			Action: tea.MouseActionPress,
+			Button: tea.MouseButtonWheelUp,
+		}
+		result, _ := m.Update(msg)
+		updated := result.(model)
+
+		assert.Equal(t, 0, updated.table.Cursor())
+	})
+}
+
+func TestMouseScroll_WatcherExpandedScrollWatcher(t *testing.T) {
+	t.Run("wheel down in watcher area scrolls watcher viewport", func(t *testing.T) {
+		m := setupMouseTestModel(testIncidents())
+		m.watcherExpanded = true
+		m.recomputeLayout()
+		m.watcherViewport.Width = m.layout.WatcherWidth
+		m.watcherViewport.Height = m.layout.WatcherHeight
+
+		lines := ""
+		for i := 0; i < 50; i++ {
+			lines += "line\n"
+		}
+		m.watcherViewport.SetContent(lines)
+
+		// Y coordinate in watcher area: after table + footer + newline
+		watcherY := m.mouseWatcherStartY()
+
+		msg := tea.MouseMsg{
+			X:      10,
+			Y:      watcherY + 2,
+			Action: tea.MouseActionPress,
+			Button: tea.MouseButtonWheelDown,
+		}
+		result, _ := m.Update(msg)
+		updated := result.(model)
+
+		assert.Greater(t, updated.watcherViewport.YOffset, 0)
+	})
+}
+
+func TestMouseScroll_WatcherExpandedScrollTable(t *testing.T) {
+	t.Run("wheel down in table area scrolls table even when watcher expanded", func(t *testing.T) {
+		m := setupMouseTestModel(testIncidents())
+		m.watcherExpanded = true
+		m.recomputeLayout()
+		m.watcherViewport.Width = m.layout.WatcherWidth
+		m.watcherViewport.Height = m.layout.WatcherHeight
+
+		assert.Equal(t, 0, m.table.Cursor())
+
+		msg := tea.MouseMsg{
+			X:      10,
+			Y:      5, // within table area
+			Action: tea.MouseActionPress,
+			Button: tea.MouseButtonWheelDown,
+		}
+		result, _ := m.Update(msg)
+		updated := result.(model)
+
+		assert.Equal(t, 1, updated.table.Cursor())
+	})
+}
+
+func TestMouseScroll_WatcherCollapsedScrollTable(t *testing.T) {
+	t.Run("wheel down scrolls table when watcher collapsed", func(t *testing.T) {
+		m := setupMouseTestModel(testIncidents())
+		m.watcherExpanded = false
+		m.recomputeLayout()
+
+		assert.Equal(t, 0, m.table.Cursor())
+
+		msg := tea.MouseMsg{
+			X:      10,
+			Y:      5,
+			Action: tea.MouseActionPress,
+			Button: tea.MouseButtonWheelDown,
+		}
+		result, _ := m.Update(msg)
+		updated := result.(model)
+
+		assert.Equal(t, 1, updated.table.Cursor())
+	})
+}
+
+func TestMouseScroll_IncidentViewForwardsToViewport(t *testing.T) {
+	t.Run("mouse scroll in incident view forwards to incidentViewer", func(t *testing.T) {
+		m := setupMouseTestModel(testIncidents())
+		m.viewingIncident = true
+
+		lines := ""
+		for i := 0; i < 100; i++ {
+			lines += "line\n"
+		}
+		m.incidentViewer.Width = m.layout.IncidentViewerWidth
+		m.incidentViewer.Height = m.layout.IncidentViewerHeight
+		m.incidentViewer.SetContent(lines)
+
+		msg := tea.MouseMsg{
+			X:      10,
+			Y:      10,
+			Action: tea.MouseActionPress,
+			Button: tea.MouseButtonWheelDown,
+		}
+		result, _ := m.Update(msg)
+		updated := result.(model)
+
+		assert.Greater(t, updated.incidentViewer.YOffset, 0)
+	})
+}
+
+func TestMouseScroll_LogViewForwardsToViewport(t *testing.T) {
+	t.Run("mouse scroll in log view forwards to logViewer", func(t *testing.T) {
+		m := setupMouseTestModel(testIncidents())
+		m.viewingLog = true
+
+		lines := ""
+		for i := 0; i < 100; i++ {
+			lines += "line\n"
+		}
+		m.logViewer.Width = m.layout.IncidentViewerWidth
+		m.logViewer.Height = m.layout.IncidentViewerHeight
+		m.logViewer.SetContent(lines)
+
+		msg := tea.MouseMsg{
+			X:      10,
+			Y:      10,
+			Action: tea.MouseActionPress,
+			Button: tea.MouseButtonWheelDown,
+		}
+		result, _ := m.Update(msg)
+		updated := result.(model)
+
+		assert.Greater(t, updated.logViewer.YOffset, 0)
+	})
+}
+
+func TestMouseScroll_NonWheelEventsAreNoOps(t *testing.T) {
+	t.Run("non-wheel mouse events return nil cmd on main view", func(t *testing.T) {
+		m := setupMouseTestModel(testIncidents())
+
+		msg := tea.MouseMsg{
+			X:      10,
+			Y:      5,
+			Action: tea.MouseActionPress,
+			Button: tea.MouseButtonLeft,
+		}
+		result, cmd := m.Update(msg)
+		updated := result.(model)
+
+		assert.Equal(t, 0, updated.table.Cursor())
+		assert.Nil(t, cmd)
+	})
+}
+
+func TestMouseScroll_AfterWindowResize(t *testing.T) {
+	t.Run("scroll routing adapts after window resize", func(t *testing.T) {
+		m := setupMouseTestModel(testIncidents())
+		m.watcherExpanded = true
+		m.recomputeLayout()
+		m.watcherViewport.Width = m.layout.WatcherWidth
+		m.watcherViewport.Height = m.layout.WatcherHeight
+
+		lines := ""
+		for i := 0; i < 50; i++ {
+			lines += "line\n"
+		}
+		m.watcherViewport.SetContent(lines)
+
+		// Record watcher start Y before resize
+		watcherYBefore := m.mouseWatcherStartY()
+
+		// Resize the window
+		windowSize = tea.WindowSizeMsg{Width: 80, Height: 40}
+		m.recomputeLayout()
+		m.watcherViewport.Width = m.layout.WatcherWidth
+		m.watcherViewport.Height = m.layout.WatcherHeight
+
+		watcherYAfter := m.mouseWatcherStartY()
+
+		// The boundary should have changed with the resize
+		assert.NotEqual(t, watcherYBefore, watcherYAfter)
+
+		// Scrolling in the new table area should still move the table
+		assert.Equal(t, 0, m.table.Cursor())
+		msg := tea.MouseMsg{
+			X:      10,
+			Y:      5,
+			Action: tea.MouseActionPress,
+			Button: tea.MouseButtonWheelDown,
+		}
+		result, _ := m.Update(msg)
+		updated := result.(model)
+		assert.Equal(t, 1, updated.table.Cursor())
+	})
+}
+
+func TestMouseScroll_SyncsSelectedIncident(t *testing.T) {
+	t.Run("scrolling table via mouse syncs selectedIncident", func(t *testing.T) {
+		m := setupMouseTestModel(testIncidents())
+
+		// Sync initial selection
+		m.syncSelectedIncidentToHighlightedRow()
+		assert.Equal(t, "Q001", m.selectedIncident.ID)
+
+		msg := tea.MouseMsg{
+			X:      10,
+			Y:      5,
+			Action: tea.MouseActionPress,
+			Button: tea.MouseButtonWheelDown,
+		}
+		result, cmd := m.Update(msg)
+		updated := result.(model)
+
+		assert.Equal(t, 1, updated.table.Cursor())
+		// Mouse scroll should trigger sync (returns a cmd for pre-fetch)
+		assert.NotNil(t, cmd)
+	})
+}
+
+func TestMouseWatcherStartY(t *testing.T) {
+	t.Run("returns correct boundary between table and watcher", func(t *testing.T) {
+		m := setupMouseTestModel(testIncidents())
+		m.watcherExpanded = true
+		m.recomputeLayout()
+
+		containerVOverhead := m.styles.TableContainer.GetVerticalBorderSize() +
+			m.styles.TableContainer.GetVerticalPadding() +
+			m.styles.TableContainer.GetVerticalMargins()
+
+		// Header (2) + table container overhead + table height + footer (1) + newline (1) - 4 adjustment
+		expected := layoutHeaderLines + containerVOverhead + m.layout.TableHeight + layoutFooterLines + layoutFooterNewline - 4
+		assert.Equal(t, expected, m.mouseWatcherStartY())
+	})
+}

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -633,12 +633,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.windowSizeMsgHandler(msg)
 
 	case tea.MouseMsg:
-		if m.watcherExpanded {
-			var cmd tea.Cmd
-			m.watcherViewport, cmd = m.watcherViewport.Update(msg)
-			return m, cmd
-		}
-		return m, nil
+		return m.handleMouseMsg(msg)
 
 	case tea.KeyMsg:
 		return m.keyMsgHandler(msg)


### PR DESCRIPTION
## Summary

- Mouse scroll events were being dropped on the main view instead of scrolling the incident table
- Extract position-aware mouse routing into `mouse.go` that uses Y coordinates from the current layout to dispatch wheel events to the correct component (table vs watcher)
- Non-table views (incident viewer, log viewer) forward unconditionally to their viewport so future views get mouse scroll for free

## Test plan

- [x] 12 new tests covering table scroll, watcher scroll, incident/log view forwarding, resize adaptation, non-wheel no-ops, and boundary calculation
- [x] All existing tests pass (`go test ./...`)
- [x] Race detector clean (`go test -race ./...`)
- [x] Manual testing with `/tmp/srepd` binary confirmed scroll works on table, watcher, and incident views

Created with assistance from Claude 🤖 <claude@anthropic.com>