### PR TITLE
Replace free-text silent policy entry with a fetched picker (OB-4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ If no config file exists — or the config file is incomplete or still contains 
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `default_silent_escalation_policy` | `string` | (none) | Silent escalation policy ID for silencing incidents. Set via `srepd config`. |
+| `default_silent_escalation_policy` | `string` | (none) | Silent escalation policy ID for silencing incidents. The wizard fetches your team's policies and recommends ones with no on-call schedules; you can also skip or enter an ID manually. |
 | `custom_service_escalation_policies` | `map[string]string` | (none) | Per-service silent policy overrides (service ID to policy ID) |
 | `editor` | `string` | `vim` | Editor for incident notes |
 | `terminal` | `string` | `gnome-terminal` | Terminal emulator for cluster login |

--- a/docs/plans/366-escalation-policy-picker.md
+++ b/docs/plans/366-escalation-policy-picker.md
@@ -1,0 +1,49 @@
+# 366: Escalation policy picker (OB-4)
+
+Issue: #353 (OB-4), #324 item 1; part of the onboarding overhaul
+Branch: `srepd/escalation-policy-picker`
+
+## Problem
+
+The wizard's silent-policy step was a free-text ID input with "find the ID in
+the PagerDuty URL" instructions — the exact scavenger hunt this overhaul
+exists to eliminate. The plumbing to do better already existed:
+`GetTeamEscalationPolicies` (team-filtered, paginated) and
+`ClassifyEscalationPolicy` (SILENT = no schedule targets) in pkg/pd.
+
+## Approach
+
+- Replace the free-text group with a `huh.Select[string]` whose `OptionsFunc`
+  is keyed on `&configState.SelectedTeams` (re-fires when the team selection
+  changes; falls back to existing teams when keeping):
+  - `fetchPolicyOptions(clientFactory, tokenInput, existingToken, teams)` —
+    fetches team policies; API errors render as a classified (OB-3),
+    skip-valued row so selecting them is harmless.
+  - `buildPolicyOptions(policies)` — SILENT-classified first with
+    "(recommended — no schedules notified)" annotation, then the rest, then
+    always-present escapes: "Skip — configure later" → `""` and "Enter an ID
+    manually…" → `policyChoiceManual`.
+- The free-text input group is retained for the weird cases, revealed via
+  `WithHideFunc` only when the picker choice is `policyChoiceManual`.
+- `resolveSilentPolicyChoice(choice, manualInput)` maps the pair to the final
+  bare policy ID at completion (both `WizardInputs` construction sites) — the
+  save format and runtime consumption are byte-identical to the free-text
+  flow, so no changes to WriteConfig or pd.NewConfigWithClient.
+- Picker pre-selects the existing policy ID when present (both
+  `SilentPolicyChoice` and the manual field seed from
+  `existing.SilentPolicy`). If the existing ID belongs to a team outside the
+  selection it simply won't highlight — skip/manual still available.
+- Mock: added `ListEscalationPoliciesErr` to `MockPagerDutyClient`.
+- Deliberately NO service picker: `custom_service_escalation_policies` stays
+  free text (plan 085's bulk service fetch warning; mappings are moving to
+  the advanced path later in this overhaul).
+
+## Tests (TDD — written first)
+
+`pkg/tui/config_policy_picker_test.go`:
+- `buildPolicyOptions`: SILENT ordering + recommendation annotation; escapes
+  always present (even with zero policies)
+- `fetchPolicyOptions`: team-filtered fetch via mock; no-teams → escapes
+  only; API error → classified, skip-valued row + escapes
+- `resolveSilentPolicyChoice`: picker wins / skip empty / manual trimmed /
+  manual blank

--- a/pkg/pd/mock.go
+++ b/pkg/pd/mock.go
@@ -58,6 +58,10 @@ type MockPagerDutyClient struct {
 	// ListEscalationPoliciesResponses is a queue of responses for ListEscalationPoliciesWithContext.
 	ListEscalationPoliciesResponses []pagerduty.ListEscalationPoliciesResponse
 
+	// ListEscalationPoliciesErr, when non-nil, causes
+	// ListEscalationPoliciesWithContext to return this error.
+	ListEscalationPoliciesErr error
+
 	// ListIncidentsResponses is an optional response queue for
 	// ListIncidentsWithContext. When populated, successive calls pop from the
 	// front. When empty or nil, the default hardcoded response is returned.
@@ -299,6 +303,10 @@ func (m *MockPagerDutyClient) GetUserWithContext(ctx context.Context, id string,
 
 func (m *MockPagerDutyClient) ListEscalationPoliciesWithContext(ctx context.Context, opts pagerduty.ListEscalationPoliciesOptions) (*pagerduty.ListEscalationPoliciesResponse, error) {
 	m.recordCall("ListEscalationPoliciesWithContext")
+
+	if m.ListEscalationPoliciesErr != nil {
+		return nil, m.ListEscalationPoliciesErr
+	}
 
 	if len(m.ListEscalationPoliciesResponses) > 0 {
 		resp := m.ListEscalationPoliciesResponses[0]

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -1404,12 +1404,16 @@ func updateTeamsInYAML(configData []byte, teamIDs []string, teamNames map[string
 type configFormState struct {
 	TokenInput    string
 	SelectedTeams []string
-	SilentPolicy  string
-	CustomInput   string
-	KeepTeams     bool
-	KeepSilent    bool
-	KeepCustom    bool
-	Confirm       bool
+	// SilentPolicyChoice is the picker selection: a policy ID,
+	// policyChoiceSkip, or policyChoiceManual (reveals the free-text input
+	// bound to SilentPolicy).
+	SilentPolicyChoice string
+	SilentPolicy       string
+	CustomInput        string
+	KeepTeams          bool
+	KeepSilent         bool
+	KeepCustom         bool
+	Confirm            bool
 }
 
 // configWizardReadyMsg is sent when the existing config has been resolved

--- a/pkg/tui/config_policy_picker_test.go
+++ b/pkg/tui/config_policy_picker_test.go
@@ -1,0 +1,113 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/PagerDuty/go-pagerduty"
+	"github.com/clcollins/srepd/pkg/pd"
+	"github.com/stretchr/testify/assert"
+)
+
+func silentPolicy(id, name string) pagerduty.EscalationPolicy {
+	return pagerduty.EscalationPolicy{
+		APIObject: pagerduty.APIObject{ID: id},
+		Name:      name,
+		EscalationRules: []pagerduty.EscalationRule{
+			{Targets: []pagerduty.APIObject{{Type: "user_reference", ID: "UBOT"}}},
+		},
+	}
+}
+
+func realPolicy(id, name string) pagerduty.EscalationPolicy {
+	return pagerduty.EscalationPolicy{
+		APIObject: pagerduty.APIObject{ID: id},
+		Name:      name,
+		EscalationRules: []pagerduty.EscalationRule{
+			{Targets: []pagerduty.APIObject{{Type: "schedule_reference", ID: "SCHED1"}}},
+		},
+	}
+}
+
+// OB-4: the silent-policy step becomes a fetched picker. SILENT-classified
+// policies (no schedules notified) lead the list with a recommendation
+// annotation; skip and manual-entry escapes are always present.
+func TestBuildPolicyOptions_SilentFirstWithAnnotation(t *testing.T) {
+	opts := buildPolicyOptions([]pagerduty.EscalationPolicy{
+		realPolicy("PREAL1", "Primary On-Call"),
+		silentPolicy("PSILENT1", "Silent Test"),
+		realPolicy("PREAL2", "Secondary"),
+		silentPolicy("PSILENT2", "Null Route"),
+	})
+
+	// 4 policies + skip + manual
+	assert.Len(t, opts, 6)
+	assert.Equal(t, "PSILENT1", opts[0].Value, "silent policies must come first")
+	assert.Equal(t, "PSILENT2", opts[1].Value)
+	assert.Contains(t, opts[0].Key, "Silent Test")
+	assert.Contains(t, opts[0].Key, "recommended", "silent candidates must be annotated")
+	assert.Equal(t, "PREAL1", opts[2].Value)
+	assert.NotContains(t, opts[2].Key, "recommended")
+}
+
+func TestBuildPolicyOptions_SentinelsAlwaysPresent(t *testing.T) {
+	opts := buildPolicyOptions(nil)
+
+	assert.Len(t, opts, 2)
+	assert.Contains(t, opts[0].Key, "Skip")
+	assert.Equal(t, policyChoiceSkip, opts[0].Value)
+	assert.Contains(t, opts[1].Key, "manually")
+	assert.Equal(t, policyChoiceManual, opts[1].Value)
+}
+
+func TestFetchPolicyOptions_UsesTeamFilter(t *testing.T) {
+	mock := &pd.MockPagerDutyClient{
+		ListEscalationPoliciesResponses: []pagerduty.ListEscalationPoliciesResponse{
+			{EscalationPolicies: []pagerduty.EscalationPolicy{
+				silentPolicy("PSILENT1", "Silent Test"),
+				realPolicy("PREAL1", "Primary"),
+			}},
+		},
+	}
+	factory := func(string) pd.PagerDutyClient { return mock }
+
+	opts := fetchPolicyOptions(factory, "u+token", "", []string{"TEAM_001"})
+
+	assert.Len(t, opts, 4, "two policies + skip + manual")
+	assert.Equal(t, "PSILENT1", opts[0].Value)
+}
+
+func TestFetchPolicyOptions_NoTeamsStillOffersEscapes(t *testing.T) {
+	opts := fetchPolicyOptions(mockFactoryOK(), "u+token", "", nil)
+
+	// GetTeamEscalationPolicies with no teams returns no policies; the user
+	// must still be able to skip or enter manually.
+	assert.Len(t, opts, 2)
+	assert.Equal(t, policyChoiceSkip, opts[0].Value)
+	assert.Equal(t, policyChoiceManual, opts[1].Value)
+}
+
+func TestFetchPolicyOptions_ErrorClassifiedAndEscapesKept(t *testing.T) {
+	mock := &pd.MockPagerDutyClient{ListEscalationPoliciesErr: pagerduty.APIError{StatusCode: 429}}
+	factory := func(string) pd.PagerDutyClient { return mock }
+
+	opts := fetchPolicyOptions(factory, "u+token", "", []string{"TEAM_001"})
+
+	// The classified error is shown as a disabled-style row, and the user can
+	// still skip or enter an ID manually.
+	assert.Len(t, opts, 3)
+	assert.Contains(t, opts[0].Key, "rate limited")
+	assert.Equal(t, policyChoiceSkip, opts[0].Value, "error row must resolve to skip so selecting it is harmless")
+	assert.Equal(t, policyChoiceSkip, opts[1].Value)
+	assert.Equal(t, policyChoiceManual, opts[2].Value)
+}
+
+func TestResolveSilentPolicyChoice(t *testing.T) {
+	assert.Equal(t, "PSILENT1", resolveSilentPolicyChoice("PSILENT1", "ignored"),
+		"picker choice wins")
+	assert.Equal(t, "", resolveSilentPolicyChoice(policyChoiceSkip, "ignored"),
+		"skip means no policy")
+	assert.Equal(t, "PMANUAL9", resolveSilentPolicyChoice(policyChoiceManual, "  PMANUAL9  "),
+		"manual choice uses the trimmed free-text input")
+	assert.Equal(t, "", resolveSilentPolicyChoice(policyChoiceManual, "   "),
+		"manual with blank input means no policy")
+}

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -326,7 +326,7 @@ func switchConfigFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 		final, err := pkgconfig.ResolveFinalValues(m.configExisting, pkgconfig.WizardInputs{
 			TokenInput:          m.configState.TokenInput,
 			SelectedTeams:       m.configState.SelectedTeams,
-			SilentPolicyID:      m.configState.SilentPolicy,
+			SilentPolicyID:      resolveSilentPolicyChoice(m.configState.SilentPolicyChoice, m.configState.SilentPolicy),
 			CustomMappingsInput: m.configState.CustomInput,
 			KeepTeams:           m.configState.KeepTeams,
 			KeepSilent:          m.configState.KeepSilent,

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -276,12 +276,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.configTeamNames = msg.teamNames
 		m.configPolicyNames = msg.policyNames
 		m.configState = &configFormState{
-			SilentPolicy: msg.existing.SilentPolicy,
-			CustomInput:  pkgconfig.FormatCustomMappings(msg.existing.CustomPolicies),
-			KeepTeams:    msg.kd.KeepTeams,
-			KeepSilent:   msg.kd.KeepSilent,
-			KeepCustom:   msg.kd.KeepCustom,
-			Confirm:      true,
+			SilentPolicyChoice: msg.existing.SilentPolicy,
+			SilentPolicy:       msg.existing.SilentPolicy,
+			CustomInput:        pkgconfig.FormatCustomMappings(msg.existing.CustomPolicies),
+			KeepTeams:          msg.kd.KeepTeams,
+			KeepSilent:         msg.kd.KeepSilent,
+			KeepCustom:         msg.kd.KeepCustom,
+			Confirm:            true,
 		}
 
 		existingTeamSet := make(map[string]bool)
@@ -1961,6 +1962,71 @@ func fetchTeamOptions(clientFactory func(string) pd.PagerDutyClient, tokenInput,
 	return opts, teams
 }
 
+// Sentinel values for the silent-policy picker (OB-4). Skip maps to the
+// empty policy ID (silencing disabled until configured); manual reveals the
+// free-text ID input for policies the picker cannot discover.
+const (
+	policyChoiceSkip   = ""
+	policyChoiceManual = "__manual__"
+)
+
+// buildPolicyOptions turns fetched escalation policies into picker options:
+// SILENT-classified policies (no schedules notified — the right target for
+// silencing) lead the list with a recommendation annotation, then the rest,
+// then the skip and manual-entry escapes.
+func buildPolicyOptions(policies []pagerduty.EscalationPolicy) []huh.Option[string] {
+	var opts []huh.Option[string]
+	for _, p := range policies {
+		if pd.ClassifyEscalationPolicy(&p) == pd.PolicyClassSilent {
+			opts = append(opts, huh.NewOption(
+				fmt.Sprintf("%s — %s (recommended — no schedules notified)", p.Name, p.ID), p.ID))
+		}
+	}
+	for _, p := range policies {
+		if pd.ClassifyEscalationPolicy(&p) != pd.PolicyClassSilent {
+			opts = append(opts, huh.NewOption(fmt.Sprintf("%s — %s", p.Name, p.ID), p.ID))
+		}
+	}
+	opts = append(opts,
+		huh.NewOption("Skip — configure later", policyChoiceSkip),
+		huh.NewOption("Enter an ID manually…", policyChoiceManual),
+	)
+	return opts
+}
+
+// fetchPolicyOptions fetches the escalation policies for the selected teams
+// and builds the picker options. Errors are classified (OB-3) and rendered
+// as a skip-valued row so selecting them is harmless; the skip and manual
+// escapes are always present.
+func fetchPolicyOptions(clientFactory func(string) pd.PagerDutyClient, tokenInput, existingToken string, teams []string) []huh.Option[string] {
+	token := strings.TrimSpace(tokenInput)
+	if token == "" {
+		token = existingToken
+	}
+	if token == "" || len(teams) == 0 {
+		return buildPolicyOptions(nil)
+	}
+
+	policies, err := pd.GetTeamEscalationPolicies(clientFactory(token), teams)
+	if err != nil {
+		return append(
+			[]huh.Option[string]{huh.NewOption("Error: "+pd.ClassifyAPIError(err), policyChoiceSkip)},
+			buildPolicyOptions(nil)...,
+		)
+	}
+	return buildPolicyOptions(policies)
+}
+
+// resolveSilentPolicyChoice maps the picker choice (plus the manual free-text
+// input) to the final policy ID. Emits the same bare ID string the free-text
+// step produced, so the save format and runtime consumption are unchanged.
+func resolveSilentPolicyChoice(choice, manualInput string) string {
+	if choice == policyChoiceManual {
+		return strings.TrimSpace(manualInput)
+	}
+	return choice
+}
+
 // validateTeamValues rejects an empty selection and the empty-valued
 // placeholder/error options fetchTeamOptions emits.
 func validateTeamValues(s []string) error {
@@ -2039,17 +2105,35 @@ func (m *model) buildConfigForm(msg configWizardReadyMsg, tokenDesc, keepTeamsDe
 				Value(&m.configState.KeepSilent),
 		).WithHideFunc(func() bool { return !msg.kd.HasSilent }),
 		huh.NewGroup(
-			huh.NewInput().
+			huh.NewSelect[string]().
 				Title("Default silent escalation policy").
 				Description(
 					"When you silence an incident, it gets reassigned to this policy —\n"+
 						"one that routes only to bot users, not on-call humans.\n"+
-						"Find the ID at People → Escalation Policies (ID is in the URL,\n"+
-						"e.g., PXXXXXX). Look for a policy like \"Silent Test\".\n"+
+						"Policies are fetched from your selected teams; ones with no\n"+
+						"schedules (nobody gets paged) are recommended.",
+				).
+				OptionsFunc(func() []huh.Option[string] {
+					teams := m.configState.SelectedTeams
+					if m.configState.KeepTeams || len(teams) == 0 {
+						teams = msg.existing.Teams
+					}
+					return fetchPolicyOptions(clientFactory, m.configState.TokenInput, msg.existing.Token, teams)
+				}, &m.configState.SelectedTeams).
+				Value(&m.configState.SilentPolicyChoice),
+		).WithHideFunc(func() bool { return m.configState.KeepSilent }),
+		huh.NewGroup(
+			huh.NewInput().
+				Title("Silent escalation policy ID").
+				Description(
+					"Enter the policy ID directly. Find it at People →\n"+
+						"Escalation Policies (the ID is in the URL, e.g., PXXXXXX).\n"+
 						"Leave blank to configure later.",
 				).
 				Value(&m.configState.SilentPolicy),
-		).WithHideFunc(func() bool { return m.configState.KeepSilent }),
+		).WithHideFunc(func() bool {
+			return m.configState.KeepSilent || m.configState.SilentPolicyChoice != policyChoiceManual
+		}),
 		huh.NewGroup(
 			huh.NewConfirm().
 				Title("Keep current custom service-to-policy mappings?").
@@ -2075,7 +2159,7 @@ func (m *model) buildConfigForm(msg configWizardReadyMsg, tokenDesc, keepTeamsDe
 					tmpFinal, _ := pkgconfig.ResolveFinalValues(m.configExisting, pkgconfig.WizardInputs{
 						TokenInput:          m.configState.TokenInput,
 						SelectedTeams:       m.configState.SelectedTeams,
-						SilentPolicyID:      m.configState.SilentPolicy,
+						SilentPolicyID:      resolveSilentPolicyChoice(m.configState.SilentPolicyChoice, m.configState.SilentPolicy),
 						CustomMappingsInput: m.configState.CustomInput,
 						KeepTeams:           m.configState.KeepTeams,
 						KeepSilent:          m.configState.KeepSilent,


### PR DESCRIPTION
> **Stacked on #366** (← #365 ← #364 ← #363). Review/merge in order; GitHub retargets automatically. Part of the onboarding overhaul (#353, #324).

## Problem

The wizard's silent-policy step was a free-text ID input with "find the ID in the PagerDuty URL" instructions — the exact scavenger hunt this overhaul exists to eliminate. All the plumbing already existed in `pkg/pd` (`GetTeamEscalationPolicies`, `ClassifyEscalationPolicy`); it just wasn't wired to a picker.

Closes OB-4 of #353 and #324's escalation-policy item.

## Changes

- Silent-policy step is now a **`huh.Select`** fed by `OptionsFunc` keyed on the selected teams (re-fetches when teams change; falls back to existing teams when keeping):
  - **SILENT-classified policies first** with "(recommended — no schedules notified)" annotation
  - Always-present escapes: **"Skip — configure later"** and **"Enter an ID manually…"** (reveals the retained free-text input for undiscoverable policies)
  - API errors render as a classified, skip-valued row (harmless to select)
- `resolveSilentPolicyChoice(choice, manual)` emits the same bare policy ID the free-text flow produced — **zero changes to save format or runtime consumption**
- Existing policy pre-seeds both the picker and the manual field
- PD mock gains `ListEscalationPoliciesErr`
- Deliberately **no service picker** — custom mappings stay text (plan 085's 30s bulk-fetch warning; they move behind the advanced gate later in the overhaul)

## Tests (TDD)

`config_policy_picker_test.go`: SILENT ordering + annotation, escapes always present, team-filtered fetch via mock, classified error row, choice resolution table. Full suite, `-race`, lint green.

## Plan doc

`docs/plans/366-escalation-policy-picker.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BtcSJfWWcDKL4rSNNH1cN