### PR TITLE
Classify wizard API errors into actionable messages (OB-3)

### DIFF
--- a/docs/plans/365-classified-api-errors.md
+++ b/docs/plans/365-classified-api-errors.md
@@ -1,0 +1,47 @@
+# 365: Classified API errors in the config wizard (OB-3)
+
+Issue: #353 (OB-3), part of the onboarding overhaul (#353, #324)
+Branch: `srepd/classified-api-errors`
+
+## Problem
+
+When the wizard's live PagerDuty calls failed, the raw Go error was dumped at
+the user: the token step said `invalid token: HTTP response with status code
+401...` and the team multiselect rendered `Error: <err>` as a *selectable
+option*, with no distinction between an auth problem (fix your token), a rate
+limit (wait), or a network problem (check VPN).
+
+## Approach
+
+- **`pd.ClassifyAPIError(err) string`** (pkg/pd/classify.go): unwraps
+  `pagerduty.APIError` — 401 → "invalid or expired token — create one at
+  <token help path>", 403 → permissions + help path, 429 → rate limited;
+  `context.DeadlineExceeded` / `net.Error` → network/VPN guidance; unknown
+  errors pass through; nil → "". Works on wrapped errors via
+  `errors.As`/`errors.Is`. The token help path (PagerDuty web → My Profile →
+  User Settings → API Access) now lives in one const.
+- **Wizard closures extracted into testable functions** (pkg/tui/tui.go):
+  - `validateTokenInput(clientFactory, input, existingToken)` — token step
+    validation, classified errors.
+  - `fetchTeamOptions(clientFactory, tokenInput, existingToken,
+    existingTeamSet)` — team options; placeholder/error states return a
+    single empty-valued option carrying the classified message.
+  - `validateTeamValues(values)` — rejects empty selection AND the
+    empty-valued placeholder/error options, with recovery guidance
+    ("shift+tab to go back").
+  `buildConfigForm`'s closures now delegate to these.
+
+Timeouts: all `pd.*` helpers (including `GetCurrentUserTeams`) already run
+through `contextWithTimeout()`, so a hung network cannot freeze the form's
+synchronous `Validate` indefinitely — no additional timeout plumbing needed.
+
+## Tests (TDD — written first)
+
+- `pkg/pd/classify_test.go`: table for nil / 401 / 403 / 429 / wrapped API
+  error / deadline / wrapped deadline / net.Error / unknown; 401 must include
+  the token acquisition path.
+- `pkg/tui/config_token_validation_test.go`: token validation via mock client
+  factory (blank-with-existing OK, blank-without required, valid OK, 401
+  classified); team options (no-token prompt, success with preselection,
+  classified error option with empty value); team-values validation rejects
+  the placeholder and names the recovery key.

--- a/pkg/pd/classify.go
+++ b/pkg/pd/classify.go
@@ -1,0 +1,45 @@
+package pd
+
+import (
+	"context"
+	"errors"
+	"net"
+
+	"github.com/PagerDuty/go-pagerduty"
+)
+
+// tokenHelpPath tells the user where to create a PagerDuty User Token; it is
+// surfaced whenever an auth failure is classified.
+const tokenHelpPath = "PagerDuty web → My Profile → User Settings → API Access → Create New API User Token"
+
+// ClassifyAPIError maps an error from a PagerDuty API call to a short,
+// actionable message for the UI: auth failures point at token acquisition,
+// rate limits say to wait, network failures say to check connectivity/VPN.
+// Unrecognized errors pass through unchanged. Returns "" for nil.
+func ClassifyAPIError(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	var apiErr pagerduty.APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.StatusCode {
+		case 401:
+			return "invalid or expired token — create one at " + tokenHelpPath
+		case 403:
+			return "token lacks permission — ensure it is a User Token created at " + tokenHelpPath
+		case 429:
+			return "rate limited by PagerDuty — wait a moment and try again"
+		}
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "network timeout — check connectivity and VPN"
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return "network problem — check connectivity and VPN (" + err.Error() + ")"
+	}
+
+	return err.Error()
+}

