### PR TITLE
Defer OCM auth until the config wizard completes (OB-6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ go install .        # standard go install
 
 SREPD reads `~/.config/srepd/srepd.yaml` and supports `SREPD_` environment variable prefix. Run `srepd config` to create or update your config interactively. Values from environment variables (e.g., `SREPD_TOKEN`) are pre-filled automatically.
 
-If no config file exists, running `srepd` automatically enters the configuration wizard on first launch. The wizard form resizes dynamically when the terminal window changes size.
+If no config file exists — or the config file is incomplete or still contains placeholder values (e.g. `<PagerDuty API token>`) — running `srepd` automatically enters the configuration wizard. The wizard form resizes dynamically when the terminal window changes size.
 
 **Migrating from old config format:** If your config uses the deprecated `service_escalation_policies` key, running `srepd config` will automatically migrate to the new `default_silent_escalation_policy` and `custom_service_escalation_policies` keys. The old block is commented out with a deprecation note.
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ When running inside a Fedora Toolbox, terminal commands are automatically prefix
 
 ## OCM Integration
 
-SREPD enriches PagerDuty incident data with cluster details from the OpenShift Cluster Manager (OCM) API. On startup, it connects to the production OCM API using tokens from `~/.config/ocm/ocm.json`. If tokens are expired, a browser window opens for auth code login in the background — the TUI starts immediately with PagerDuty incidents visible, and OCM enrichment populates once authentication completes.
+SREPD enriches PagerDuty incident data with cluster details from the OpenShift Cluster Manager (OCM) API. On startup, it connects to the production OCM API using tokens from `~/.config/ocm/ocm.json`. If tokens are expired, a browser window opens for auth code login in the background — the TUI starts immediately with PagerDuty incidents visible, and OCM enrichment populates once authentication completes. OCM authentication is skipped while the configuration wizard is on screen (`srepd config` and first-run setup) so new users aren't interrupted before saving a token; it runs automatically as soon as the wizard completes and the live session begins.
 
 Enriched data includes:
 * **Cluster display names** replace PD service names in the incident table (e.g., `mycluster.abc1.p1.example.org` instead of `osd-mycluster.abc1.p1.example.org-hive-cluster`)

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -6,7 +6,6 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 	"time"
@@ -15,7 +14,6 @@ import (
 	pkgconfig "github.com/clcollins/srepd/pkg/config"
 	"github.com/clcollins/srepd/pkg/deprecation"
 	"github.com/clcollins/srepd/pkg/launcher"
-	"github.com/clcollins/srepd/pkg/ocm"
 	"github.com/clcollins/srepd/pkg/tui"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -102,27 +100,6 @@ func launchTUIWithConfig() {
 		log.Fatal(err)
 	}
 
-	var ocmClient ocm.OCMClient
-	var ocmAuthPending bool
-	var asyncOCMClient *ocm.Client
-
-	cfg, armed, checkErr := ocm.CheckTokens()
-	if checkErr != nil {
-		log.Warn("OCM config check failed", "error", checkErr)
-	} else if armed {
-		client, connErr := ocm.NewClientFromConfig(cfg, tui.Version)
-		if connErr != nil {
-			log.Warn("OCM connection failed", "error", connErr)
-		} else {
-			ocmClient = client
-			asyncOCMClient = client
-			log.Info("OCM connected")
-		}
-	} else {
-		ocmAuthPending = true
-		log.Info("OCM tokens not valid — will authenticate async")
-	}
-
 	m, _ := tui.InitialModel(
 		viper.GetString("token"),
 		viper.GetStringSlice("teams"),
@@ -132,40 +109,19 @@ func launchTUIWithConfig() {
 		l,
 		launcher.ClusterLauncher{}, // rosa-boundary not needed in config mode
 		viper.GetBool("debug"),
-		ocmClient,
+		nil, // ocmClient — no OCM auth in config mode (OB-6)
 		viper.GetStringMapString("colors"),
 		viper.GetString("default_silent_escalation_policy"),
 		viper.GetStringMapString("custom_service_escalation_policies"),
-		true, // configMode
-		ocmAuthPending,
-		nil, // aiProvider — not needed in config mode
-		"",  // agentCLICommand — not needed in config mode
-		nil, // backplaneClient — not needed in config mode
-		nil, // backplaneConfig — not needed in config mode
+		true,  // configMode
+		false, // ocmAuthPending — never authenticate during config mode
+		nil,   // aiProvider — not needed in config mode
+		"",    // agentCLICommand — not needed in config mode
+		nil,   // backplaneClient — not needed in config mode
+		nil,   // backplaneConfig — not needed in config mode
 	)
 
 	p := tea.NewProgram(m, tea.WithAltScreen())
-
-	if ocmAuthPending {
-		go func() {
-			fmt.Fprintln(os.Stderr, "OCM tokens expired — opening browser for authentication...")
-			token, authErr := ocm.AuthenticateAsync(cfg)
-			if authErr != nil {
-				log.Debug("OCM browser auth failed", "error", authErr)
-				p.Send(tui.OCMClientReadyMsg{Err: authErr})
-				return
-			}
-			fmt.Fprintln(os.Stderr, "OCM authentication successful.")
-			ocm.ApplyAuthToken(cfg, token)
-			client, connErr := ocm.NewClientFromConfig(cfg, tui.Version)
-			if connErr != nil {
-				p.Send(tui.OCMClientReadyMsg{Err: connErr})
-				return
-			}
-			asyncOCMClient = client
-			p.Send(tui.OCMClientReadyMsg{Client: client})
-		}()
-	}
 
 	go func() {
 		for {
@@ -175,10 +131,6 @@ func launchTUIWithConfig() {
 	}()
 
 	_, err = p.Run()
-
-	if asyncOCMClient != nil {
-		asyncOCMClient.Close()
-	}
 
 	if err != nil {
 		fmt.Println(err)

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -209,10 +209,16 @@ func validateConfig() error {
 	}
 
 	for k, v := range pkgconfig.RequiredKeys {
-		if _, ok := settings[k]; !ok {
-			errs = append(errs, fmt.Errorf("missing required key: %s ", k))
-			log.Error("Missing required key", "key_name", k, "key_description", v)
+		if _, ok := settings[k]; ok {
+			continue
 		}
+		// AllSettings does not include values resolved from SREPD_* env vars;
+		// consult the live accessor before declaring the key missing.
+		if viper.GetString(k) != "" {
+			continue
+		}
+		errs = append(errs, fmt.Errorf("missing required key: %s ", k))
+		log.Error("Missing required key", "key_name", k, "key_description", v)
 	}
 
 	if _, ok := settings["service_escalation_policies"]; ok {

--- a/cmd/config_ocm_test.go
+++ b/cmd/config_ocm_test.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// OB-6 regression guard: config-wizard mode must never trigger OCM auth. A
+// brand-new user setting up srepd should not see "OCM tokens expired —
+// opening browser" or OCM warnings before they have even saved a token.
+// launchTUIWithConfig lives in config.go; the OCM setup must stay out of it.
+func TestConfigMode_NoOCMAuth(t *testing.T) {
+	src, err := os.ReadFile("config.go")
+	assert.NoError(t, err)
+
+	content := string(src)
+	for _, forbidden := range []string{
+		"ocm.CheckTokens",
+		"ocm.AuthenticateAsync",
+		"ocm.NewClientFromConfig",
+		"ocm.ApplyAuthToken",
+		"OCMClientReadyMsg",
+	} {
+		assert.NotContains(t, content, forbidden,
+			"config mode must not perform OCM auth (%s found in cmd/config.go)", forbidden)
+	}
+}
+
+// The OCM startup logic must live in exactly one place: the setupOCM helper
+// used by the normal launch path.
+func TestSetupOCM_SingleCallSite(t *testing.T) {
+	src, err := os.ReadFile("root.go")
+	assert.NoError(t, err)
+
+	content := string(src)
+	assert.Contains(t, content, "func setupOCM(", "setupOCM helper must exist in root.go")
+	assert.Equal(t, 1, strings.Count(content, "ocm.CheckTokens"),
+		"ocm.CheckTokens must be called only inside setupOCM")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,6 +35,8 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/log"
+	ocmconfig "github.com/openshift-online/ocm-common/pkg/ocm/config"
+
 	"github.com/clcollins/srepd/pkg/ai"
 	"github.com/clcollins/srepd/pkg/backplane"
 	pkgconfig "github.com/clcollins/srepd/pkg/config"
@@ -210,26 +212,7 @@ func launchTUI() {
 		log.Fatal(err)
 	}
 
-	var ocmClient ocm.OCMClient
-	var ocmAuthPending bool
-	var asyncOCMClient *ocm.Client
-
-	cfg, armed, checkErr := ocm.CheckTokens()
-	if checkErr != nil {
-		log.Warn("OCM config check failed", "error", checkErr)
-	} else if armed {
-		client, connErr := ocm.NewClientFromConfig(cfg, tui.Version)
-		if connErr != nil {
-			log.Warn("OCM connection failed", "error", connErr)
-		} else {
-			ocmClient = client
-			asyncOCMClient = client
-			log.Info("OCM connected")
-		}
-	} else {
-		ocmAuthPending = true
-		log.Info("OCM tokens not valid — will authenticate async")
-	}
+	ocmClient, asyncOCMClient, ocmAuthPending, cfg := setupOCM()
 
 	var aiProvider ai.Provider
 	llmCfg := ai.Config{
@@ -351,6 +334,37 @@ func launchTUI() {
 		fmt.Println(err)
 		log.Fatal(err)
 	}
+}
+
+// setupOCM checks OCM tokens and connects when possible. It returns the
+// client handed to the TUI, the concrete client for lifecycle cleanup,
+// whether async browser auth is still required, and the OCM config needed to
+// complete that auth. Config-wizard mode deliberately skips this (OB-6): a
+// brand-new user must not see browser-auth prompts or OCM warnings before
+// they have even saved a PagerDuty token.
+func setupOCM() (ocm.OCMClient, *ocm.Client, bool, *ocmconfig.Config) {
+	var ocmClient ocm.OCMClient
+	var concreteClient *ocm.Client
+	var authPending bool
+
+	cfg, armed, checkErr := ocm.CheckTokens()
+	if checkErr != nil {
+		log.Warn("OCM config check failed", "error", checkErr)
+	} else if armed {
+		client, connErr := ocm.NewClientFromConfig(cfg, tui.Version)
+		if connErr != nil {
+			log.Warn("OCM connection failed", "error", connErr)
+		} else {
+			ocmClient = client
+			concreteClient = client
+			log.Info("OCM connected")
+		}
+	} else {
+		authPending = true
+		log.Info("OCM tokens not valid — will authenticate async")
+	}
+
+	return ocmClient, concreteClient, authPending, cfg
 }
 
 // logWriter holds the active asyncWriter so it can be flushed on shutdown.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -85,6 +85,16 @@ but rather a simple tool to make on-call tasks easier.`,
 			return
 		}
 
+		route, reason := classifyStartup()
+		switch route {
+		case routeWizard:
+			needsWizard = true
+			log.Info("Config incomplete — launching setup wizard", "reason", reason)
+			return
+		case routeFatal:
+			log.Fatal(fmt.Errorf("%s — fix or remove %s, or run `srepd config`", reason, configFile))
+		}
+
 		if err := validateConfig(); err != nil {
 			log.Fatal(err)
 		}
@@ -109,9 +119,48 @@ but rather a simple tool to make on-call tasks easier.`,
 			launchTUIWithConfig()
 			return
 		}
+		if needsWizard {
+			ensureViperDefaults()
+			launchTUIWithConfig()
+			return
+		}
 
 		launchTUI()
 	},
+}
+
+// needsWizard is set in PreRun when an existing config file is missing
+// required values or contains placeholders (e.g. copied from the README
+// example); Run then enters the config wizard instead of aborting.
+var needsWizard bool
+
+// startupRoute describes how Run should proceed for an existing config file.
+type startupRoute int
+
+const (
+	routeNormal startupRoute = iota
+	routeWizard
+	routeFatal
+)
+
+// classifyStartup maps the config health of the current viper state to a
+// startup route. Token and teams are read through viper's accessors so values
+// supplied via SREPD_* env vars count as configured.
+func classifyStartup() (startupRoute, string) {
+	health, reason := pkgconfig.ClassifyConfigHealth(
+		viper.GetString("token"),
+		viper.GetStringSlice("teams"),
+		viper.AllSettings(),
+	)
+
+	switch health {
+	case pkgconfig.HealthNeedsWizard:
+		return routeWizard, reason
+	case pkgconfig.HealthInvalid:
+		return routeFatal, reason
+	default:
+		return routeNormal, ""
+	}
 }
 
 // resolveConfigFilePath builds the path to the srepd config file, surfacing (rather

--- a/cmd/wizard_routing_test.go
+++ b/cmd/wizard_routing_test.go
@@ -1,0 +1,91 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClassifyStartup_ValidConfigRoutesNormal(t *testing.T) {
+	viper.Reset()
+	viper.Set("token", "test-pagerduty-token")
+	viper.Set("teams", []string{"TEAM1"})
+
+	route, reason := classifyStartup()
+
+	assert.Equal(t, routeNormal, route)
+	assert.Empty(t, reason)
+}
+
+func TestClassifyStartup_PlaceholderTokenRoutesWizard(t *testing.T) {
+	viper.Reset()
+	viper.Set("token", "<PagerDuty API token>")
+	viper.Set("teams", []string{"TEAM1"})
+
+	route, reason := classifyStartup()
+
+	assert.Equal(t, routeWizard, route)
+	assert.NotEmpty(t, reason)
+}
+
+func TestClassifyStartup_MissingTokenRoutesWizard(t *testing.T) {
+	viper.Reset()
+	viper.Set("teams", []string{"TEAM1"})
+
+	route, reason := classifyStartup()
+
+	assert.Equal(t, routeWizard, route)
+	assert.NotEmpty(t, reason)
+}
+
+func TestClassifyStartup_MissingTeamsRoutesWizard(t *testing.T) {
+	viper.Reset()
+	viper.Set("token", "test-pagerduty-token")
+
+	route, reason := classifyStartup()
+
+	assert.Equal(t, routeWizard, route)
+	assert.NotEmpty(t, reason)
+}
+
+func TestClassifyStartup_StructurallyInvalidRoutesFatal(t *testing.T) {
+	viper.Reset()
+	viper.Set("token", "test-pagerduty-token")
+	viper.Set("teams", []string{"TEAM1"})
+	viper.Set("service_escalation_policies", "not-a-map")
+
+	route, reason := classifyStartup()
+
+	assert.Equal(t, routeFatal, route)
+	assert.NotEmpty(t, reason)
+}
+
+// Values supplied only via SREPD_* env vars must count as configured: the
+// classifier reads viper's live accessors, not just the settings map.
+func TestClassifyStartup_EnvTokenRoutesNormal(t *testing.T) {
+	viper.Reset()
+	t.Setenv("SREPD_TOKEN", "env-pagerduty-token")
+	viper.SetEnvPrefix("srepd")
+	viper.AutomaticEnv()
+	viper.Set("teams", []string{"TEAM1"})
+
+	route, reason := classifyStartup()
+
+	assert.Equal(t, routeNormal, route)
+	assert.Empty(t, reason)
+}
+
+// validateConfig must not report a required key missing when it is supplied
+// via an SREPD_* env var (AllSettings does not include env-resolved values).
+func TestValidateConfig_RequiredKeyFromEnv(t *testing.T) {
+	viper.Reset()
+	t.Setenv("SREPD_TOKEN", "env-pagerduty-token")
+	viper.SetEnvPrefix("srepd")
+	viper.AutomaticEnv()
+	viper.Set("teams", []string{"TEAM1"})
+
+	err := validateConfig()
+
+	assert.NoError(t, err)
+}

--- a/docs/plans/361-wizard-routing-broken-config.md
+++ b/docs/plans/361-wizard-routing-broken-config.md
@@ -1,0 +1,71 @@
+# 361: Route broken/placeholder configs into the wizard (OB-1)
+
+Issue: #353 (OB-1), part of the onboarding overhaul (#353, #324)
+Branch: `srepd/wizard-routing-broken-config`
+
+## Problem
+
+The config wizard only auto-launches when the config file is **absent**
+(root.go `Run`). A config file that exists but is broken — the most likely
+real-world first-run failure — dead-ends instead:
+
+- Missing required key → `PreRun` → `validateConfig()` → `log.Fatal`, no hint.
+- Placeholder token (the literal `<PagerDuty API token>` from the README
+  example) → passes validation, then fails at PD auth with a red ERROR view
+  and no recovery path.
+
+Placeholder detection existed for teams only (`HasPlaceholderTeams`), with a
+private duplicate in `pkg/tui` (`hasPlaceholderTeamsCfg`), and it missed the
+README's own `<team ID>` form.
+
+## Approach
+
+Classify config health once, before validation, and route wizard-shaped
+problems into the existing in-TUI wizard:
+
+- `pkg/config/health.go` — new:
+  - `HasPlaceholderToken(string) bool`: empty/whitespace or `<...>`
+    angle-bracket placeholder.
+  - `ClassifyConfigHealth(token, teams, settings) (ConfigHealth, reason)`:
+    `HealthOK | HealthNeedsWizard | HealthInvalid`. NeedsWizard = missing or
+    placeholder token/teams. Invalid = structural damage the wizard's AST
+    merge cannot safely fix (e.g. `service_escalation_policies` not a map).
+    Token/teams come from viper accessors so `SREPD_*` env values count.
+- `cmd/root.go`:
+  - `classifyStartup()` maps health → `routeNormal | routeWizard | routeFatal`.
+  - `PreRun`: `routeWizard` sets `needsWizard` + logs the reason instead of
+    Fatal-ing; `routeFatal` keeps Fatal with "fix or remove <file>, or run
+    `srepd config`" guidance; `routeNormal` proceeds to `validateConfig()` +
+    auto-migration as before.
+  - `Run`: `needsWizard` → `ensureViperDefaults()` + `launchTUIWithConfig()`.
+- `validateConfig()` required-key check now falls back to `viper.GetString`
+  before declaring a key missing (AllSettings omits env-resolved values).
+- `HasPlaceholderTeams` generalized: any `<...>` entry is a placeholder (was:
+  only the `<PagerDuty Team ID` prefix, which missed the README's `<team ID>`).
+- Dedupe: `tui.hasPlaceholderTeamsCfg` deleted; `tui.go` Init uses
+  `pkgconfig.HasPlaceholderTeams`.
+
+The wizard-launch reason is logged (`Config incomplete — launching setup
+wizard`). Surfacing it inside the wizard's welcome step is deferred to the
+first-run polish PR of this overhaul, which adds the welcome group.
+
+## Key design decisions
+
+- **Classifier is pure and env-aware**: takes token/teams as values (callers
+  use viper accessors) plus the raw settings map only for structural checks.
+  This keeps it testable and avoids misrouting `SREPD_TOKEN`-only users.
+- **Structural errors stay fatal**: the wizard's merge path edits the YAML AST
+  in place; routing a malformed document into it risks data loss. HealthInvalid
+  is deliberately narrow.
+- **No signature changes**: `launchTUIWithConfig()` and `InitialModel` are
+  untouched; routing is a flag between PreRun and Run.
+
+## Tests (TDD — written first)
+
+- `pkg/config/health_test.go`: `HasPlaceholderToken` table (10 cases);
+  `ClassifyConfigHealth` table (10 cases incl. structural-wins ordering);
+  generalized `HasPlaceholderTeams`; regression: the verbatim README example
+  YAML must classify `HealthNeedsWizard`; empty-file case.
+- `cmd/wizard_routing_test.go`: `classifyStartup` routes for valid /
+  placeholder-token / missing-token / missing-teams / invalid-map configs;
+  env-token routes normal; `validateConfig` accepts env-supplied required keys.

--- a/docs/plans/362-fix-mouse-scroll.md
+++ b/docs/plans/362-fix-mouse-scroll.md
@@ -1,0 +1,44 @@
+# 362: Fix mouse wheel scrolling on main table and watcher views
+
+## Problem
+
+Mouse wheel scrolling stopped working on the main incident table and watcher
+pane. The `tea.MouseMsg` handler in `Update()` only forwarded scroll events to
+the watcher viewport when expanded, and dropped them entirely when collapsed.
+The incident table never received scroll events. Meanwhile, incident view and
+log view scrolling worked because their viewports received events through a
+different code path.
+
+## Approach
+
+Extracted mouse event routing into `pkg/tui/mouse.go` with position-aware
+dispatch based on the mouse Y coordinate and the current view mode.
+
+### Routing logic
+
+1. **Non-wheel events**: no-op (return nil)
+2. **Incident view / log view**: forward unconditionally to the active
+   viewport — no Y computation needed, and any future views added to this
+   switch get mouse scroll for free
+3. **Config / bulk silence / team select / cluster select / merge modes**:
+   no-op (forms don't scroll via mouse)
+4. **Main table view**: compute the Y boundary between the table and watcher
+   using `mouseWatcherStartY()`, which derives the threshold from the current
+   layout (adapts on window resize). Route to watcher viewport or translate
+   wheel events to `MoveUp`/`MoveDown` on the table with incident sync.
+
+### Key design decisions
+
+- `mouseWatcherStartY()` is computed from layout constants and style overhead
+  so it automatically adjusts after `tea.WindowSizeMsg` triggers
+  `recomputeLayout()`
+- Table scrolling translates wheel events to `MoveUp`/`MoveDown` + calls
+  `syncSelectedIncidentToHighlightedRow()` for pre-fetch consistency
+- `tea.MouseMsg` was already in the logging skip list — no change needed
+
+## Testing
+
+12 new tests in `mouse_scroll_test.go` covering: table scroll up/down,
+watcher scroll, table scroll with watcher expanded, incident/log view
+forwarding, non-wheel no-op, resize adaptation, selected incident sync,
+and boundary calculation.

--- a/docs/plans/363-config-mode-no-ocm.md
+++ b/docs/plans/363-config-mode-no-ocm.md
@@ -1,0 +1,58 @@
+# 363: No OCM auth in config-wizard mode (OB-6)
+
+Issue: #353 (OB-6), part of the onboarding overhaul (#353, #324)
+Branch: `srepd/config-mode-no-ocm`
+
+## Problem
+
+`launchTUIWithConfig()` — the config-wizard entry point — ran the same OCM
+startup as the normal launch path: `ocm.CheckTokens()` plus an async
+browser-auth goroutine. A brand-new user running `srepd config` (or hitting
+the first-run wizard) saw "OCM tokens expired — opening browser for
+authentication..." and OCM warnings before they had even saved a PagerDuty
+token. Confusing at best, alarming at worst — and entirely unnecessary, since
+config mode makes no OCM calls.
+
+## Approach
+
+Defer OCM, don't drop it. The wizard itself is OCM-free, and the session
+that continues after the wizard connects OCM exactly like a normal launch —
+a first-run user must not get a degraded (enrichment-less) srepd, or they
+try it once, get underwhelmed, and never come back.
+
+- `cmd/config.go` `launchTUIWithConfig()`: delete the OCM token-check block
+  and the async browser-auth goroutine; pass `nil` ocmClient and `false`
+  ocmAuthPending to `tui.InitialModel`. Config mode is now OCM-free.
+- `cmd/root.go`: extract the (previously duplicated) OCM startup into a
+  `setupOCM()` helper returning `(ocm.OCMClient, *ocm.Client, authPending,
+  *ocmconfig.Config)`. `launchTUI()` — the normal path — is its only caller,
+  with behavior unchanged.
+- `pkg/ocm`: new `Connect(agentVersion)` — CheckTokens → browser auth if
+  expired → NewClientFromConfig, blocking; for use inside a tea.Cmd.
+- `pkg/tui`: post-wizard OCM handoff. `connectOCMCmdIfNeeded()` (nil when
+  connected or dev mode; result flows through the existing
+  `OCMClientReadyMsg` handler, which already wires the client, deferred
+  backplane, and cluster enrichment). `ocmHandoffCmd(requirePDConfig)` sets
+  `ocmAuthPending` and gates on a usable PD config. Wired into all four
+  wizard-exit paths: save (`configSavedMsg`, batched with PD init), discard,
+  no-changes, and abort — the last three require an existing PD config so a
+  brand-new user backing out never gets a browser-auth prompt on the way out.
+  Injectable `model.ocmConnect` for tests.
+
+## Tests (TDD — written first)
+
+`cmd/config_ocm_test.go` source-scan regression guards (pattern from plan 086
+verification):
+- `TestConfigMode_NoOCMAuth` — `cmd/config.go` must not reference
+  `ocm.CheckTokens`, `ocm.AuthenticateAsync`, `ocm.NewClientFromConfig`,
+  `ocm.ApplyAuthToken`, or `OCMClientReadyMsg`.
+- `TestSetupOCM_SingleCallSite` — `setupOCM` exists in root.go and is the
+  single `ocm.CheckTokens` call site.
+
+`pkg/tui/config_ocm_handoff_test.go` (mock OCM client via injectable
+`ocmConnect`):
+- connect cmd produced when no client; nil when connected / dev mode; error
+  surfaces as `OCMClientReadyMsg.Err`
+- `configSavedMsg` success queues the connect (`ocmAuthPending` set); save
+  error and already-connected cases do not
+- wizard abort without a PD config performs no OCM handoff

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -784,7 +784,7 @@ func HasPlaceholderTeams(teams []string) bool {
 	}
 	for _, team := range teams {
 		trimmed := strings.TrimSpace(team)
-		if trimmed != "" && !strings.HasPrefix(trimmed, "<PagerDuty Team ID") {
+		if trimmed != "" && !isAnglePlaceholder(trimmed) {
 			return false
 		}
 	}

--- a/pkg/config/health.go
+++ b/pkg/config/health.go
@@ -1,0 +1,63 @@
+package config
+
+import "strings"
+
+// ConfigHealth classifies whether a present config file is usable, fixable by
+// the interactive wizard, or structurally broken beyond what the wizard can
+// repair.
+type ConfigHealth int
+
+const (
+	// HealthOK — required values are present and non-placeholder; start normally.
+	HealthOK ConfigHealth = iota
+	// HealthNeedsWizard — required values are missing or placeholders (e.g. a
+	// config copied from the README example); route the user into the wizard.
+	HealthNeedsWizard
+	// HealthInvalid — the file is structurally malformed; the wizard cannot fix
+	// it without risking data loss, so startup must abort with guidance.
+	HealthInvalid
+)
+
+// HasPlaceholderToken reports whether token is empty/whitespace or an
+// angle-bracket placeholder such as the README's "<PagerDuty API token>".
+func HasPlaceholderToken(token string) bool {
+	trimmed := strings.TrimSpace(token)
+	if trimmed == "" {
+		return true
+	}
+	return isAnglePlaceholder(trimmed)
+}
+
+// ClassifyConfigHealth decides how startup should proceed when a config file
+// exists. token and teams must come from viper's Get accessors (which resolve
+// env vars and defaults), while settings is viper's AllSettings map, used only
+// for structural checks. The returned reason is human-readable and suitable
+// for logs and the wizard banner; it is empty for HealthOK.
+func ClassifyConfigHealth(token string, teams []string, settings map[string]any) (ConfigHealth, string) {
+	// Structural problems first: the wizard's merge path edits the YAML AST in
+	// place, so a malformed document must be fixed by hand instead.
+	if raw, ok := settings["service_escalation_policies"]; ok {
+		if _, ok := raw.(map[string]any); !ok {
+			return HealthInvalid, "'service_escalation_policies' is not a valid map"
+		}
+	}
+
+	if HasPlaceholderToken(token) {
+		if strings.TrimSpace(token) == "" {
+			return HealthNeedsWizard, "no PagerDuty API token configured"
+		}
+		return HealthNeedsWizard, "the configured PagerDuty API token is a placeholder value"
+	}
+
+	if HasPlaceholderTeams(teams) {
+		return HealthNeedsWizard, "no PagerDuty teams configured"
+	}
+
+	return HealthOK, ""
+}
+
+// isAnglePlaceholder reports whether s (already trimmed) is a template value
+// like "<PagerDuty API token>" or "<team ID>".
+func isAnglePlaceholder(s string) bool {
+	return strings.HasPrefix(s, "<") && strings.HasSuffix(s, ">")
+}

--- a/pkg/config/health_test.go
+++ b/pkg/config/health_test.go
@@ -1,0 +1,181 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+func TestHasPlaceholderToken(t *testing.T) {
+	tests := []struct {
+		name  string
+		token string
+		want  bool
+	}{
+		{"empty", "", true},
+		{"whitespace only", "   ", true},
+		{"readme literal", "<PagerDuty API token>", true},
+		{"generic angle brackets", "<token>", true},
+		{"angle brackets with spaces", "  <PagerDuty API token>  ", true},
+		{"real token", "u+wXyZ1234567890abcd", false},
+		{"real token with whitespace", "  u+wXyZ1234567890abcd  ", false},
+		{"leading angle only", "<unclosed", false},
+		{"trailing angle only", "unopened>", false},
+		{"angle brackets inside", "ab<cd>ef", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, HasPlaceholderToken(tt.token))
+		})
+	}
+}
+
+func TestClassifyConfigHealth(t *testing.T) {
+	tests := []struct {
+		name       string
+		token      string
+		teams      []string
+		settings   map[string]any
+		wantHealth ConfigHealth
+		wantReason string
+	}{
+		{
+			name:       "valid config",
+			token:      "u+realtoken123",
+			teams:      []string{"PTEAM01"},
+			settings:   map[string]any{"token": "u+realtoken123", "teams": []any{"PTEAM01"}},
+			wantHealth: HealthOK,
+		},
+		{
+			name:       "missing token",
+			token:      "",
+			teams:      []string{"PTEAM01"},
+			settings:   map[string]any{"teams": []any{"PTEAM01"}},
+			wantHealth: HealthNeedsWizard,
+			wantReason: "no PagerDuty API token configured",
+		},
+		{
+			name:       "placeholder token from README",
+			token:      "<PagerDuty API token>",
+			teams:      []string{"PTEAM01"},
+			settings:   map[string]any{"token": "<PagerDuty API token>", "teams": []any{"PTEAM01"}},
+			wantHealth: HealthNeedsWizard,
+			wantReason: "the configured PagerDuty API token is a placeholder value",
+		},
+		{
+			name:       "missing teams",
+			token:      "u+realtoken123",
+			teams:      nil,
+			settings:   map[string]any{"token": "u+realtoken123"},
+			wantHealth: HealthNeedsWizard,
+			wantReason: "no PagerDuty teams configured",
+		},
+		{
+			name:       "placeholder teams",
+			token:      "u+realtoken123",
+			teams:      []string{"<PagerDuty Team ID>"},
+			settings:   map[string]any{"token": "u+realtoken123", "teams": []any{"<PagerDuty Team ID>"}},
+			wantHealth: HealthNeedsWizard,
+			wantReason: "no PagerDuty teams configured",
+		},
+		{
+			name:       "readme-style generic team placeholder",
+			token:      "u+realtoken123",
+			teams:      []string{"<team ID>"},
+			settings:   map[string]any{"token": "u+realtoken123", "teams": []any{"<team ID>"}},
+			wantHealth: HealthNeedsWizard,
+			wantReason: "no PagerDuty teams configured",
+		},
+		{
+			name:       "everything missing",
+			token:      "",
+			teams:      nil,
+			settings:   map[string]any{},
+			wantHealth: HealthNeedsWizard,
+			wantReason: "no PagerDuty API token configured",
+		},
+		{
+			name:       "legacy policies not a map is structural",
+			token:      "u+realtoken123",
+			teams:      []string{"PTEAM01"},
+			settings:   map[string]any{"token": "u+realtoken123", "teams": []any{"PTEAM01"}, "service_escalation_policies": "not-a-map"},
+			wantHealth: HealthInvalid,
+			wantReason: "'service_escalation_policies' is not a valid map",
+		},
+		{
+			name:       "structural problem wins over wizard-shaped problem",
+			token:      "",
+			teams:      nil,
+			settings:   map[string]any{"service_escalation_policies": []any{"nope"}},
+			wantHealth: HealthInvalid,
+			wantReason: "'service_escalation_policies' is not a valid map",
+		},
+		{
+			name:       "legacy policies as valid map is fine",
+			token:      "u+realtoken123",
+			teams:      []string{"PTEAM01"},
+			settings:   map[string]any{"token": "u+realtoken123", "teams": []any{"PTEAM01"}, "service_escalation_policies": map[string]any{"default": "P123", "silent_default": "P456"}},
+			wantHealth: HealthOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			health, reason := ClassifyConfigHealth(tt.token, tt.teams, tt.settings)
+			assert.Equal(t, tt.wantHealth, health)
+			if tt.wantReason != "" {
+				assert.Equal(t, tt.wantReason, reason)
+			}
+			if tt.wantHealth == HealthOK {
+				assert.Empty(t, reason)
+			}
+		})
+	}
+}
+
+// HasPlaceholderTeams must recognize generic angle-bracket placeholders like
+// the README's "<team ID>", not only the "<PagerDuty Team ID" prefix.
+func TestHasPlaceholderTeams_GenericAngleBrackets(t *testing.T) {
+	assert.True(t, HasPlaceholderTeams([]string{"<team ID>"}))
+	assert.True(t, HasPlaceholderTeams([]string{"<team ID>", "<PagerDuty Team ID 1>"}))
+	assert.False(t, HasPlaceholderTeams([]string{"<team ID>", "PTEAM01"}))
+}
+
+// Regression for OB-1: a config file built by copying the README example
+// verbatim must route the user into the wizard, never a fatal error.
+func TestClassifyConfigHealth_ReadmeExampleRoutesToWizard(t *testing.T) {
+	readmeExample := `
+token: <PagerDuty API token>
+teams:
+  - <team ID>
+default_silent_escalation_policy: P654321
+terminal: gnome-terminal
+cluster_login_command: ocm-container --cluster-id %%CLUSTER_ID%%
+rosa_boundary_command: rosa-boundary start-task --cluster-id %%CLUSTER_ID%% --connect
+toolbox_mode: auto
+`
+	var settings map[string]any
+	err := yaml.Unmarshal([]byte(readmeExample), &settings)
+	assert.NoError(t, err)
+
+	token, _ := settings["token"].(string)
+	var teams []string
+	if raw, ok := settings["teams"].([]any); ok {
+		for _, entry := range raw {
+			teams = append(teams, entry.(string))
+		}
+	}
+
+	health, reason := ClassifyConfigHealth(token, teams, settings)
+	assert.Equal(t, HealthNeedsWizard, health)
+	assert.NotEmpty(t, reason)
+}
+
+// An empty (zero-byte) config file must also route to the wizard.
+func TestClassifyConfigHealth_EmptyFileRoutesToWizard(t *testing.T) {
+	health, reason := ClassifyConfigHealth("", nil, map[string]any{})
+	assert.Equal(t, HealthNeedsWizard, health)
+	assert.NotEmpty(t, reason)
+}

--- a/pkg/ocm/client.go
+++ b/pkg/ocm/client.go
@@ -87,6 +87,25 @@ func AuthenticateAsync(cfg *ocmconfig.Config) (string, error) {
 	return token, nil
 }
 
+// Connect checks OCM tokens and returns a connected client, running the
+// interactive browser authentication flow when tokens are expired. It blocks
+// until authentication completes, so callers must run it off the UI thread
+// (e.g. inside a tea.Cmd).
+func Connect(agentVersion string) (*Client, error) {
+	cfg, armed, err := CheckTokens()
+	if err != nil {
+		return nil, fmt.Errorf("OCM config check failed: %w", err)
+	}
+	if !armed {
+		token, authErr := AuthenticateAsync(cfg)
+		if authErr != nil {
+			return nil, fmt.Errorf("OCM authentication failed: %w", authErr)
+		}
+		ApplyAuthToken(cfg, token)
+	}
+	return NewClientFromConfig(cfg, agentVersion)
+}
+
 // ApplyAuthToken classifies a raw auth token and sets the appropriate
 // field on the OCM config (RefreshToken or AccessToken).
 func ApplyAuthToken(cfg *ocmconfig.Config, token string) {

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -1500,6 +1500,53 @@ type OCMClientReadyMsg struct {
 	Err    error
 }
 
+// connectOCMCmdIfNeeded returns a command that connects OCM after the config
+// wizard exits into a live session, so cluster enrichment works exactly like
+// a normal launch. OCM auth is deliberately skipped while the wizard runs
+// (OB-6); this is the follow-through that keeps the first session fully
+// functional. Returns nil when OCM is already connected or in dev mode. The
+// connection (including browser auth for expired tokens) blocks inside the
+// tea.Cmd goroutine, and the result flows through the existing
+// OCMClientReadyMsg handler (client, deferred backplane, enrichment).
+func (m model) connectOCMCmdIfNeeded() tea.Cmd {
+	if m.ocmClient != nil || m.devMode {
+		return nil
+	}
+	connect := m.ocmConnect
+	if connect == nil {
+		connect = func() (ocm.OCMClient, error) {
+			client, err := ocm.Connect(Version)
+			if err != nil {
+				return nil, err
+			}
+			return client, nil
+		}
+	}
+	return func() tea.Msg {
+		client, err := connect()
+		if err != nil || client == nil {
+			return OCMClientReadyMsg{Err: err}
+		}
+		return OCMClientReadyMsg{Client: client}
+	}
+}
+
+// ocmHandoffCmd wraps connectOCMCmdIfNeeded for the wizard-exit paths,
+// setting ocmAuthPending so the UI reflects the in-flight connection. When
+// requirePDConfig is true (discard/no-changes/abort paths), the handoff only
+// happens if a usable PD config exists — a brand-new user backing out of the
+// wizard must not get a browser-auth prompt on the way out.
+func (m *model) ocmHandoffCmd(requirePDConfig bool) tea.Cmd {
+	if requirePDConfig && (m.config == nil || m.config.Client == nil) {
+		return nil
+	}
+	cmd := m.connectOCMCmdIfNeeded()
+	if cmd != nil {
+		m.ocmAuthPending = true
+	}
+	return cmd
+}
+
 type pdClientInitializedMsg struct {
 	config *pd.Config
 	err    error

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -1233,19 +1233,6 @@ func getIDsFromIncidents(incidents []pagerduty.Incident) []string {
 	return ids
 }
 
-func hasPlaceholderTeamsCfg(teams []string) bool {
-	if len(teams) == 0 {
-		return true
-	}
-	for _, team := range teams {
-		trimmed := strings.TrimSpace(team)
-		if trimmed != "" && !strings.HasPrefix(trimmed, "<PagerDuty Team ID") {
-			return false
-		}
-	}
-	return true
-}
-
 type fetchedTeamsMsg struct {
 	teams []pagerduty.Team
 	err   error

--- a/pkg/tui/config_ocm_handoff_test.go
+++ b/pkg/tui/config_ocm_handoff_test.go
@@ -1,0 +1,121 @@
+package tui
+
+import (
+	"fmt"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/huh"
+	"github.com/clcollins/srepd/pkg/ocm"
+	"github.com/stretchr/testify/assert"
+)
+
+// OB-6 follow-through: OCM auth is skipped while the config wizard runs, but
+// the session that continues after the wizard must get OCM enrichment exactly
+// like a normal launch — otherwise first-run users see a degraded srepd and
+// never come back.
+
+func TestConnectOCMCmdIfNeeded_ReturnsCmdWhenNoClient(t *testing.T) {
+	mock := createMockOCMClient()
+	m := createConfigTestModel()
+	m.ocmClient = nil
+	m.ocmConnect = func() (ocm.OCMClient, error) { return mock, nil }
+
+	cmd := m.connectOCMCmdIfNeeded()
+
+	assert.NotNil(t, cmd, "should return a connect command when no OCM client exists")
+	msg := cmd()
+	ready, ok := msg.(OCMClientReadyMsg)
+	assert.True(t, ok, "command must produce OCMClientReadyMsg, got %T", msg)
+	assert.NoError(t, ready.Err)
+	assert.Equal(t, ocm.OCMClient(mock), ready.Client)
+}
+
+func TestConnectOCMCmdIfNeeded_NilWhenClientPresent(t *testing.T) {
+	m := createConfigTestModel()
+	m.ocmClient = createMockOCMClient()
+
+	assert.Nil(t, m.connectOCMCmdIfNeeded(), "must not reconnect when OCM client already exists")
+}
+
+func TestConnectOCMCmdIfNeeded_NilInDevMode(t *testing.T) {
+	m := createConfigTestModel()
+	m.ocmClient = nil
+	m.devMode = true
+
+	assert.Nil(t, m.connectOCMCmdIfNeeded(), "dev mode must not attempt OCM connections")
+}
+
+func TestConnectOCMCmdIfNeeded_ErrorProducesErrMsg(t *testing.T) {
+	m := createConfigTestModel()
+	m.ocmClient = nil
+	m.ocmConnect = func() (ocm.OCMClient, error) { return nil, fmt.Errorf("auth cancelled") }
+
+	cmd := m.connectOCMCmdIfNeeded()
+	assert.NotNil(t, cmd)
+
+	msg := cmd()
+	ready, ok := msg.(OCMClientReadyMsg)
+	assert.True(t, ok, "command must produce OCMClientReadyMsg, got %T", msg)
+	assert.Error(t, ready.Err)
+	assert.Nil(t, ready.Client)
+}
+
+// Saving the wizard must queue the OCM connect alongside PD init, flagged via
+// ocmAuthPending so the UI reflects the in-flight connection.
+func TestConfigSaved_TriggersOCMConnect(t *testing.T) {
+	mock := createMockOCMClient()
+	m := createConfigTestModel()
+	m.ocmClient = nil
+	m.ocmConnect = func() (ocm.OCMClient, error) { return mock, nil }
+
+	result, cmd := m.Update(configSavedMsg{err: nil})
+	updated := result.(model)
+
+	assert.NotNil(t, cmd)
+	assert.True(t, updated.ocmAuthPending, "OCM connect must be queued after config save")
+}
+
+func TestConfigSaved_NoOCMConnectWhenAlreadyConnected(t *testing.T) {
+	m := createConfigTestModel()
+	m.ocmClient = createMockOCMClient()
+
+	result, cmd := m.Update(configSavedMsg{err: nil})
+	updated := result.(model)
+
+	assert.NotNil(t, cmd, "PD init must still be dispatched")
+	assert.False(t, updated.ocmAuthPending, "no OCM connect when a client already exists")
+}
+
+func TestConfigSaved_NoOCMConnectOnSaveError(t *testing.T) {
+	m := createConfigTestModel()
+	m.ocmClient = nil
+	m.ocmConnect = func() (ocm.OCMClient, error) { return createMockOCMClient(), nil }
+
+	result, _ := m.Update(configSavedMsg{err: fmt.Errorf("disk full")})
+	updated := result.(model)
+
+	assert.False(t, updated.ocmAuthPending, "failed save must not trigger OCM connect")
+}
+
+// A brand-new user aborting the wizard has no usable session — do not pop
+// browser auth at them on the way out.
+func TestConfigAborted_NoOCMConnectWithoutPDConfig(t *testing.T) {
+	m := createConfigTestModel()
+	m.configMode = true
+	m.ocmClient = nil
+	m.config = nil
+	m.ocmConnect = func() (ocm.OCMClient, error) { return createMockOCMClient(), nil }
+
+	form := huh.NewForm(huh.NewGroup(huh.NewNote().Title("test")))
+	form.Init()
+	form.State = huh.StateAborted
+	m.configForm = form
+
+	result, cmd := switchConfigFocusMode(m, tea.KeyMsg{Type: tea.KeyEscape})
+	updated := result.(model)
+
+	assert.False(t, updated.configMode)
+	assert.Nil(t, cmd)
+	assert.False(t, updated.ocmAuthPending, "abort without a PD config must not connect OCM")
+}

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -199,8 +199,11 @@ type model struct {
 	configWizardPending *configWizardReadyMsg
 
 	// OCM enrichment state
-	ocmClient             ocm.OCMClient
-	ocmAuthPending        bool
+	ocmClient      ocm.OCMClient
+	ocmAuthPending bool
+	// ocmConnect overrides the post-wizard OCM connection for tests; nil
+	// means the real ocm.Connect (which may run browser auth).
+	ocmConnect            func() (ocm.OCMClient, error)
 	incidentClusterMap    map[string][]string // incident ID → cluster IDs
 	clusterEnrichInFlight map[string]bool     // cluster IDs currently being enriched
 	clusterEnrichFailed   map[string]int      // failure count per cluster ID

--- a/pkg/tui/mouse.go
+++ b/pkg/tui/mouse.go
@@ -1,0 +1,63 @@
+package tui
+
+import tea "github.com/charmbracelet/bubbletea"
+
+// mouseWatcherStartY returns the Y coordinate where the watcher pane begins.
+// This is computed from the current layout so it stays correct after window resizes.
+// The -4 adjustment accounts for style padding that the layout constants don't capture.
+func (m model) mouseWatcherStartY() int {
+	containerVOverhead := m.styles.TableContainer.GetVerticalBorderSize() +
+		m.styles.TableContainer.GetVerticalPadding() +
+		m.styles.TableContainer.GetVerticalMargins()
+
+	return layoutHeaderLines + containerVOverhead + m.layout.TableHeight + layoutFooterLines + layoutFooterNewline - 4
+}
+
+// handleMouseMsg routes mouse events to the correct component based on the
+// current view mode and the mouse Y position within the window.
+//
+// For non-table views (incident viewer, log viewer, and any future views),
+// mouse events are forwarded unconditionally to the active viewport via the
+// focus-mode dispatch so new views get mouse scroll for free.
+//
+// For the main table view, Y coordinates determine whether the event targets
+// the incident table or the watcher pane.
+func (m model) handleMouseMsg(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	if msg.Button != tea.MouseButtonWheelUp && msg.Button != tea.MouseButtonWheelDown {
+		return m, nil
+	}
+
+	switch {
+	case m.viewingIncident:
+		m.incidentViewer, _ = m.incidentViewer.Update(msg)
+		return m, nil
+
+	case m.viewingLog:
+		m.logViewer, _ = m.logViewer.Update(msg)
+		return m, nil
+
+	case m.configMode, m.bulkSilenceMode, m.teamSelectMode, m.clusterSelectMode, m.mergeMode:
+		return m, nil
+
+	default:
+		return m.handleMouseScrollMainView(msg)
+	}
+}
+
+// handleMouseScrollMainView routes wheel events on the main table+watcher screen.
+func (m model) handleMouseScrollMainView(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	if m.watcherExpanded && msg.Y >= m.mouseWatcherStartY() {
+		var cmd tea.Cmd
+		m.watcherViewport, cmd = m.watcherViewport.Update(msg)
+		return m, cmd
+	}
+
+	switch msg.Button {
+	case tea.MouseButtonWheelDown:
+		m.table.MoveDown(1)
+	case tea.MouseButtonWheelUp:
+		m.table.MoveUp(1)
+	}
+	cmd := m.syncSelectedIncidentToHighlightedRow()
+	return m, cmd
+}

--- a/pkg/tui/mouse_scroll_test.go
+++ b/pkg/tui/mouse_scroll_test.go
@@ -1,0 +1,325 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/PagerDuty/go-pagerduty"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+)
+
+func setupMouseTestModel(incidents []pagerduty.Incident) model {
+	m := createTestModelWithTable(incidents)
+	m.help = newHelp()
+	windowSize = tea.WindowSizeMsg{Width: 80, Height: 60}
+	m.recomputeLayout()
+	m.table.Focus()
+	return m
+}
+
+func testIncidents() []pagerduty.Incident {
+	return []pagerduty.Incident{
+		{
+			APIObject:          pagerduty.APIObject{ID: "Q001"},
+			Title:              "Incident 1",
+			Service:            pagerduty.APIObject{Summary: "svc-1"},
+			LastStatusChangeAt: "2024-01-01T00:00:00Z",
+		},
+		{
+			APIObject:          pagerduty.APIObject{ID: "Q002"},
+			Title:              "Incident 2",
+			Service:            pagerduty.APIObject{Summary: "svc-2"},
+			LastStatusChangeAt: "2024-01-01T00:00:00Z",
+		},
+		{
+			APIObject:          pagerduty.APIObject{ID: "Q003"},
+			Title:              "Incident 3",
+			Service:            pagerduty.APIObject{Summary: "svc-3"},
+			LastStatusChangeAt: "2024-01-01T00:00:00Z",
+		},
+	}
+}
+
+func TestMouseScroll_TableScrollDown(t *testing.T) {
+	t.Run("wheel down on table area moves cursor down", func(t *testing.T) {
+		m := setupMouseTestModel(testIncidents())
+
+		// Table cursor starts at row 0
+		assert.Equal(t, 0, m.table.Cursor())
+
+		msg := tea.MouseMsg{
+			X:      10,
+			Y:      5, // within table area
+			Action: tea.MouseActionPress,
+			Button: tea.MouseButtonWheelDown,
+		}
+		result, _ := m.Update(msg)
+		updated := result.(model)
+
+		assert.Equal(t, 1, updated.table.Cursor())
+	})
+}
+
+func TestMouseScroll_TableScrollUp(t *testing.T) {
+	t.Run("wheel up on table area moves cursor up", func(t *testing.T) {
+		m := setupMouseTestModel(testIncidents())
+
+		// Move to row 2 first
+		m.table.MoveDown(2)
+		assert.Equal(t, 2, m.table.Cursor())
+
+		msg := tea.MouseMsg{
+			X:      10,
+			Y:      5, // within table area
+			Action: tea.MouseActionPress,
+			Button: tea.MouseButtonWheelUp,
+		}
+		result, _ := m.Update(msg)
+		updated := result.(model)
+
+		assert.Equal(t, 1, updated.table.Cursor())
+	})
+}
+
+func TestMouseScroll_TableScrollUpAtTop(t *testing.T) {
+	t.Run("wheel up at top of table stays at row 0", func(t *testing.T) {
+		m := setupMouseTestModel(testIncidents())
+		assert.Equal(t, 0, m.table.Cursor())
+
+		msg := tea.MouseMsg{
+			X:      10,
+			Y:      5,
+			Action: tea.MouseActionPress,
+			Button: tea.MouseButtonWheelUp,
+		}
+		result, _ := m.Update(msg)
+		updated := result.(model)
+
+		assert.Equal(t, 0, updated.table.Cursor())
+	})
+}
+
+func TestMouseScroll_WatcherExpandedScrollWatcher(t *testing.T) {
+	t.Run("wheel down in watcher area scrolls watcher viewport", func(t *testing.T) {
+		m := setupMouseTestModel(testIncidents())
+		m.watcherExpanded = true
+		m.recomputeLayout()
+		m.watcherViewport.Width = m.layout.WatcherWidth
+		m.watcherViewport.Height = m.layout.WatcherHeight
+
+		lines := ""
+		for i := 0; i < 50; i++ {
+			lines += "line\n"
+		}
+		m.watcherViewport.SetContent(lines)
+
+		// Y coordinate in watcher area: after table + footer + newline
+		watcherY := m.mouseWatcherStartY()
+
+		msg := tea.MouseMsg{
+			X:      10,
+			Y:      watcherY + 2,
+			Action: tea.MouseActionPress,
+			Button: tea.MouseButtonWheelDown,
+		}
+		result, _ := m.Update(msg)
+		updated := result.(model)
+
+		assert.Greater(t, updated.watcherViewport.YOffset, 0)
+	})
+}
+
+func TestMouseScroll_WatcherExpandedScrollTable(t *testing.T) {
+	t.Run("wheel down in table area scrolls table even when watcher expanded", func(t *testing.T) {
+		m := setupMouseTestModel(testIncidents())
+		m.watcherExpanded = true
+		m.recomputeLayout()
+		m.watcherViewport.Width = m.layout.WatcherWidth
+		m.watcherViewport.Height = m.layout.WatcherHeight
+
+		assert.Equal(t, 0, m.table.Cursor())
+
+		msg := tea.MouseMsg{
+			X:      10,
+			Y:      5, // within table area
+			Action: tea.MouseActionPress,
+			Button: tea.MouseButtonWheelDown,
+		}
+		result, _ := m.Update(msg)
+		updated := result.(model)
+
+		assert.Equal(t, 1, updated.table.Cursor())
+	})
+}
+
+func TestMouseScroll_WatcherCollapsedScrollTable(t *testing.T) {
+	t.Run("wheel down scrolls table when watcher collapsed", func(t *testing.T) {
+		m := setupMouseTestModel(testIncidents())
+		m.watcherExpanded = false
+		m.recomputeLayout()
+
+		assert.Equal(t, 0, m.table.Cursor())
+
+		msg := tea.MouseMsg{
+			X:      10,
+			Y:      5,
+			Action: tea.MouseActionPress,
+			Button: tea.MouseButtonWheelDown,
+		}
+		result, _ := m.Update(msg)
+		updated := result.(model)
+
+		assert.Equal(t, 1, updated.table.Cursor())
+	})
+}
+
+func TestMouseScroll_IncidentViewForwardsToViewport(t *testing.T) {
+	t.Run("mouse scroll in incident view forwards to incidentViewer", func(t *testing.T) {
+		m := setupMouseTestModel(testIncidents())
+		m.viewingIncident = true
+
+		lines := ""
+		for i := 0; i < 100; i++ {
+			lines += "line\n"
+		}
+		m.incidentViewer.Width = m.layout.IncidentViewerWidth
+		m.incidentViewer.Height = m.layout.IncidentViewerHeight
+		m.incidentViewer.SetContent(lines)
+
+		msg := tea.MouseMsg{
+			X:      10,
+			Y:      10,
+			Action: tea.MouseActionPress,
+			Button: tea.MouseButtonWheelDown,
+		}
+		result, _ := m.Update(msg)
+		updated := result.(model)
+
+		assert.Greater(t, updated.incidentViewer.YOffset, 0)
+	})
+}
+
+func TestMouseScroll_LogViewForwardsToViewport(t *testing.T) {
+	t.Run("mouse scroll in log view forwards to logViewer", func(t *testing.T) {
+		m := setupMouseTestModel(testIncidents())
+		m.viewingLog = true
+
+		lines := ""
+		for i := 0; i < 100; i++ {
+			lines += "line\n"
+		}
+		m.logViewer.Width = m.layout.IncidentViewerWidth
+		m.logViewer.Height = m.layout.IncidentViewerHeight
+		m.logViewer.SetContent(lines)
+
+		msg := tea.MouseMsg{
+			X:      10,
+			Y:      10,
+			Action: tea.MouseActionPress,
+			Button: tea.MouseButtonWheelDown,
+		}
+		result, _ := m.Update(msg)
+		updated := result.(model)
+
+		assert.Greater(t, updated.logViewer.YOffset, 0)
+	})
+}
+
+func TestMouseScroll_NonWheelEventsAreNoOps(t *testing.T) {
+	t.Run("non-wheel mouse events return nil cmd on main view", func(t *testing.T) {
+		m := setupMouseTestModel(testIncidents())
+
+		msg := tea.MouseMsg{
+			X:      10,
+			Y:      5,
+			Action: tea.MouseActionPress,
+			Button: tea.MouseButtonLeft,
+		}
+		result, cmd := m.Update(msg)
+		updated := result.(model)
+
+		assert.Equal(t, 0, updated.table.Cursor())
+		assert.Nil(t, cmd)
+	})
+}
+
+func TestMouseScroll_AfterWindowResize(t *testing.T) {
+	t.Run("scroll routing adapts after window resize", func(t *testing.T) {
+		m := setupMouseTestModel(testIncidents())
+		m.watcherExpanded = true
+		m.recomputeLayout()
+		m.watcherViewport.Width = m.layout.WatcherWidth
+		m.watcherViewport.Height = m.layout.WatcherHeight
+
+		lines := ""
+		for i := 0; i < 50; i++ {
+			lines += "line\n"
+		}
+		m.watcherViewport.SetContent(lines)
+
+		// Record watcher start Y before resize
+		watcherYBefore := m.mouseWatcherStartY()
+
+		// Resize the window
+		windowSize = tea.WindowSizeMsg{Width: 80, Height: 40}
+		m.recomputeLayout()
+		m.watcherViewport.Width = m.layout.WatcherWidth
+		m.watcherViewport.Height = m.layout.WatcherHeight
+
+		watcherYAfter := m.mouseWatcherStartY()
+
+		// The boundary should have changed with the resize
+		assert.NotEqual(t, watcherYBefore, watcherYAfter)
+
+		// Scrolling in the new table area should still move the table
+		assert.Equal(t, 0, m.table.Cursor())
+		msg := tea.MouseMsg{
+			X:      10,
+			Y:      5,
+			Action: tea.MouseActionPress,
+			Button: tea.MouseButtonWheelDown,
+		}
+		result, _ := m.Update(msg)
+		updated := result.(model)
+		assert.Equal(t, 1, updated.table.Cursor())
+	})
+}
+
+func TestMouseScroll_SyncsSelectedIncident(t *testing.T) {
+	t.Run("scrolling table via mouse syncs selectedIncident", func(t *testing.T) {
+		m := setupMouseTestModel(testIncidents())
+
+		// Sync initial selection
+		m.syncSelectedIncidentToHighlightedRow()
+		assert.Equal(t, "Q001", m.selectedIncident.ID)
+
+		msg := tea.MouseMsg{
+			X:      10,
+			Y:      5,
+			Action: tea.MouseActionPress,
+			Button: tea.MouseButtonWheelDown,
+		}
+		result, cmd := m.Update(msg)
+		updated := result.(model)
+
+		assert.Equal(t, 1, updated.table.Cursor())
+		// Mouse scroll should trigger sync (returns a cmd for pre-fetch)
+		assert.NotNil(t, cmd)
+	})
+}
+
+func TestMouseWatcherStartY(t *testing.T) {
+	t.Run("returns correct boundary between table and watcher", func(t *testing.T) {
+		m := setupMouseTestModel(testIncidents())
+		m.watcherExpanded = true
+		m.recomputeLayout()
+
+		containerVOverhead := m.styles.TableContainer.GetVerticalBorderSize() +
+			m.styles.TableContainer.GetVerticalPadding() +
+			m.styles.TableContainer.GetVerticalMargins()
+
+		// Header (2) + table container overhead + table height + footer (1) + newline (1) - 4 adjustment
+		expected := layoutHeaderLines + containerVOverhead + m.layout.TableHeight + layoutFooterLines + layoutFooterNewline - 4
+		assert.Equal(t, expected, m.mouseWatcherStartY())
+	})
+}

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -306,7 +306,11 @@ func switchConfigFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		if !m.configState.Confirm {
 			m.setStatus("config changes discarded")
-			return m, func() tea.Msg { return updateIncidentListMsg("config discarded") }
+			cmds := []tea.Cmd{func() tea.Msg { return updateIncidentListMsg("config discarded") }}
+			if ocmCmd := m.ocmHandoffCmd(true); ocmCmd != nil {
+				cmds = append(cmds, ocmCmd)
+			}
+			return m, tea.Batch(cmds...)
 		}
 
 		final, err := pkgconfig.ResolveFinalValues(m.configExisting, pkgconfig.WizardInputs{
@@ -341,7 +345,11 @@ func switchConfigFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		if !changes.AnyChanged() {
 			m.setStatus("config is valid, no changes needed")
-			return m, func() tea.Msg { return updateIncidentListMsg("config unchanged") }
+			cmds := []tea.Cmd{func() tea.Msg { return updateIncidentListMsg("config unchanged") }}
+			if ocmCmd := m.ocmHandoffCmd(true); ocmCmd != nil {
+				cmds = append(cmds, ocmCmd)
+			}
+			return m, tea.Batch(cmds...)
 		}
 
 		teamNames := make(map[string]string)
@@ -375,7 +383,7 @@ func switchConfigFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.configModeRequested = false
 		m.table.Focus()
 		m.setStatus("config cancelled")
-		return m, nil
+		return m, m.ocmHandoffCmd(true)
 	}
 	return m, cmd
 }

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -53,7 +53,7 @@ func (m model) Init() tea.Cmd {
 		checkForUpdate(m.devMode, ""),
 	}
 
-	if m.config != nil && m.config.Client != nil && hasPlaceholderTeamsCfg(viper.GetStringSlice("teams")) {
+	if m.config != nil && m.config.Client != nil && pkgconfig.HasPlaceholderTeams(viper.GetStringSlice("teams")) {
 		initCmds = append(initCmds, fetchUserTeams(m.config.Client))
 	}
 

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -351,7 +351,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.setStatus("config saved — initializing...")
 		m.table.Focus()
-		return m, initPDClientCmd()
+		cmds := []tea.Cmd{initPDClientCmd()}
+		if ocmCmd := m.ocmHandoffCmd(false); ocmCmd != nil {
+			cmds = append(cmds, ocmCmd)
+		}
+		return m, tea.Batch(cmds...)
 
 	case pdClientInitializedMsg:
 		if msg.err != nil {

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -633,12 +633,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.windowSizeMsgHandler(msg)
 
 	case tea.MouseMsg:
-		if m.watcherExpanded {
-			var cmd tea.Cmd
-			m.watcherViewport, cmd = m.watcherViewport.Update(msg)
-			return m, cmd
-		}
-		return m, nil
+		return m.handleMouseMsg(msg)
 
 	case tea.KeyMsg:
 		return m.keyMsgHandler(msg)


### PR DESCRIPTION
> **Stacked on #363** — review/merge that first; GitHub will retarget this to `main` automatically. Part of the onboarding overhaul (#353, #324).

## Problem

`launchTUIWithConfig()` — the wizard entry point — ran the same OCM startup as a normal launch. A brand-new user running `srepd config` (or hitting the first-run wizard) saw "OCM tokens expired — opening browser for authentication..." and OCM warnings **before they had even saved a PagerDuty token**.

Closes OB-6 of #353.

## Design: defer, don't drop

The wizard itself is OCM-free, and the session that continues after the wizard connects OCM **exactly like a normal launch** — a first-run user must not get a degraded (enrichment-less) srepd on their very first session.

## Changes

- **`cmd/config.go`**: `launchTUIWithConfig()` no longer checks OCM tokens or spawns the browser-auth goroutine; passes `nil`/`false` to the model.
- **`cmd/root.go`**: the (previously duplicated) OCM startup extracted into `setupOCM()`; `launchTUI()` is its only caller, behavior unchanged.
- **`pkg/ocm`**: new `Connect(agentVersion)` — token check → browser auth if expired → connect; blocking, for use inside a `tea.Cmd`.
- **`pkg/tui`**: post-wizard OCM handoff. `connectOCMCmdIfNeeded()` feeds the existing `OCMClientReadyMsg` handler (which already wires client + deferred backplane + cluster enrichment). Wired into **all four** wizard-exit paths — save, no-changes, discard, cancel. The non-save paths require an existing PD config, so a brand-new user backing out never gets a browser popup on the way out. `ocmAuthPending` reflects the in-flight connect; dev mode never connects. Injectable `model.ocmConnect` seam for tests.

## Tests (TDD)

- `pkg/tui/config_ocm_handoff_test.go` — 8 tests with a mock OCM client: connect queued after save; not queued when already connected / save failed / dev mode; errors surface via `OCMClientReadyMsg.Err`; abort-without-config performs no handoff.
- `cmd/config_ocm_test.go` — source-scan guards: no OCM auth references may reappear in `cmd/config.go`; `setupOCM` is the single `ocm.CheckTokens` call site.
- Full suite, `-race`, `golangci-lint` green.

## Plan doc

`docs/plans/363-config-mode-no-ocm.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BtcSJfWWcDKL4rSNNH1cN