### PR TITLE
Greet the user, smart-preselect teams, gate advanced options

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ go install .        # standard go install
 
 SREPD reads `~/.config/srepd/srepd.yaml` and supports `SREPD_` environment variable prefix. Run `srepd config` to create or update your config interactively. Values from environment variables (e.g., `SREPD_TOKEN`) are pre-filled automatically.
 
-If no config file exists — or the config file is incomplete or still contains placeholder values (e.g. `<PagerDuty API token>`) — running `srepd` automatically enters the configuration wizard. The wizard form resizes dynamically when the terminal window changes size.
+If no config file exists — or the config file is incomplete or still contains placeholder values — running `srepd` automatically enters the configuration wizard. The wizard validates your token, greets you by name, auto-selects your team when you belong to exactly one, and gates advanced options (custom service-to-policy mappings) behind a default-No confirm so most users never see them. The form resizes dynamically when the terminal window changes size.
 
 **Migrating from old config format:** If your config uses the deprecated `service_escalation_policies` key, running `srepd config` will automatically migrate to the new `default_silent_escalation_policy` and `custom_service_escalation_policies` keys. The old block is commented out with a deprecation note.
 

--- a/docs/plans/367-teams-ux-greeting.md
+++ b/docs/plans/367-teams-ux-greeting.md
@@ -1,0 +1,46 @@
+# 367: Teams UX — greeting, smart preselection, advanced gate
+
+Issue: #353/#324 (onboarding overhaul — token-first wizard phase)
+Branch: `srepd/teams-ux-greeting`
+
+## Problem
+
+Three friction points in the wizard's team step and beyond:
+1. After pasting a token, the user got no confirmation of *who* PagerDuty
+   thinks they are — just a team list.
+2. A new user on exactly one team (the common SRE case) still had to
+   manually select it; #324 asks the wizard to steer toward one team.
+3. `custom_service_escalation_policies` — a "have to know to know" team
+   policy — was prompted at every new user, even though most should never
+   touch it.
+
+## Approach
+
+- **Greeting**: `pd.GetCurrentUserWithTeams` returns the full user (one API
+  call for identity + teams; `GetCurrentUserTeams` now delegates to it).
+  `fetchTeamOptions` returns the user's name; the OptionsFunc stores
+  `FetchedUserName`/`FetchedTeamCount` on `configFormState`, and the team
+  step's `DescriptionFunc` — keyed on `&FetchedUserName` so it re-fires
+  right after the fetch completes — renders `teamGreeting(name, count)`:
+  "Hi Chris — found 2 teams on your PagerDuty profile. …most users need
+  exactly one." Neutral copy until a user resolves.
+- **Preselection**: `teamPreselection(existingTeamSet, teams)` — existing
+  config always wins; else a single fetched team is preselected; multiple
+  teams preselect nothing (deliberate choice, guided by copy). Kept
+  MultiSelect (per user decision) — no migration story for multi-team
+  configs, no second code path.
+- **Advanced gate**: new "Configure advanced options?" confirm (default No),
+  shown only to users with no existing custom mappings; the custom-mappings
+  input hides unless it's opened (or the user already has mappings, where
+  the keep/edit flow is unchanged). Copy points at team onboarding docs /
+  the upcoming preset mechanism.
+- Mock user now carries `Name: "Mock User"`.
+
+Full group reorder (welcome first, environment group) lands with PRs 7/10.
+
+## Tests (TDD — written first)
+
+`pkg/tui/config_teams_ux_test.go`: `teamGreeting` (plural/singular/fallback),
+`fetchTeamOptions` returns the user name, `teamPreselection` table (existing
+wins / single auto / nil set / multiple none). Updated PR-366 tests to the
+3-value `fetchTeamOptions` signature.