--- a/pkg/pd/classify_test.go
+++ b/pkg/pd/classify_test.go
@@ -1,0 +1,94 @@
+package pd
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/PagerDuty/go-pagerduty"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeNetError struct{}
+
+func (fakeNetError) Error() string   { return "dial tcp: connection refused" }
+func (fakeNetError) Timeout() bool   { return false }
+func (fakeNetError) Temporary() bool { return true }
+
+var _ net.Error = fakeNetError{}
+
+// OB-3: wizard/API errors must be classified into actionable messages, not
+// dumped raw. A 401 is a token problem, a timeout is a VPN problem — the
+// user should not have to reverse-engineer which.
+func TestClassifyAPIError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		contains string
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			contains: "",
+		},
+		{
+			name:     "401 unauthorized is a token problem",
+			err:      pagerduty.APIError{StatusCode: 401},
+			contains: "invalid or expired token",
+		},
+		{
+			name:     "403 forbidden is a permissions problem",
+			err:      pagerduty.APIError{StatusCode: 403},
+			contains: "permission",
+		},
+		{
+			name:     "429 is rate limiting",
+			err:      pagerduty.APIError{StatusCode: 429},
+			contains: "rate limited",
+		},
+		{
+			name:     "wrapped API error still classifies",
+			err:      fmt.Errorf("fetching teams: %w", pagerduty.APIError{StatusCode: 401}),
+			contains: "invalid or expired token",
+		},
+		{
+			name:     "context deadline is a network problem",
+			err:      context.DeadlineExceeded,
+			contains: "network",
+		},
+		{
+			name:     "wrapped deadline classifies",
+			err:      fmt.Errorf("call failed: %w", context.DeadlineExceeded),
+			contains: "network",
+		},
+		{
+			name:     "net.Error is a network problem",
+			err:      fakeNetError{},
+			contains: "network",
+		},
+		{
+			name:     "unknown errors pass through",
+			err:      fmt.Errorf("something odd happened"),
+			contains: "something odd happened",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := ClassifyAPIError(tt.err)
+			if tt.contains == "" {
+				assert.Empty(t, msg)
+				return
+			}
+			assert.Contains(t, msg, tt.contains)
+		})
+	}
+}
+
+// The 401 message must tell the user where to get a token — that help
+// currently only exists deep in the wizard.
+func TestClassifyAPIError_TokenHelpPath(t *testing.T) {
+	msg := ClassifyAPIError(pagerduty.APIError{StatusCode: 401})
+	assert.Contains(t, msg, "User Settings")
+}

--- a/pkg/tui/config_token_validation_test.go
+++ b/pkg/tui/config_token_validation_test.go
@@ -1,0 +1,79 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/PagerDuty/go-pagerduty"
+	"github.com/clcollins/srepd/pkg/pd"
+	"github.com/stretchr/testify/assert"
+)
+
+func mockFactoryWithErr(err error) func(string) pd.PagerDutyClient {
+	return func(string) pd.PagerDutyClient {
+		return &pd.MockPagerDutyClient{GetCurrentUserErr: err}
+	}
+}
+
+func mockFactoryOK() func(string) pd.PagerDutyClient {
+	return func(string) pd.PagerDutyClient { return &pd.MockPagerDutyClient{} }
+}
+
+func TestValidateTokenInput_EmptyWithExistingToken(t *testing.T) {
+	err := validateTokenInput(mockFactoryOK(), "", "existing-token")
+	assert.NoError(t, err, "blank input keeps the existing token")
+}
+
+func TestValidateTokenInput_EmptyWithoutExistingToken(t *testing.T) {
+	err := validateTokenInput(mockFactoryOK(), "  ", "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "required")
+}
+
+func TestValidateTokenInput_ValidToken(t *testing.T) {
+	err := validateTokenInput(mockFactoryOK(), "u+goodtoken", "")
+	assert.NoError(t, err)
+}
+
+// OB-3: a 401 must be reported as a token problem with acquisition help, not
+// a raw API dump.
+func TestValidateTokenInput_Classifies401(t *testing.T) {
+	err := validateTokenInput(mockFactoryWithErr(pagerduty.APIError{StatusCode: 401}), "u+badtoken", "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid or expired token")
+}
+
+func TestFetchTeamOptions_NoTokenPrompts(t *testing.T) {
+	opts, teams := fetchTeamOptions(mockFactoryOK(), "", "", nil)
+	assert.Nil(t, teams)
+	assert.Len(t, opts, 1)
+	assert.Contains(t, opts[0].Key, "enter a token first")
+}
+
+func TestFetchTeamOptions_Success(t *testing.T) {
+	opts, teams := fetchTeamOptions(mockFactoryOK(), "u+goodtoken", "", map[string]bool{"TEAM_002": true})
+	assert.Len(t, teams, 2, "mock returns two teams")
+	assert.Len(t, opts, 2)
+	assert.Contains(t, opts[0].Key, "Mock Team Alpha")
+}
+
+// OB-3: the error option must carry the classified message, and its value
+// must be empty so validation can reject it.
+func TestFetchTeamOptions_ClassifiedErrorOption(t *testing.T) {
+	opts, teams := fetchTeamOptions(mockFactoryWithErr(pagerduty.APIError{StatusCode: 429}), "u+token", "", nil)
+	assert.Nil(t, teams)
+	assert.Len(t, opts, 1)
+	assert.Contains(t, opts[0].Key, "rate limited")
+	assert.Equal(t, "", opts[0].Value)
+}
+
+func TestValidateTeamValues(t *testing.T) {
+	assert.Error(t, validateTeamValues(nil), "no teams selected")
+	assert.Error(t, validateTeamValues([]string{""}),
+		"selecting the error/prompt placeholder must be rejected")
+	assert.NoError(t, validateTeamValues([]string{"TEAM_001"}))
+}
+
+func TestValidateTeamValues_ErrorMentionsRecovery(t *testing.T) {
+	err := validateTeamValues([]string{""})
+	assert.Contains(t, err.Error(), "shift+tab", "error must tell the user how to go back and fix the token")
+}

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -1914,6 +1914,67 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 }
 
