### PR TITLE
Detect terminal/editor/AI environment in the wizard (OB-5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ If no config file exists — or the config file is incomplete or still contains 
 |-----|------|---------|-------------|
 | `default_silent_escalation_policy` | `string` | (none) | Silent escalation policy ID for silencing incidents. The wizard fetches your team's policies and recommends ones with no on-call schedules; you can also skip or enter an ID manually. |
 | `custom_service_escalation_policies` | `map[string]string` | (none) | Per-service silent policy overrides (service ID to policy ID) |
-| `editor` | `string` | `vim` | Editor for incident notes |
-| `terminal` | `string` | `gnome-terminal` | Terminal emulator for cluster login |
+| `editor` | `string` | `vim` | Editor for incident notes (wizard prefills from `$EDITOR`/`$VISUAL`) |
+| `terminal` | `string` | `gnome-terminal` | Terminal emulator for cluster login (wizard detects installed terminals and warns when the configured one is missing) |
 | `cluster_login_command` | `string` | `ocm backplane login %%CLUSTER_ID%%` | Cluster login command |
 | `rosa_boundary_command` | `string` | `rosa-boundary start-task --cluster-id %%CLUSTER_ID%% --connect` | rosa-boundary cluster login command |
 | `toolbox_mode` | `string` | `auto` | Toolbox detection: `auto`, `true`, or `false` |

--- a/docs/plans/368-environment-detection.md
+++ b/docs/plans/368-environment-detection.md
@@ -1,0 +1,61 @@
+# 368: Environment detection — terminal, editor, AI agent (OB-5)
+
+Issue: #353 (OB-5), #324 agent item; part of the onboarding overhaul
+Branch: `srepd/environment-detection`
+
+## Problem
+
+- The `terminal` default (`gnome-terminal --`) is wrong on macOS and
+  non-GNOME systems, the wizard never surfaced it, and a bad terminal only
+  failed as a journal warning at cluster-login time (OB-5).
+- `editor` silently defaulted to vim, ignoring `$EDITOR`.
+- The AI agent config (`agent_cli_command`) existed but was invisible in the
+  wizard (#324): users had to know it was there.
+- None of terminal/editor/agent were part of the wizard's resolve → detect →
+  write pipeline at all — `BuildFullConfig` wrote hardcoded defaults.
+
+## Approach
+
+**Detection (`pkg/launcher/detect.go`)**: `DetectTerminals(lookPath, getenv,
+goos)` probes PATH for every executable the profile registry understands,
+ranked: `$TERM_PROGRAM` match first, tmux next (only when `$TMUX` is set — a
+tmux window outside a session can't open), rest in probe order; darwin always
+includes Terminal.app/iTerm2 (osascript-launched, not on PATH). Fully
+injectable for tests.
+
+**Wizard environment group** (after the policy steps):
+- Terminal `Select`: current setting first, annotated "(current)" or
+  "(current — not found on this system!)" (the OB-5 surfacing), then
+  detected terminals deduplicated (`buildTerminalOptions`). Flatpak app IDs
+  are exempt from the not-found warning (reverse-DNS heuristic). Falls back
+  to the default option when nothing is detected.
+- Editor `Input`: prefilled `resolveEditorDefault`: config → `$EDITOR` →
+  `$VISUAL` → vim.
+- AI confirm: shown only when `shouldOfferAgentSetup` — claude on PATH AND
+  the agent command is unset/default (a customized command means the user
+  already configured it; no claude → silent skip per #324). Yes → default
+  `claude --print`; No → `agent_cli_command: ""` persisted (deliberate
+  disable). Known quirk: `ensureViperDefaults` resets an empty agent command
+  in the wizard session itself; normal launches respect the disable.
+
+**Write path (`pkg/config`)**: `ExistingConfig`/`WizardInputs`/
+`ResolvedValues` gain Terminal/Editor/Agent fields (`AgentTouched`
+distinguishes "step ran, empty = disabled" from "step hidden, keep
+existing"); `DetectChanges`/`DetectChangesForNewFile` cover them;
+`MergeIntoExistingConfig` upserts the three keys; `BuildFullConfig` writes
+the resolved terminal/editor instead of hardcoded defaults; `BuildSummary`
+shows changed environment values. `prepareConfigWizardCmd` populates the
+existing values from viper.
+
+## Tests (TDD — written first)
+
+- `pkg/launcher/detect_test.go`: probe results, none-found, `$TERM_PROGRAM`
+  ranking, tmux only-inside-session, darwin Apple terminals + ranking,
+  linux exclusion.
+- `pkg/tui/config_environment_test.go`: terminal options (current-first
+  annotation, missing-current warning, dedup), editor default chain, agent
+  offer gating.
+- `pkg/config/environment_test.go`: resolve (inputs win / fallback /
+  deliberate disable), change detection, BuildFullConfig uses resolved
+  values + defaults when empty + persists a disable, merge upserts while
+  preserving untouched keys.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -65,6 +65,11 @@ type ExistingConfig struct {
 	SilentPolicy      string
 	CustomPolicies    map[string]string
 	OldFormatDetected bool
+	// Environment settings surfaced by the wizard (OB-5). Populated by the
+	// caller from viper; empty means unset.
+	Terminal        string
+	Editor          string
+	AgentCLICommand string
 }
 
 func ResolveExistingConfig(
@@ -142,6 +147,14 @@ type WizardInputs struct {
 	KeepTeams           bool
 	KeepSilent          bool
 	KeepCustom          bool
+	// Environment step (OB-5). Blank Terminal/Editor inputs keep the
+	// existing values. AgentTouched distinguishes "the agent step ran"
+	// (AgentInput is authoritative, even when empty = deliberately
+	// disabled) from "the step was hidden" (keep existing).
+	TerminalInput string
+	EditorInput   string
+	AgentInput    string
+	AgentTouched  bool
 }
 
 type ResolvedValues struct {
@@ -149,6 +162,10 @@ type ResolvedValues struct {
 	Teams               []string
 	SilentPolicy        string
 	CustomMappingsInput string
+	Terminal            string
+	Editor              string
+	AgentCLICommand     string
+	AgentTouched        bool
 }
 
 func ResolveFinalValues(existing ExistingConfig, inputs WizardInputs) (ResolvedValues, error) {
@@ -181,35 +198,59 @@ func ResolveFinalValues(existing ExistingConfig, inputs WizardInputs) (ResolvedV
 		rv.CustomMappingsInput = strings.TrimSpace(inputs.CustomMappingsInput)
 	}
 
+	rv.Terminal = existing.Terminal
+	if trimmed := strings.TrimSpace(inputs.TerminalInput); trimmed != "" {
+		rv.Terminal = trimmed
+	}
+	rv.Editor = existing.Editor
+	if trimmed := strings.TrimSpace(inputs.EditorInput); trimmed != "" {
+		rv.Editor = trimmed
+	}
+	rv.AgentCLICommand = existing.AgentCLICommand
+	rv.AgentTouched = inputs.AgentTouched
+	if inputs.AgentTouched {
+		rv.AgentCLICommand = strings.TrimSpace(inputs.AgentInput)
+	}
+
 	return rv, nil
 }
 
 type ConfigChanges struct {
-	TokenChanged  bool
-	TeamsChanged  bool
-	SilentChanged bool
-	CustomChanged bool
+	TokenChanged    bool
+	TeamsChanged    bool
+	SilentChanged   bool
+	CustomChanged   bool
+	TerminalChanged bool
+	EditorChanged   bool
+	AgentChanged    bool
 }
 
 func (c ConfigChanges) AnyChanged() bool {
-	return c.TokenChanged || c.TeamsChanged || c.SilentChanged || c.CustomChanged
+	return c.TokenChanged || c.TeamsChanged || c.SilentChanged || c.CustomChanged ||
+		c.TerminalChanged || c.EditorChanged || c.AgentChanged
 }
 
 func DetectChangesForNewFile(final ResolvedValues) ConfigChanges {
 	return ConfigChanges{
-		TokenChanged:  true,
-		TeamsChanged:  true,
-		SilentChanged: final.SilentPolicy != "",
-		CustomChanged: final.CustomMappingsInput != "",
+		TokenChanged:    true,
+		TeamsChanged:    true,
+		SilentChanged:   final.SilentPolicy != "",
+		CustomChanged:   final.CustomMappingsInput != "",
+		TerminalChanged: final.Terminal != "",
+		EditorChanged:   final.Editor != "",
+		AgentChanged:    final.AgentTouched,
 	}
 }
 
 func DetectChanges(existing ExistingConfig, final ResolvedValues, tokenInput string) ConfigChanges {
 	return ConfigChanges{
-		TokenChanged:  tokenInput != "" && tokenInput != existing.Token,
-		TeamsChanged:  !StringSlicesEqual(final.Teams, existing.Teams),
-		SilentChanged: final.SilentPolicy != existing.SilentPolicy,
-		CustomChanged: final.CustomMappingsInput != FormatCustomMappings(existing.CustomPolicies),
+		TokenChanged:    tokenInput != "" && tokenInput != existing.Token,
+		TeamsChanged:    !StringSlicesEqual(final.Teams, existing.Teams),
+		TerminalChanged: final.Terminal != existing.Terminal,
+		EditorChanged:   final.Editor != existing.Editor,
+		AgentChanged:    final.AgentTouched && final.AgentCLICommand != existing.AgentCLICommand,
+		SilentChanged:   final.SilentPolicy != existing.SilentPolicy,
+		CustomChanged:   final.CustomMappingsInput != FormatCustomMappings(existing.CustomPolicies),
 	}
 }
 
@@ -370,6 +411,27 @@ func MergeIntoExistingConfig(existingData []byte, final ResolvedValues, changes 
 		}
 	}
 
+	if changes.TerminalChanged {
+		data, err = UpsertScalarInConfig(data, "terminal", final.Terminal)
+		if err != nil {
+			return nil, fmt.Errorf("failed to update terminal: %w", err)
+		}
+	}
+
+	if changes.EditorChanged {
+		data, err = UpsertScalarInConfig(data, "editor", final.Editor)
+		if err != nil {
+			return nil, fmt.Errorf("failed to update editor: %w", err)
+		}
+	}
+
+	if changes.AgentChanged {
+		data, err = UpsertScalarInConfig(data, "agent_cli_command", final.AgentCLICommand)
+		if err != nil {
+			return nil, fmt.Errorf("failed to update agent command: %w", err)
+		}
+	}
+
 	if changes.SilentChanged || changes.CustomChanged {
 		data = CommentOutOldPolicies(data)
 	}
@@ -394,16 +456,32 @@ func BuildFullConfig(final ResolvedValues, teamNames map[string]string, silentPo
 		}
 	}
 
+	editor := final.Editor
+	if editor == "" {
+		editor = DefaultOptionalKeys["editor"]
+	}
+	terminal := final.Terminal
+	if terminal == "" {
+		terminal = DefaultOptionalKeys["terminal"]
+	}
+
 	sb.WriteString("\n# Optional settings\n")
 	for _, entry := range []struct{ key, val string }{
-		{"editor", "vim"},
-		{"terminal", "gnome-terminal --"},
-		{"cluster_login_command", "ocm backplane login %%CLUSTER_ID%%"},
-		{"toolbox_mode", "auto"},
-		{"chord_prefix", "ctrl+x"},
-		{"rosa_boundary_command", "rosa-boundary start-task --cluster-id %%CLUSTER_ID%% --connect"},
+		{"editor", editor},
+		{"terminal", terminal},
+		{"cluster_login_command", DefaultOptionalKeys["cluster_login_command"]},
+		{"toolbox_mode", DefaultOptionalKeys["toolbox_mode"]},
+		{"chord_prefix", DefaultOptionalKeys["chord_prefix"]},
+		{"rosa_boundary_command", DefaultOptionalKeys["rosa_boundary_command"]},
 	} {
 		fmt.Fprintf(&sb, "%s: %s\n", entry.key, entry.val)
+	}
+
+	// Persist a deliberate agent decision when it differs from the default
+	// (including "" = AI features disabled).
+	if final.AgentTouched && final.AgentCLICommand != DefaultOptionalKeys["agent_cli_command"] {
+		sb.WriteString("\n# CLI agent for :agent queries (empty disables AI features)\n")
+		fmt.Fprintf(&sb, "agent_cli_command: %q\n", final.AgentCLICommand)
 	}
 
 	if silentPolicy != "" {
@@ -455,6 +533,20 @@ func BuildSummary(existing ExistingConfig, final ResolvedValues, changes ConfigC
 			silentDisplay = fmt.Sprintf("%s (%s)", name, final.SilentPolicy)
 		}
 		fmt.Fprintf(&sb, "  Silent policy:  %s%s\n", silentDisplay, changeLabel)
+	}
+
+	if changes.TerminalChanged && final.Terminal != "" {
+		fmt.Fprintf(&sb, "  Terminal:       %s (changed)\n", final.Terminal)
+	}
+	if changes.EditorChanged && final.Editor != "" {
+		fmt.Fprintf(&sb, "  Editor:         %s (changed)\n", final.Editor)
+	}
+	if changes.AgentChanged {
+		agentDisplay := final.AgentCLICommand
+		if agentDisplay == "" {
+			agentDisplay = "(disabled)"
+		}
+		fmt.Fprintf(&sb, "  AI agent:       %s (changed)\n", agentDisplay)
 	}
 
 	if final.CustomMappingsInput != "" {

--- a/pkg/config/environment_test.go
+++ b/pkg/config/environment_test.go
@@ -1,0 +1,123 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The wizard's environment step (terminal/editor/agent) must flow through
+// resolve → detect-changes → write, like every other wizard value.
+
+func TestResolveFinalValues_EnvironmentFields(t *testing.T) {
+	existing := ExistingConfig{
+		Token:           "tok",
+		Teams:           []string{"T1"},
+		Terminal:        "gnome-terminal --",
+		Editor:          "vim",
+		AgentCLICommand: "claude --print",
+	}
+
+	rv, err := ResolveFinalValues(existing, WizardInputs{
+		TokenInput:    "",
+		KeepTeams:     true,
+		TerminalInput: "kitty",
+		EditorInput:   "  nano  ",
+		AgentInput:    "claude --print",
+		AgentTouched:  true,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "kitty", rv.Terminal)
+	assert.Equal(t, "nano", rv.Editor, "editor input is trimmed")
+	assert.Equal(t, "claude --print", rv.AgentCLICommand)
+}
+
+func TestResolveFinalValues_EnvironmentFallsBackToExisting(t *testing.T) {
+	existing := ExistingConfig{
+		Token:           "tok",
+		Teams:           []string{"T1"},
+		Terminal:        "gnome-terminal --",
+		Editor:          "emacs",
+		AgentCLICommand: "custom-agent",
+	}
+
+	rv, err := ResolveFinalValues(existing, WizardInputs{KeepTeams: true})
+	assert.NoError(t, err)
+	assert.Equal(t, "gnome-terminal --", rv.Terminal, "blank input keeps existing terminal")
+	assert.Equal(t, "emacs", rv.Editor)
+	assert.Equal(t, "custom-agent", rv.AgentCLICommand, "untouched agent keeps existing value")
+}
+
+func TestResolveFinalValues_AgentDisabled(t *testing.T) {
+	existing := ExistingConfig{Token: "tok", Teams: []string{"T1"}, AgentCLICommand: "claude --print"}
+
+	rv, err := ResolveFinalValues(existing, WizardInputs{
+		KeepTeams:    true,
+		AgentInput:   "",
+		AgentTouched: true,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "", rv.AgentCLICommand, "touched-and-empty means deliberately disabled")
+}
+
+func TestDetectChanges_EnvironmentFields(t *testing.T) {
+	existing := ExistingConfig{
+		Token:    "tok",
+		Teams:    []string{"T1"},
+		Terminal: "gnome-terminal --",
+		Editor:   "vim",
+	}
+	final := ResolvedValues{
+		Token:    "tok",
+		Teams:    []string{"T1"},
+		Terminal: "kitty",
+		Editor:   "vim",
+	}
+
+	changes := DetectChanges(existing, final, "")
+	assert.True(t, changes.TerminalChanged)
+	assert.False(t, changes.EditorChanged)
+	assert.True(t, changes.AnyChanged())
+}
+
+func TestBuildFullConfig_UsesResolvedEnvironment(t *testing.T) {
+	final := ResolvedValues{
+		Token:    "tok",
+		Teams:    []string{"T1"},
+		Terminal: "kitty",
+		Editor:   "nano",
+	}
+
+	out := string(BuildFullConfig(final, nil, "", nil))
+	assert.Contains(t, out, "terminal: kitty")
+	assert.Contains(t, out, "editor: nano")
+	assert.NotContains(t, out, "terminal: gnome-terminal --", "resolved terminal must replace the hardcoded default")
+}
+
+func TestBuildFullConfig_DefaultsWhenEnvironmentEmpty(t *testing.T) {
+	final := ResolvedValues{Token: "tok", Teams: []string{"T1"}}
+
+	out := string(BuildFullConfig(final, nil, "", nil))
+	assert.Contains(t, out, "terminal: gnome-terminal --")
+	assert.Contains(t, out, "editor: vim")
+}
+
+func TestBuildFullConfig_AgentDisabledWritten(t *testing.T) {
+	final := ResolvedValues{Token: "tok", Teams: []string{"T1"}, AgentCLICommand: "", AgentTouched: true}
+
+	out := string(BuildFullConfig(final, nil, "", nil))
+	assert.Contains(t, out, `agent_cli_command: ""`, "a deliberate disable must be persisted")
+}
+
+func TestMergeIntoExistingConfig_EnvironmentUpserts(t *testing.T) {
+	existing := []byte("token: tok\nteams:\n  - T1\nterminal: gnome-terminal --\n")
+	final := ResolvedValues{Token: "tok", Teams: []string{"T1"}, Terminal: "kitty", Editor: "nano"}
+	changes := ConfigChanges{TerminalChanged: true, EditorChanged: true}
+
+	out, err := MergeIntoExistingConfig(existing, final, changes, nil, nil)
+	assert.NoError(t, err)
+	assert.Contains(t, string(out), "terminal: kitty")
+	assert.Contains(t, string(out), "editor: nano")
+	assert.True(t, strings.Contains(string(out), "token: tok"), "untouched keys preserved")
+}

--- a/pkg/launcher/detect.go
+++ b/pkg/launcher/detect.go
@@ -1,0 +1,82 @@
+package launcher
+
+// DetectedTerminal describes a terminal emulator found on this system,
+// with the config-ready `terminal` value to use for it. Profiles handle
+// argument style at launch time, so Command is just the executable name
+// (or AppleScript identifier on macOS).
+type DetectedTerminal struct {
+	Name    string
+	Command string
+}
+
+// detectableTerminals is the PATH probe order for the known profiles —
+// every executable DetectTerminalProfile understands, most common first.
+// tmux is handled separately (only offered inside a session), and the
+// macOS AppleScript terminals are appended on darwin.
+var detectableTerminals = []string{
+	"gnome-terminal",
+	"ptyxis",
+	"konsole",
+	"wezterm",
+	"kitty",
+	"alacritty",
+	"ghostty",
+	"foot",
+	"blackbox",
+	"terminator",
+	"contour",
+}
+
+// termProgramNames maps $TERM_PROGRAM values to detected-terminal names so
+// the terminal the user is sitting in can be ranked first.
+var termProgramNames = map[string]string{
+	"WezTerm":        "wezterm",
+	"ghostty":        "ghostty",
+	"kitty":          "kitty",
+	"tmux":           "tmux",
+	"iTerm.app":      "iterm2",
+	"Apple_Terminal": "terminal",
+}
+
+// DetectTerminals probes this system for known terminal emulators and
+// returns them ranked: the terminal identified by $TERM_PROGRAM first, tmux
+// next when running inside a session, then the rest in probe order. On
+// darwin, Terminal.app and iTerm2 are always candidates (launched via
+// osascript, not PATH). lookPath, getenv, and goos are injectable for tests;
+// production callers pass exec.LookPath, os.Getenv, runtime.GOOS.
+func DetectTerminals(lookPath func(string) (string, error), getenv func(string) string, goos string) []DetectedTerminal {
+	var found []DetectedTerminal
+
+	// Inside a tmux session, a new window lands in the session — offer it.
+	if getenv("TMUX") != "" {
+		if _, err := lookPath("tmux"); err == nil {
+			found = append(found, DetectedTerminal{Name: "tmux", Command: "tmux"})
+		}
+	}
+
+	for _, name := range detectableTerminals {
+		if _, err := lookPath(name); err == nil {
+			found = append(found, DetectedTerminal{Name: name, Command: name})
+		}
+	}
+
+	if goos == "darwin" {
+		found = append(found,
+			DetectedTerminal{Name: "terminal", Command: "terminal"},
+			DetectedTerminal{Name: "iterm2", Command: "iterm2"},
+		)
+	}
+
+	// Rank the terminal the user is sitting in first.
+	if current, ok := termProgramNames[getenv("TERM_PROGRAM")]; ok {
+		for i, dt := range found {
+			if dt.Name == current && i > 0 {
+				found = append(found[:i], found[i+1:]...)
+				found = append([]DetectedTerminal{dt}, found...)
+				break
+			}
+		}
+	}
+
+	return found
+}

--- a/pkg/launcher/detect_test.go
+++ b/pkg/launcher/detect_test.go
@@ -1,0 +1,99 @@
+package launcher
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func fakeLookPath(found ...string) func(string) (string, error) {
+	set := make(map[string]bool)
+	for _, f := range found {
+		set[f] = true
+	}
+	return func(name string) (string, error) {
+		if set[name] {
+			return "/usr/bin/" + name, nil
+		}
+		return "", fmt.Errorf("%s not found", name)
+	}
+}
+
+func fakeGetenv(env map[string]string) func(string) string {
+	return func(key string) string { return env[key] }
+}
+
+func names(dts []DetectedTerminal) []string {
+	var out []string
+	for _, dt := range dts {
+		out = append(out, dt.Name)
+	}
+	return out
+}
+
+// OB-5: probe PATH for the known terminal profiles so the wizard can offer
+// real choices instead of assuming gnome-terminal.
+func TestDetectTerminals_ProbesKnownProfiles(t *testing.T) {
+	dts := DetectTerminals(fakeLookPath("konsole", "kitty"), fakeGetenv(nil), "linux")
+
+	assert.Equal(t, []string{"konsole", "kitty"}, names(dts))
+	for _, dt := range dts {
+		assert.NotEmpty(t, dt.Command)
+	}
+}
+
+func TestDetectTerminals_NoneFound(t *testing.T) {
+	dts := DetectTerminals(fakeLookPath(), fakeGetenv(nil), "linux")
+	assert.Empty(t, dts)
+}
+
+// $TERM_PROGRAM identifies the terminal the user is sitting in — rank it first.
+func TestDetectTerminals_TermProgramRanksFirst(t *testing.T) {
+	dts := DetectTerminals(
+		fakeLookPath("gnome-terminal", "wezterm"),
+		fakeGetenv(map[string]string{"TERM_PROGRAM": "WezTerm"}),
+		"linux",
+	)
+	assert.Equal(t, "wezterm", dts[0].Name, "the terminal the user is in ranks first")
+}
+
+// Inside tmux, offer tmux near the front (new windows land in the session).
+func TestDetectTerminals_TmuxWhenInside(t *testing.T) {
+	dts := DetectTerminals(
+		fakeLookPath("tmux", "gnome-terminal"),
+		fakeGetenv(map[string]string{"TMUX": "/tmp/tmux-1000/default,1,0"}),
+		"linux",
+	)
+	assert.Contains(t, names(dts), "tmux")
+	assert.Equal(t, "tmux", dts[0].Name)
+}
+
+func TestDetectTerminals_TmuxOnlyWhenInside(t *testing.T) {
+	dts := DetectTerminals(fakeLookPath("tmux", "gnome-terminal"), fakeGetenv(nil), "linux")
+	assert.NotContains(t, names(dts), "tmux",
+		"tmux outside a session cannot open a window — do not offer it")
+}
+
+// macOS: Terminal.app and iTerm2 are launched via osascript, not PATH — they
+// are always candidates on darwin.
+func TestDetectTerminals_DarwinIncludesAppleTerminals(t *testing.T) {
+	dts := DetectTerminals(fakeLookPath(), fakeGetenv(nil), "darwin")
+	assert.Contains(t, names(dts), "terminal")
+	assert.Contains(t, names(dts), "iterm2")
+}
+
+func TestDetectTerminals_DarwinTermProgramRanksITermFirst(t *testing.T) {
+	dts := DetectTerminals(
+		fakeLookPath(),
+		fakeGetenv(map[string]string{"TERM_PROGRAM": "iTerm.app"}),
+		"darwin",
+	)
+	assert.Equal(t, "iterm2", dts[0].Name)
+}
+
+func TestDetectTerminals_LinuxExcludesAppleTerminals(t *testing.T) {
+	dts := DetectTerminals(fakeLookPath("gnome-terminal"), fakeGetenv(nil), "linux")
+	assert.NotContains(t, names(dts), "terminal")
+	assert.NotContains(t, names(dts), "iterm2")
+}

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -1417,6 +1417,13 @@ type configFormState struct {
 	// mappings) that most users should never see; defaults to No.
 	AdvancedOptions bool
 	Confirm         bool
+	// Environment step (OB-5).
+	TerminalChoice string
+	EditorInput    string
+	AgentEnabled   bool
+	// AgentOffered records whether the AI section was shown at all —
+	// hidden means "keep the existing agent setting".
+	AgentOffered bool
 	// FetchedUserName/FetchedTeamCount are set by the team OptionsFunc after
 	// a successful fetch and drive the greeting DescriptionFunc.
 	FetchedUserName  string
@@ -1462,6 +1469,9 @@ func prepareConfigWizardCmd(m model) tea.Cmd {
 			viper.GetString("custom_service_escalation_policies"),
 			viper.GetStringMapString("service_escalation_policies"),
 		)
+		existing.Terminal = viper.GetString("terminal")
+		existing.Editor = viper.GetString("editor")
+		existing.AgentCLICommand = viper.GetString("agent_cli_command")
 		kd := pkgconfig.ResolveKeepDefaults(existing.Teams, existing.SilentPolicy, existing.CustomPolicies)
 
 		home, _ := os.UserHomeDir()

--- a/pkg/tui/config_environment_test.go
+++ b/pkg/tui/config_environment_test.go
@@ -1,0 +1,70 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/clcollins/srepd/pkg/launcher"
+	"github.com/stretchr/testify/assert"
+)
+
+// OB-5: the wizard's environment step offers detected terminals; the current
+// setting leads, annotated — with a warning when its binary is missing.
+func TestBuildTerminalOptions_CurrentFirstAnnotated(t *testing.T) {
+	detected := []launcher.DetectedTerminal{
+		{Name: "konsole", Command: "konsole"},
+		{Name: "kitty", Command: "kitty"},
+	}
+
+	opts := buildTerminalOptions("gnome-terminal --", true, detected)
+
+	assert.Equal(t, "gnome-terminal --", opts[0].Value)
+	assert.Contains(t, opts[0].Key, "current")
+	assert.NotContains(t, opts[0].Key, "not found")
+	assert.Equal(t, "konsole", opts[1].Value)
+	assert.Equal(t, "kitty", opts[2].Value)
+}
+
+func TestBuildTerminalOptions_MissingCurrentWarns(t *testing.T) {
+	opts := buildTerminalOptions("gnome-terminal --", false, []launcher.DetectedTerminal{
+		{Name: "kitty", Command: "kitty"},
+	})
+
+	assert.Equal(t, "gnome-terminal --", opts[0].Value)
+	assert.Contains(t, opts[0].Key, "not found on this system")
+}
+
+func TestBuildTerminalOptions_CurrentDeduplicated(t *testing.T) {
+	opts := buildTerminalOptions("kitty", true, []launcher.DetectedTerminal{
+		{Name: "kitty", Command: "kitty"},
+		{Name: "foot", Command: "foot"},
+	})
+
+	assert.Len(t, opts, 2, "the current terminal must not be listed twice")
+	assert.Equal(t, "kitty", opts[0].Value)
+	assert.Equal(t, "foot", opts[1].Value)
+}
+
+// Editor default: existing config → $EDITOR → $VISUAL → vim.
+func TestResolveEditorDefault(t *testing.T) {
+	env := func(m map[string]string) func(string) string {
+		return func(k string) string { return m[k] }
+	}
+
+	assert.Equal(t, "emacs", resolveEditorDefault("emacs", env(map[string]string{"EDITOR": "nano"})),
+		"existing config wins")
+	assert.Equal(t, "nano", resolveEditorDefault("", env(map[string]string{"EDITOR": "nano", "VISUAL": "code"})),
+		"$EDITOR beats $VISUAL")
+	assert.Equal(t, "code", resolveEditorDefault("", env(map[string]string{"VISUAL": "code"})))
+	assert.Equal(t, "vim", resolveEditorDefault("", env(nil)), "final fallback is vim")
+}
+
+// #324: offer AI setup only when the claude CLI is actually on PATH, and not
+// when the user has already customized the agent command.
+func TestShouldOfferAgentSetup(t *testing.T) {
+	defaultCmd := "claude --print"
+
+	assert.True(t, shouldOfferAgentSetup(defaultCmd, true), "default command + claude present → offer")
+	assert.True(t, shouldOfferAgentSetup("", true), "unset command + claude present → offer")
+	assert.False(t, shouldOfferAgentSetup(defaultCmd, false), "no claude on PATH → silent skip")
+	assert.False(t, shouldOfferAgentSetup("ollama run llama", true), "customized command → already configured, skip")
+}

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -331,6 +331,10 @@ func switchConfigFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 			KeepTeams:           m.configState.KeepTeams,
 			KeepSilent:          m.configState.KeepSilent,
 			KeepCustom:          m.configState.KeepCustom,
+			TerminalInput:       m.configState.TerminalChoice,
+			EditorInput:         m.configState.EditorInput,
+			AgentInput:          agentInputValue(m.configState.AgentEnabled),
+			AgentTouched:        m.configState.AgentOffered,
 		})
 		if err != nil {
 			m.setStatus("config error: " + err.Error())

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -2,7 +2,10 @@ package tui
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
 	"reflect"
+	"runtime"
 	"slices"
 	"strings"
 	"time"
@@ -18,6 +21,7 @@ import (
 	"github.com/clcollins/srepd/pkg/alert"
 	"github.com/clcollins/srepd/pkg/backplane"
 	pkgconfig "github.com/clcollins/srepd/pkg/config"
+	"github.com/clcollins/srepd/pkg/launcher"
 	"github.com/clcollins/srepd/pkg/ocm"
 	"github.com/clcollins/srepd/pkg/pd"
 	"github.com/spf13/viper"
@@ -283,6 +287,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			KeepSilent:         msg.kd.KeepSilent,
 			KeepCustom:         msg.kd.KeepCustom,
 			Confirm:            true,
+			TerminalChoice:     msg.existing.Terminal,
+			EditorInput:        resolveEditorDefault(msg.existing.Editor, os.Getenv),
+			AgentEnabled:       true,
 		}
 
 		existingTeamSet := make(map[string]bool)
@@ -2059,6 +2066,66 @@ func resolveSilentPolicyChoice(choice, manualInput string) string {
 	return choice
 }
 
+// buildTerminalOptions builds the environment step's terminal choices: the
+// current setting first (annotated, with a warning when its binary is
+// missing), then the detected terminals, deduplicated.
+func buildTerminalOptions(current string, currentFound bool, detected []launcher.DetectedTerminal) []huh.Option[string] {
+	var opts []huh.Option[string]
+	if current != "" {
+		label := fmt.Sprintf("%s (current)", current)
+		if !currentFound {
+			label = fmt.Sprintf("%s (current — not found on this system!)", current)
+		}
+		opts = append(opts, huh.NewOption(label, current))
+	}
+	currentExec := ""
+	if fields := strings.Fields(current); len(fields) > 0 {
+		currentExec = fields[0]
+	}
+	for _, dt := range detected {
+		if dt.Command == current || dt.Name == currentExec {
+			continue
+		}
+		opts = append(opts, huh.NewOption(dt.Name, dt.Command))
+	}
+	return opts
+}
+
+// resolveEditorDefault picks the editor the wizard should offer: existing
+// config → $EDITOR → $VISUAL → vim.
+func resolveEditorDefault(current string, getenv func(string) string) string {
+	if current != "" {
+		return current
+	}
+	if e := getenv("EDITOR"); e != "" {
+		return e
+	}
+	if v := getenv("VISUAL"); v != "" {
+		return v
+	}
+	return "vim"
+}
+
+// shouldOfferAgentSetup gates the AI section (#324): only when the claude
+// CLI is on PATH, and only when the user hasn't already customized the
+// agent command (a custom value means they've configured it themselves).
+func shouldOfferAgentSetup(existingCmd string, claudeOnPath bool) bool {
+	if !claudeOnPath {
+		return false
+	}
+	return existingCmd == "" || existingCmd == pkgconfig.DefaultOptionalKeys["agent_cli_command"]
+}
+
+// agentInputValue maps the AI confirm to the agent_cli_command value:
+// enabled → the default claude command, disabled → "" (persisted so the
+// decision sticks).
+func agentInputValue(enabled bool) string {
+	if enabled {
+		return pkgconfig.DefaultOptionalKeys["agent_cli_command"]
+	}
+	return ""
+}
+
 // validateTeamValues rejects an empty selection and the empty-valued
 // placeholder/error options fetchTeamOptions emits.
 func validateTeamValues(s []string) error {
@@ -2092,6 +2159,27 @@ func (m *model) buildConfigForm(msg configWizardReadyMsg, tokenDesc, keepTeamsDe
 	if clientFactory == nil {
 		clientFactory = pd.NewClient
 	}
+
+	// Environment step data (OB-5): detect terminals, check the current one,
+	// and decide whether to offer the AI section (#324).
+	detected := launcher.DetectTerminals(exec.LookPath, os.Getenv, runtime.GOOS)
+	currentTerminal := msg.existing.Terminal
+	currentFound := true
+	if fields := strings.Fields(currentTerminal); len(fields) > 0 {
+		// Flatpak app IDs (reverse-DNS) are not in PATH; don't warn on them.
+		if strings.Count(fields[0], ".") < 2 {
+			_, lookErr := exec.LookPath(fields[0])
+			currentFound = lookErr == nil
+		}
+	}
+	terminalOpts := buildTerminalOptions(currentTerminal, currentFound, detected)
+	if len(terminalOpts) == 0 {
+		terminalOpts = []huh.Option[string]{
+			huh.NewOption(pkgconfig.DefaultOptionalKeys["terminal"]+" (default)", pkgconfig.DefaultOptionalKeys["terminal"]),
+		}
+	}
+	_, claudeErr := exec.LookPath("claude")
+	m.configState.AgentOffered = shouldOfferAgentSetup(msg.existing.AgentCLICommand, claudeErr == nil)
 
 	return huh.NewForm(
 		huh.NewGroup(
@@ -2171,6 +2259,29 @@ func (m *model) buildConfigForm(msg configWizardReadyMsg, tokenDesc, keepTeamsDe
 			return m.configState.KeepSilent || m.configState.SilentPolicyChoice != policyChoiceManual
 		}),
 		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title("Terminal for cluster login").
+				Description(
+					"Opens cluster login sessions. Terminals detected on this\n"+
+						"system are listed; your current setting comes first.",
+				).
+				Options(terminalOpts...).
+				Value(&m.configState.TerminalChoice),
+			huh.NewInput().
+				Title("Editor for incident notes").
+				Description("Prefilled from your config or $EDITOR/$VISUAL.").
+				Value(&m.configState.EditorInput),
+		),
+		huh.NewGroup(
+			huh.NewConfirm().
+				Title("Enable AI agent features?").
+				Description(
+					"The claude CLI was detected on this system. :agent queries\n"+
+						"use it for read-only incident investigation.",
+				).
+				Value(&m.configState.AgentEnabled),
+		).WithHideFunc(func() bool { return !m.configState.AgentOffered }),
+		huh.NewGroup(
 			huh.NewConfirm().
 				Title("Configure advanced options?").
 				Description(
@@ -2215,6 +2326,10 @@ func (m *model) buildConfigForm(msg configWizardReadyMsg, tokenDesc, keepTeamsDe
 						KeepTeams:           m.configState.KeepTeams,
 						KeepSilent:          m.configState.KeepSilent,
 						KeepCustom:          m.configState.KeepCustom,
+						TerminalInput:       m.configState.TerminalChoice,
+						EditorInput:         m.configState.EditorInput,
+						AgentInput:          agentInputValue(m.configState.AgentEnabled),
+						AgentTouched:        m.configState.AgentOffered,
 					})
 					tmpNames := make(map[string]string)
 					for k, v := range m.configTeamNames {


### PR DESCRIPTION
> **Stacked on #368** (← #367 ← #366 ← #365 ← #364 ← #363). Review/merge in order. Part of the onboarding overhaul (#353, #324).

## Problem

- `terminal: gnome-terminal --` default is wrong on macOS/non-GNOME; the wizard never surfaced it; a bad terminal only failed as a journal warning at cluster-login time (OB-5)
- `$EDITOR` was ignored
- AI agent config existed but was invisible in the wizard (#324)
- Terminal/editor/agent weren't part of the wizard's write pipeline at all — `BuildFullConfig` wrote hardcoded defaults

## Changes

- **`launcher.DetectTerminals(lookPath, getenv, goos)`** — probes PATH for every profile-registry executable; `$TERM_PROGRAM` match ranks first, tmux only offered inside a session, Terminal.app/iTerm2 always candidates on darwin. Fully injectable.
- **New environment step in the wizard**: terminal `Select` (current setting first, annotated — **"(current — not found on this system!)"** when its binary is missing), editor `Input` (config → `$EDITOR` → `$VISUAL` → vim), and an AI confirm shown only when claude is on PATH and `agent_cli_command` isn't customized (silent skip otherwise, per #324). Declining AI persists `agent_cli_command: ""`.
- **Write path extended** (`pkg/config`): Terminal/Editor/Agent flow through resolve → detect-changes → merge/build; `AgentTouched` distinguishes "deliberately disabled" from "step hidden, keep existing"; `BuildFullConfig` writes resolved values instead of hardcoded defaults; summary shows changed environment values.

## Tests (TDD)

Three new test files across launcher/tui/config: detection ranking table, terminal option building (annotation/warning/dedup), editor chain, agent gating, resolve/detect/merge/build coverage incl. the deliberate-disable case. Full suite, `-race`, lint green.

## Plan doc

`docs/plans/368-environment-detection.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BtcSJfWWcDKL4rSNNH1cN