--- a/pkg/pd/mock.go
+++ b/pkg/pd/mock.go
@@ -261,6 +261,7 @@ func (m *MockPagerDutyClient) GetCurrentUserWithContext(ctx context.Context, opt
 	}
 	user := &pagerduty.User{
 		APIObject: pagerduty.APIObject{ID: "MOCK_USER"},
+		Name:      "Mock User",
 		Email:     "mock@example.com",
 	}
 	for _, inc := range opts.Includes {

--- a/pkg/pd/pd.go
+++ b/pkg/pd/pd.go
@@ -385,6 +385,17 @@ func GetUser(client PagerDutyClient, id string, opts pagerduty.GetUserOptions) (
 }
 
 func GetCurrentUserTeams(client PagerDutyClient) ([]pagerduty.Team, error) {
+	user, err := GetCurrentUserWithTeams(client)
+	if err != nil {
+		return nil, fmt.Errorf("pd.GetCurrentUserTeams(): failed to get current user: %w", err)
+	}
+	return user.Teams, nil
+}
+
+// GetCurrentUserWithTeams returns the currently-authenticated user with
+// their teams included — one API call serving both identity (greeting,
+// validation feedback) and team discovery.
+func GetCurrentUserWithTeams(client PagerDutyClient) (*pagerduty.User, error) {
 	ctx, cancel := contextWithTimeout()
 	defer cancel()
 
@@ -392,10 +403,9 @@ func GetCurrentUserTeams(client PagerDutyClient) ([]pagerduty.Team, error) {
 		Includes: []string{"teams"},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("pd.GetCurrentUserTeams(): failed to get current user: %w", err)
+		return nil, fmt.Errorf("pd.GetCurrentUserWithTeams(): failed to get current user: %w", err)
 	}
-
-	return user.Teams, nil
+	return user, nil
 }
 
 // GetCurrentUser returns the currently-authenticated PagerDuty user, applying the

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -1413,7 +1413,14 @@ type configFormState struct {
 	KeepTeams          bool
 	KeepSilent         bool
 	KeepCustom         bool
-	Confirm            bool
+	// AdvancedOptions gates the team-policy groups (custom service→policy
+	// mappings) that most users should never see; defaults to No.
+	AdvancedOptions bool
+	Confirm         bool
+	// FetchedUserName/FetchedTeamCount are set by the team OptionsFunc after
+	// a successful fetch and drive the greeting DescriptionFunc.
+	FetchedUserName  string
+	FetchedTeamCount int
 }
 
 // configWizardReadyMsg is sent when the existing config has been resolved

--- a/pkg/tui/config_teams_ux_test.go
+++ b/pkg/tui/config_teams_ux_test.go
@@ -1,0 +1,59 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/PagerDuty/go-pagerduty"
+	"github.com/stretchr/testify/assert"
+)
+
+// The team step should greet the validated user by name so the wizard feels
+// responsive ("the token worked, and it's really me").
+func TestTeamGreeting(t *testing.T) {
+	assert.Equal(t,
+		"Hi Chris — found 2 teams on your PagerDuty profile. Select the team(s) whose incidents you want to monitor; most users need exactly one.",
+		teamGreeting("Chris", 2))
+	assert.Equal(t,
+		"Hi Chris — found 1 team on your PagerDuty profile. Select the team(s) whose incidents you want to monitor; most users need exactly one.",
+		teamGreeting("Chris", 1))
+	// No user name (token not validated yet / lookup failed): fall back to
+	// neutral guidance.
+	assert.Equal(t,
+		"Select the team(s) whose incidents you want to monitor; most users need exactly one.",
+		teamGreeting("", 0))
+}
+
+// fetchTeamOptions must surface the validated user's name for the greeting.
+func TestFetchTeamOptions_ReturnsUserName(t *testing.T) {
+	opts, teams, userName := fetchTeamOptions(mockFactoryOK(), "u+goodtoken", "", nil)
+	assert.Len(t, opts, 2)
+	assert.Len(t, teams, 2)
+	assert.Equal(t, "Mock User", userName)
+}
+
+func team(id string) pagerduty.Team {
+	return pagerduty.Team{APIObject: pagerduty.APIObject{ID: id}}
+}
+
+// teamPreselection decides which options render preselected:
+// existing-config teams always win; a brand-new user on exactly one team has
+// it preselected (the common SRE case answers itself); multiple teams with
+// no existing config preselect nothing — a deliberate choice, guided by the
+// "most users need exactly one" copy.
+func TestTeamPreselection(t *testing.T) {
+	existing := map[string]bool{"TEAM_002": true}
+
+	sel := teamPreselection(existing, []pagerduty.Team{team("TEAM_001"), team("TEAM_002")})
+	assert.False(t, sel["TEAM_001"])
+	assert.True(t, sel["TEAM_002"], "existing config selection wins")
+
+	sel = teamPreselection(map[string]bool{}, []pagerduty.Team{team("TEAM_001")})
+	assert.True(t, sel["TEAM_001"], "a single team must be preselected for new users")
+
+	sel = teamPreselection(nil, []pagerduty.Team{team("TEAM_001")})
+	assert.True(t, sel["TEAM_001"], "nil existing set behaves like empty")
+
+	sel = teamPreselection(map[string]bool{}, []pagerduty.Team{team("TEAM_001"), team("TEAM_002")})
+	assert.False(t, sel["TEAM_001"])
+	assert.False(t, sel["TEAM_002"])
+}