+// validateTokenInput validates the wizard token input against the live API.
+// A blank input is allowed when an existing token will be kept. API errors
+// are classified into actionable messages (OB-3).
+func validateTokenInput(clientFactory func(string) pd.PagerDutyClient, input, existingToken string) error {
+	token := strings.TrimSpace(input)
+	if token == "" {
+		if existingToken != "" {
+			return nil
+		}
+		return fmt.Errorf("a PagerDuty API token is required")
+	}
+	if _, err := pd.GetCurrentUserTeams(clientFactory(token)); err != nil {
+		return fmt.Errorf("invalid token: %s", pd.ClassifyAPIError(err))
+	}
+	return nil
+}
+
+// fetchTeamOptions builds the wizard team options for the current token.
+// Placeholder and error states are returned as a single empty-valued option
+// (rejected by validateTeamValues) carrying a classified message.
+func fetchTeamOptions(clientFactory func(string) pd.PagerDutyClient, tokenInput, existingToken string, existingTeamSet map[string]bool) ([]huh.Option[string], []pagerduty.Team) {
+	token := strings.TrimSpace(tokenInput)
+	if token == "" {
+		token = existingToken
+	}
+	if token == "" {
+		return []huh.Option[string]{huh.NewOption("(enter a token first)", "")}, nil
+	}
+
+	teams, err := pd.GetCurrentUserTeams(clientFactory(token))
+	if err != nil {
+		return []huh.Option[string]{
+			huh.NewOption("Error: "+pd.ClassifyAPIError(err), ""),
+		}, nil
+	}
+
+	var opts []huh.Option[string]
+	for _, team := range teams {
+		opt := huh.NewOption(fmt.Sprintf("%s — %s", team.Name, team.ID), team.ID)
+		if existingTeamSet[team.ID] {
+			opt = opt.Selected(true)
+		}
+		opts = append(opts, opt)
+	}
+	return opts, teams
+}
+
+// validateTeamValues rejects an empty selection and the empty-valued
+// placeholder/error options fetchTeamOptions emits.
+func validateTeamValues(s []string) error {
+	if len(s) == 0 {
+		return fmt.Errorf("at least one team is required")
+	}
+	for _, v := range s {
+		if v == "" {
+			return fmt.Errorf("fix the token above (shift+tab to go back), then choose a team")
+		}
+	}
+	return nil
+}
+
 func (m *model) buildConfigForm(msg configWizardReadyMsg, tokenDesc, keepTeamsDesc, keepSilentDesc, keepCustomDesc string, existingTeamSet map[string]bool) *huh.Form {
 	var fetchedTeams []pagerduty.Team
 	submitted := false
@@ -1942,19 +2003,7 @@ func (m *model) buildConfigForm(msg configWizardReadyMsg, tokenDesc, keepTeamsDe
 				EchoMode(huh.EchoModePassword).
 				Value(&m.configState.TokenInput).
 				Validate(func(s string) error {
-					token := strings.TrimSpace(s)
-					if token == "" {
-						if msg.existing.Token != "" {
-							return nil
-						}
-						return fmt.Errorf("a PagerDuty API token is required")
-					}
-					client := clientFactory(token)
-					_, err := pd.GetCurrentUserTeams(client)
-					if err != nil {
-						return fmt.Errorf("invalid token: %v", err)
-					}
-					return nil
+					return validateTokenInput(clientFactory, s, msg.existing.Token)
 				}),
 		),
 		huh.NewGroup(
@@ -1968,32 +2017,9 @@ func (m *model) buildConfigForm(msg configWizardReadyMsg, tokenDesc, keepTeamsDe
 				Title("Select your PagerDuty teams").
 				Description("Select the team(s) whose incidents you want to monitor. Most users only need one.").
 				OptionsFunc(func() []huh.Option[string] {
-					token := strings.TrimSpace(m.configState.TokenInput)
-					if token == "" {
-						token = msg.existing.Token
-					}
-					if token == "" {
-						return []huh.Option[string]{
-							huh.NewOption("(enter a token first)", ""),
-						}
-					}
-					client := clientFactory(token)
-					teams, err := pd.GetCurrentUserTeams(client)
-					if err != nil {
-						return []huh.Option[string]{
-							huh.NewOption(fmt.Sprintf("Error: %v", err), ""),
-						}
-					}
-					fetchedTeams = teams
-					var opts []huh.Option[string]
-					for _, team := range teams {
-						opt := huh.NewOption(
-							fmt.Sprintf("%s — %s", team.Name, team.ID), team.ID,
-						)
-						if existingTeamSet[team.ID] {
-							opt = opt.Selected(true)
-						}
-						opts = append(opts, opt)
+					opts, teams := fetchTeamOptions(clientFactory, m.configState.TokenInput, msg.existing.Token, existingTeamSet)
+					if teams != nil {
+						fetchedTeams = teams
 					}
 					return opts
 				}, &m.configState.TokenInput).
@@ -2003,10 +2029,7 @@ func (m *model) buildConfigForm(msg configWizardReadyMsg, tokenDesc, keepTeamsDe
 						submitted = true
 						return nil
 					}
-					if len(s) == 0 {
-						return fmt.Errorf("at least one team is required")
-					}
-					return nil
+					return validateTeamValues(s)
 				}),
 		).WithHideFunc(func() bool { return m.configState.KeepTeams }),
 		huh.NewGroup(


### PR DESCRIPTION
> **Stacked on #365** (← #364 ← #363). Review/merge in order; GitHub retargets automatically. Part of the onboarding overhaul (#353, #324).

## Problem

When the wizard's live PagerDuty calls failed, raw Go errors were dumped at the user: `invalid token: HTTP response with status code 401...`, and the team multiselect rendered `Error: <err>` as a **selectable option** — indistinguishable auth vs rate-limit vs network failures, and the error row could be "selected" as a team.

Closes OB-3 of #353.

## Changes

- **`pd.ClassifyAPIError(err) string`** — 401/403 → token problem with the acquisition path ("PagerDuty web → My Profile → User Settings → API Access"), 429 → rate limited, `net.Error`/deadline → check connectivity/VPN, unknown → pass through. Handles wrapped errors.
- **Wizard closures extracted into testable functions**: `validateTokenInput`, `fetchTeamOptions`, `validateTeamValues` — `buildConfigForm` now delegates. Selecting the empty-valued error/placeholder option is rejected with recovery guidance ("fix the token above — shift+tab to go back").
- Timeout note: all `pd.*` helpers already run through `contextWithTimeout()`, so the synchronous `Validate` can't hang indefinitely — no extra plumbing needed.

## Tests (TDD)

- `pkg/pd/classify_test.go` — classification table incl. wrapped errors and the token-help-path assertion
- `pkg/tui/config_token_validation_test.go` — token validation + team options + selection validation via mock client factory
- Full suite, `-race`, lint green

## Plan doc

`docs/plans/365-classified-api-errors.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BtcSJfWWcDKL4rSNNH1cN