--- a/pkg/tui/config_token_validation_test.go
+++ b/pkg/tui/config_token_validation_test.go
@@ -43,14 +43,14 @@ func TestValidateTokenInput_Classifies401(t *testing.T) {
 }
 
 func TestFetchTeamOptions_NoTokenPrompts(t *testing.T) {
-	opts, teams := fetchTeamOptions(mockFactoryOK(), "", "", nil)
+	opts, teams, _ := fetchTeamOptions(mockFactoryOK(), "", "", nil)
 	assert.Nil(t, teams)
 	assert.Len(t, opts, 1)
 	assert.Contains(t, opts[0].Key, "enter a token first")
 }
 
 func TestFetchTeamOptions_Success(t *testing.T) {
-	opts, teams := fetchTeamOptions(mockFactoryOK(), "u+goodtoken", "", map[string]bool{"TEAM_002": true})
+	opts, teams, _ := fetchTeamOptions(mockFactoryOK(), "u+goodtoken", "", map[string]bool{"TEAM_002": true})
 	assert.Len(t, teams, 2, "mock returns two teams")
 	assert.Len(t, opts, 2)
 	assert.Contains(t, opts[0].Key, "Mock Team Alpha")
@@ -59,8 +59,9 @@ func TestFetchTeamOptions_Success(t *testing.T) {
 // OB-3: the error option must carry the classified message, and its value
 // must be empty so validation can reject it.
 func TestFetchTeamOptions_ClassifiedErrorOption(t *testing.T) {
-	opts, teams := fetchTeamOptions(mockFactoryWithErr(pagerduty.APIError{StatusCode: 429}), "u+token", "", nil)
+	opts, teams, userName := fetchTeamOptions(mockFactoryWithErr(pagerduty.APIError{StatusCode: 429}), "u+token", "", nil)
 	assert.Nil(t, teams)
+	assert.Empty(t, userName)
 	assert.Len(t, opts, 1)
 	assert.Contains(t, opts[0].Key, "rate limited")
 	assert.Equal(t, "", opts[0].Value)

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -1932,34 +1932,66 @@ func validateTokenInput(clientFactory func(string) pd.PagerDutyClient, input, ex
 	return nil
 }
 
-// fetchTeamOptions builds the wizard team options for the current token.
-// Placeholder and error states are returned as a single empty-valued option
-// (rejected by validateTeamValues) carrying a classified message.
-func fetchTeamOptions(clientFactory func(string) pd.PagerDutyClient, tokenInput, existingToken string, existingTeamSet map[string]bool) ([]huh.Option[string], []pagerduty.Team) {
+// teamGreeting builds the team-step description: a personal confirmation
+// that the token worked, plus single-team guidance. Falls back to neutral
+// copy when no user has been resolved yet.
+func teamGreeting(userName string, teamCount int) string {
+	const guidance = "Select the team(s) whose incidents you want to monitor; most users need exactly one."
+	if userName == "" {
+		return guidance
+	}
+	noun := "teams"
+	if teamCount == 1 {
+		noun = "team"
+	}
+	return fmt.Sprintf("Hi %s — found %d %s on your PagerDuty profile. %s", userName, teamCount, noun, guidance)
+}
+
+// teamPreselection decides which team options render preselected: teams from
+// the existing config always win; otherwise a single fetched team is
+// preselected (the common SRE case answers itself); multiple teams with no
+// existing config preselect nothing.
+func teamPreselection(existingTeamSet map[string]bool, teams []pagerduty.Team) map[string]bool {
+	if len(existingTeamSet) > 0 {
+		return existingTeamSet
+	}
+	sel := make(map[string]bool)
+	if len(teams) == 1 {
+		sel[teams[0].ID] = true
+	}
+	return sel
+}
+
+// fetchTeamOptions builds the wizard team options for the current token and
+// returns the validated user's name for the greeting. Placeholder and error
+// states are returned as a single empty-valued option (rejected by
+// validateTeamValues) carrying a classified message.
+func fetchTeamOptions(clientFactory func(string) pd.PagerDutyClient, tokenInput, existingToken string, existingTeamSet map[string]bool) ([]huh.Option[string], []pagerduty.Team, string) {
 	token := strings.TrimSpace(tokenInput)
 	if token == "" {
 		token = existingToken
 	}
 	if token == "" {
-		return []huh.Option[string]{huh.NewOption("(enter a token first)", "")}, nil
+		return []huh.Option[string]{huh.NewOption("(enter a token first)", "")}, nil, ""
 	}
 
-	teams, err := pd.GetCurrentUserTeams(clientFactory(token))
+	user, err := pd.GetCurrentUserWithTeams(clientFactory(token))
 	if err != nil {
 		return []huh.Option[string]{
 			huh.NewOption("Error: "+pd.ClassifyAPIError(err), ""),
-		}, nil
+		}, nil, ""
 	}
 
+	selected := teamPreselection(existingTeamSet, user.Teams)
 	var opts []huh.Option[string]
-	for _, team := range teams {
+	for _, team := range user.Teams {
 		opt := huh.NewOption(fmt.Sprintf("%s — %s", team.Name, team.ID), team.ID)
-		if existingTeamSet[team.ID] {
+		if selected[team.ID] {
 			opt = opt.Selected(true)
 		}
 		opts = append(opts, opt)
 	}
-	return opts, teams
+	return opts, user.Teams, user.Name
 }
 
 // Sentinel values for the silent-policy picker (OB-4). Skip maps to the
@@ -2081,11 +2113,15 @@ func (m *model) buildConfigForm(msg configWizardReadyMsg, tokenDesc, keepTeamsDe
 		huh.NewGroup(
 			huh.NewMultiSelect[string]().
 				Title("Select your PagerDuty teams").
-				Description("Select the team(s) whose incidents you want to monitor. Most users only need one.").
+				DescriptionFunc(func() string {
+					return teamGreeting(m.configState.FetchedUserName, m.configState.FetchedTeamCount)
+				}, &m.configState.FetchedUserName).
 				OptionsFunc(func() []huh.Option[string] {
-					opts, teams := fetchTeamOptions(clientFactory, m.configState.TokenInput, msg.existing.Token, existingTeamSet)
+					opts, teams, userName := fetchTeamOptions(clientFactory, m.configState.TokenInput, msg.existing.Token, existingTeamSet)
 					if teams != nil {
 						fetchedTeams = teams
+						m.configState.FetchedUserName = userName
+						m.configState.FetchedTeamCount = len(teams)
 					}
 					return opts
 				}, &m.configState.TokenInput).
@@ -2136,6 +2172,16 @@ func (m *model) buildConfigForm(msg configWizardReadyMsg, tokenDesc, keepTeamsDe
 		}),
 		huh.NewGroup(
 			huh.NewConfirm().
+				Title("Configure advanced options?").
+				Description(
+					"Custom service-to-policy silence overrides — a team-policy\n"+
+						"setting most users don't need. Skip unless your team's\n"+
+						"onboarding docs say otherwise.",
+				).
+				Value(&m.configState.AdvancedOptions),
+		).WithHideFunc(func() bool { return msg.kd.HasCustom }),
+		huh.NewGroup(
+			huh.NewConfirm().
 				Title("Keep current custom service-to-policy mappings?").
 				Description(keepCustomDesc).
 				Value(&m.configState.KeepCustom),
@@ -2151,7 +2197,12 @@ func (m *model) buildConfigForm(msg configWizardReadyMsg, tokenDesc, keepTeamsDe
 						"Leave blank to skip.",
 				).
 				Value(&m.configState.CustomInput),
-		).WithHideFunc(func() bool { return m.configState.KeepCustom }),
+		).WithHideFunc(func() bool {
+			if msg.kd.HasCustom {
+				return m.configState.KeepCustom
+			}
+			return !m.configState.AdvancedOptions
+		}),
 		huh.NewGroup(
 			huh.NewNote().
 				Title("Configuration summary").


### PR DESCRIPTION
> **Stacked on #367** (← #366 ← #365 ← #364 ← #363). Review/merge in order. Part of the onboarding overhaul (#353, #324).

## Changes

Three team-step/flow improvements from #324:

1. **Greeting** — after token validation, the team step reads "Hi Chris — found 2 teams on your PagerDuty profile. …most users need exactly one." One API call serves identity + teams (`pd.GetCurrentUserWithTeams`; `GetCurrentUserTeams` now delegates to it). The greeting `DescriptionFunc` is keyed on the fetched user name so it re-fires immediately after the team fetch completes.
2. **Smart preselection** — `teamPreselection`: existing-config teams always win; a brand-new user on exactly **one** team gets it preselected (the common SRE case answers itself); multiple teams preselect nothing. MultiSelect retained (per the plan decision) — no migration story for existing multi-team configs.
3. **Advanced gate** — `custom_service_escalation_policies` is a "have to know to know" team policy. Users with no existing mappings now see a default-**No** "Configure advanced options?" confirm instead of the mapping prompt; users who already have mappings keep the unchanged keep/edit flow.

## Tests (TDD)

`config_teams_ux_test.go`: greeting copy (plural/singular/fallback), user-name plumbing, preselection truth table. Mock user gains `Name`. Full suite, `-race`, lint green.

## Plan doc

`docs/plans/367-teams-ux-greeting.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BtcSJfWWcDKL4rSNNH1cN