### PR TITLE
Add team presets: srepd config --preset <file|https-url>

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ go install .        # standard go install
 | `srepd update` | Update to the latest release in place |
 | `srepd --version` | Print version and git SHA |
 | `srepd --dev` | Run with fixture data (no PD connection) |
-| `srepd config` | Interactive configuration wizard |
+| `srepd config` | Interactive configuration wizard (`--preset <file\|https-url>` to pre-seed from a team preset) |
 | `srepd config generate` | Print a complete annotated config with defaults (`--out <path>` to write a file) |
 
 ## Configuration
@@ -54,6 +54,8 @@ SREPD reads `~/.config/srepd/srepd.yaml` and supports `SREPD_` environment varia
 If no config file exists — or the config file is incomplete or still contains placeholder values — running `srepd` automatically enters the configuration wizard. The wizard validates your token, greets you by name, auto-selects your team when you belong to exactly one, and gates advanced options (custom service-to-policy mappings) behind a default-No confirm so most users never see them. The form resizes dynamically when the terminal window changes size.
 
 **Migrating from old config format:** If your config uses the deprecated `service_escalation_policies` key, running `srepd config` will automatically migrate to the new `default_silent_escalation_policy` and `custom_service_escalation_policies` keys. The old block is commented out with a deprecation note.
+
+**Team presets:** `srepd config --preset <file|https-url>` pre-seeds the wizard from a team-published YAML fragment carrying team policy decisions — teams, `default_silent_escalation_policy`, `custom_service_escalation_policies`, `cluster_login_command`, and optionally `terminal`/`editor`. Presets can never set `token` or `llm_api` credentials, only fill values you haven't configured, and every value is still confirmed in the wizard. URL fetches are HTTPS-only and size-capped. Teams can publish one preset link in their onboarding docs to eliminate the ID scavenger hunt for new members.
 
 ### Required
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -57,6 +57,11 @@ func maskConfigValue(key, value string) string {
 	return "*****"
 }
 
+// configPresetRef is the --preset flag value: a file path or HTTPS URL to a
+// team-published preset that pre-seeds the wizard (teams, silent policy,
+// custom mappings, cluster login command). Never a token.
+var configPresetRef string
+
 // configCmd represents the config command
 var configCmd = &cobra.Command{
 	Use:          "config",
@@ -64,11 +69,15 @@ var configCmd = &cobra.Command{
 	Long:         description,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if configPresetRef != "" {
+			viper.Set("config_preset", configPresetRef)
+		}
 		return runConfigWizard()
 	},
 }
 
 func init() {
+	configCmd.Flags().StringVar(&configPresetRef, "preset", "", "file path or https URL of a team preset to pre-seed the wizard")
 	rootCmd.AddCommand(configCmd)
 }
 

--- a/docs/plans/370-team-preset.md
+++ b/docs/plans/370-team-preset.md
@@ -1,0 +1,51 @@
+# 370: Team preset — srepd config --preset <file|https-url>
+
+Issue: #353/#324 (onboarding overhaul — the "have to know to know" problem)
+Branch: `srepd/team-preset`
+
+## Problem
+
+Some wizard values are pure team policy and fundamentally undiscoverable:
+`custom_service_escalation_policies` mappings, an org-specific
+`cluster_login_command`, sometimes which team/silent policy to pick. They are
+"100% policy, not accurate or applicable to everyone" — no heuristic can
+derive them, and hardcoding any org's choices into SREPD would be wrong.
+
+## Approach: policy-as-artifact
+
+A team publishes one YAML fragment in its onboarding docs; new SREs run
+`srepd config --preset <file|https-url>` and inherit the decisions.
+
+- **`pkgconfig.Preset` / `ParsePreset`**: strict allowlist — teams,
+  default_silent_escalation_policy, custom_service_escalation_policies,
+  cluster_login_command, terminal, editor. ANY other key (above all `token`
+  and `llm_api`) rejects the whole preset loudly; a typo in a team preset
+  should fail review, not be silently ignored.
+- **`LoadPreset(ref, client)`**: file path or URL. URL guardrails: HTTPS
+  only, 64KB cap (`presetMaxBytes`), non-200 rejected, explicit flag only
+  (never auto-fetched), injectable client for tests, source recorded and
+  shown in the wizard.
+- **`ApplyPreset(existing, preset)`**: overlays only where existing is empty
+  — the user's real config always wins over team defaults. Returns
+  `PresetApplied` flags + source.
+- **Wizard integration**: `prepareConfigWizardCmd` loads/applies the preset
+  (load failure → hard error view; the user explicitly asked for it);
+  keep-prompts show "(from preset: <source>)"; summary gets a "Preset
+  applied" line; `ForcePresetChanges` marks seeded fields changed so they
+  are persisted even though they equal the seeded "existing" values.
+- **`viperConfiguredString`**: environment values count as existing only when
+  actually user-set (config file / SREPD_* env) — `ensureViperDefaults`
+  fills viper with in-process defaults that must not block preset overlay.
+- **`cluster_login_command`** threaded through the write pipeline
+  (ExistingConfig/ResolvedValues/changes/merge/BuildFullConfig) — it has no
+  wizard step; it flows from config or preset straight to disk.
+- Every value is still walked and confirmed in the wizard — a preset is
+  defaults, not a config.
+
+## Tests (TDD — written first)
+
+`pkg/config/preset_test.go`: parse (valid/reject token/reject llm_api/reject
+unknown/invalid YAML), apply (existing wins, empty fills, applied flags, nil
+no-op), file load, HTTPS-only, TLS fetch via httptest, size cap, non-200,
+change forcing. README documents the feature (config.go changed →
+readme-check).

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -1,0 +1,89 @@
+# Team Presets
+
+A preset is a YAML file containing team policy decisions that new SREs
+inherit instead of hunting for PagerDuty IDs. It pre-seeds the config
+wizard — every value is still shown to and confirmed by the user.
+
+## Usage
+
+```bash
+# From a local file
+srepd config --preset /path/to/team-preset.yaml
+
+# From an HTTPS URL (e.g. a GitHub gist)
+srepd config --preset https://gist.githubusercontent.com/.../preset.yaml
+```
+
+The wizard opens with preset values pre-filled. The summary step tags
+preset-sourced values with "(from preset: <source>)".
+
+## Example preset
+
+```yaml
+# SREP Team Preset
+# Only include keys your team standardizes on — everything else
+# is discovered by the wizard or left at the user's preference.
+
+# Team ID(s) to monitor
+teams:
+  - PASPK4G
+
+# Silent escalation policy for silencing incidents
+default_silent_escalation_policy: PCGXUDY
+
+# Per-service overrides (service ID → silent policy ID)
+custom_service_escalation_policies:
+  P5LAB5Y: PVBANNN
+
+# Cluster login command (ocm backplane or ocm-container)
+cluster_login_command: ocm backplane login %%CLUSTER_ID%%
+
+# Optional: terminal and editor preferences
+# terminal: gnome-terminal --
+# editor: vim
+```
+
+## Allowed keys
+
+| Key | Purpose |
+|-----|---------|
+| `teams` | PagerDuty team IDs to monitor |
+| `default_silent_escalation_policy` | Silent escalation policy ID |
+| `custom_service_escalation_policies` | Per-service silent policy overrides |
+| `cluster_login_command` | Cluster login command template |
+| `terminal` | Terminal emulator |
+| `editor` | Editor for incident notes |
+
+Any other key is **rejected loudly** — a typo in a team preset should fail
+review, not be silently ignored. In particular, `token` and `llm_api` are
+never accepted: presets carry team policy, not credentials.
+
+## How presets interact with existing config
+
+- **Existing values always win.** A preset only fills values the user hasn't
+  configured. If your config already has a `terminal`, the preset's
+  `terminal` is ignored.
+- **Presets don't bypass the wizard.** Every value is shown in the wizard for
+  confirmation. The summary tags preset-sourced values.
+- **`--preset` is explicit.** Presets are never auto-fetched. The user must
+  pass the flag.
+
+## Security
+
+- **HTTPS only** for URL fetches — HTTP is rejected
+- **64KB size cap** — a preset is a handful of IDs, not a megabyte document
+- **No credentials** — `token` and `llm_api` keys are always rejected
+- **No redirects to insecure hosts** — Go's `http.Client` follows redirects
+  but the initial URL must be HTTPS
+
+## Publishing a preset for your team
+
+1. Create a YAML file with your team's policy decisions (see example above)
+2. Host it somewhere your team can access:
+   - A GitHub/GitLab gist (use the "raw" URL)
+   - Your team's internal docs repo
+   - Any HTTPS-accessible URL
+3. Add one line to your team's onboarding docs:
+   ```
+   srepd config --preset https://your-url/srep-preset.yaml
+   ```

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -70,6 +70,9 @@ type ExistingConfig struct {
 	Terminal        string
 	Editor          string
 	AgentCLICommand string
+	// ClusterLoginCommand has no wizard step; it flows from an existing
+	// config or a team preset straight through to the write path.
+	ClusterLoginCommand string
 }
 
 func ResolveExistingConfig(
@@ -166,6 +169,7 @@ type ResolvedValues struct {
 	Editor              string
 	AgentCLICommand     string
 	AgentTouched        bool
+	ClusterLoginCommand string
 }
 
 func ResolveFinalValues(existing ExistingConfig, inputs WizardInputs) (ResolvedValues, error) {
@@ -211,23 +215,25 @@ func ResolveFinalValues(existing ExistingConfig, inputs WizardInputs) (ResolvedV
 	if inputs.AgentTouched {
 		rv.AgentCLICommand = strings.TrimSpace(inputs.AgentInput)
 	}
+	rv.ClusterLoginCommand = existing.ClusterLoginCommand
 
 	return rv, nil
 }
 
 type ConfigChanges struct {
-	TokenChanged    bool
-	TeamsChanged    bool
-	SilentChanged   bool
-	CustomChanged   bool
-	TerminalChanged bool
-	EditorChanged   bool
-	AgentChanged    bool
+	TokenChanged        bool
+	TeamsChanged        bool
+	SilentChanged       bool
+	CustomChanged       bool
+	TerminalChanged     bool
+	EditorChanged       bool
+	AgentChanged        bool
+	ClusterLoginChanged bool
 }
 
 func (c ConfigChanges) AnyChanged() bool {
 	return c.TokenChanged || c.TeamsChanged || c.SilentChanged || c.CustomChanged ||
-		c.TerminalChanged || c.EditorChanged || c.AgentChanged
+		c.TerminalChanged || c.EditorChanged || c.AgentChanged || c.ClusterLoginChanged
 }
 
 func DetectChangesForNewFile(final ResolvedValues) ConfigChanges {
@@ -432,6 +438,13 @@ func MergeIntoExistingConfig(existingData []byte, final ResolvedValues, changes 
 		}
 	}
 
+	if changes.ClusterLoginChanged && final.ClusterLoginCommand != "" {
+		data, err = UpsertScalarInConfig(data, "cluster_login_command", final.ClusterLoginCommand)
+		if err != nil {
+			return nil, fmt.Errorf("failed to update cluster login command: %w", err)
+		}
+	}
+
 	if changes.SilentChanged || changes.CustomChanged {
 		data = CommentOutOldPolicies(data)
 	}
@@ -464,12 +477,16 @@ func BuildFullConfig(final ResolvedValues, teamNames map[string]string, silentPo
 	if terminal == "" {
 		terminal = DefaultOptionalKeys["terminal"]
 	}
+	clusterLogin := final.ClusterLoginCommand
+	if clusterLogin == "" {
+		clusterLogin = DefaultOptionalKeys["cluster_login_command"]
+	}
 
 	sb.WriteString("\n# Optional settings\n")
 	for _, entry := range []struct{ key, val string }{
 		{"editor", editor},
 		{"terminal", terminal},
-		{"cluster_login_command", DefaultOptionalKeys["cluster_login_command"]},
+		{"cluster_login_command", clusterLogin},
 		{"toolbox_mode", DefaultOptionalKeys["toolbox_mode"]},
 		{"chord_prefix", DefaultOptionalKeys["chord_prefix"]},
 		{"rosa_boundary_command", DefaultOptionalKeys["rosa_boundary_command"]},

--- a/pkg/config/preset.go
+++ b/pkg/config/preset.go
@@ -1,0 +1,213 @@
+package config
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// presetMaxBytes caps fetched preset size: a team preset is a handful of
+// IDs, never megabytes.
+const presetMaxBytes = 64 * 1024
+
+// Preset is a team-published YAML fragment carrying the "have to know to
+// know" policy decisions (custom service→policy mappings, org cluster login
+// command, the team's silent policy) so new SREs inherit them instead of
+// hunting IDs. A preset only pre-seeds the wizard — every value is still
+// shown to and confirmed by the user, and it can never carry credentials.
+type Preset struct {
+	Teams               []string
+	SilentPolicy        string
+	CustomPolicies      map[string]string
+	ClusterLoginCommand string
+	Terminal            string
+	Editor              string
+	Source              string
+}
+
+// PresetApplied records which fields a preset actually seeded, so the
+// wizard can tag them and force them into the write set.
+type PresetApplied struct {
+	Teams        bool
+	Silent       bool
+	Custom       bool
+	ClusterLogin bool
+	Terminal     bool
+	Editor       bool
+	Source       string
+}
+
+func (p PresetApplied) Any() bool {
+	return p.Teams || p.Silent || p.Custom || p.ClusterLogin || p.Terminal || p.Editor
+}
+
+// presetAllowedKeys is the strict allowlist of keys a preset may set.
+// Everything else — above all token and llm_api credentials — is rejected
+// loudly rather than silently ignored.
+var presetAllowedKeys = map[string]bool{
+	"teams":                              true,
+	"default_silent_escalation_policy":   true,
+	"custom_service_escalation_policies": true,
+	"cluster_login_command":              true,
+	"terminal":                           true,
+	"editor":                             true,
+}
+
+// ParsePreset parses and validates a preset document. source is recorded for
+// display ("(from preset: <source>)").
+func ParsePreset(data []byte, source string) (*Preset, error) {
+	var raw map[string]any
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("invalid preset YAML: %w", err)
+	}
+
+	var rejected []string
+	for key := range raw {
+		if !presetAllowedKeys[key] {
+			rejected = append(rejected, key)
+		}
+	}
+	if len(rejected) > 0 {
+		sort.Strings(rejected)
+		return nil, fmt.Errorf("preset may not set %s — presets carry team policy only, never credentials or personal settings", strings.Join(rejected, ", "))
+	}
+
+	p := &Preset{Source: source}
+	if teams, ok := raw["teams"].([]any); ok {
+		for _, t := range teams {
+			p.Teams = append(p.Teams, fmt.Sprintf("%v", t))
+		}
+	}
+	if v, ok := raw["default_silent_escalation_policy"].(string); ok {
+		p.SilentPolicy = v
+	}
+	if mappings, ok := raw["custom_service_escalation_policies"].(map[string]any); ok {
+		p.CustomPolicies = make(map[string]string, len(mappings))
+		for k, v := range mappings {
+			p.CustomPolicies[k] = fmt.Sprintf("%v", v)
+		}
+	}
+	if v, ok := raw["cluster_login_command"].(string); ok {
+		p.ClusterLoginCommand = v
+	}
+	if v, ok := raw["terminal"].(string); ok {
+		p.Terminal = v
+	}
+	if v, ok := raw["editor"].(string); ok {
+		p.Editor = v
+	}
+	return p, nil
+}
+
+// LoadPreset loads a preset from a local file path or an HTTPS URL.
+// URL fetches are HTTPS-only, size-capped, and never automatic — the user
+// passed --preset explicitly. client is injectable for tests; nil means
+// http.DefaultClient.
+func LoadPreset(ref string, client *http.Client) (*Preset, error) {
+	if strings.Contains(ref, "://") {
+		return fetchPresetURL(ref, client)
+	}
+
+	data, err := os.ReadFile(ref)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read preset file: %w", err)
+	}
+	return ParsePreset(data, ref)
+}
+
+func fetchPresetURL(url string, client *http.Client) (*Preset, error) {
+	if !strings.HasPrefix(url, "https://") {
+		return nil, fmt.Errorf("preset URLs must use https, got %q", url)
+	}
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch preset: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch preset: %s returned %s", url, resp.Status)
+	}
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, presetMaxBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read preset: %w", err)
+	}
+	if len(data) > presetMaxBytes {
+		return nil, fmt.Errorf("preset exceeds the %d byte limit", presetMaxBytes)
+	}
+
+	return ParsePreset(data, url)
+}
+
+// ApplyPreset overlays preset values onto existing where existing is empty:
+// the user's real config always wins over team defaults. Returns the merged
+// config and which fields the preset seeded.
+func ApplyPreset(existing ExistingConfig, p *Preset) (ExistingConfig, PresetApplied) {
+	if p == nil {
+		return existing, PresetApplied{}
+	}
+
+	applied := PresetApplied{Source: p.Source}
+
+	if HasPlaceholderTeams(existing.Teams) && len(p.Teams) > 0 {
+		existing.Teams = p.Teams
+		applied.Teams = true
+	}
+	if existing.SilentPolicy == "" && p.SilentPolicy != "" {
+		existing.SilentPolicy = p.SilentPolicy
+		applied.Silent = true
+	}
+	if len(existing.CustomPolicies) == 0 && len(p.CustomPolicies) > 0 {
+		existing.CustomPolicies = p.CustomPolicies
+		applied.Custom = true
+	}
+	if existing.ClusterLoginCommand == "" && p.ClusterLoginCommand != "" {
+		existing.ClusterLoginCommand = p.ClusterLoginCommand
+		applied.ClusterLogin = true
+	}
+	if existing.Terminal == "" && p.Terminal != "" {
+		existing.Terminal = p.Terminal
+		applied.Terminal = true
+	}
+	if existing.Editor == "" && p.Editor != "" {
+		existing.Editor = p.Editor
+		applied.Editor = true
+	}
+
+	return existing, applied
+}
+
+// ForcePresetChanges marks preset-seeded fields as changed so they are
+// persisted even though they equal the seeded "existing" values (the config
+// file does not actually contain them yet).
+func ForcePresetChanges(changes ConfigChanges, applied PresetApplied) ConfigChanges {
+	if applied.Teams {
+		changes.TeamsChanged = true
+	}
+	if applied.Silent {
+		changes.SilentChanged = true
+	}
+	if applied.Custom {
+		changes.CustomChanged = true
+	}
+	if applied.ClusterLogin {
+		changes.ClusterLoginChanged = true
+	}
+	if applied.Terminal {
+		changes.TerminalChanged = true
+	}
+	if applied.Editor {
+		changes.EditorChanged = true
+	}
+	return changes
+}

--- a/pkg/config/preset_test.go
+++ b/pkg/config/preset_test.go
@@ -1,0 +1,169 @@
+package config
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const validPreset = `
+teams:
+  - PTEAM99
+default_silent_escalation_policy: PSILENT9
+custom_service_escalation_policies:
+  PSVC1: PPOL1
+cluster_login_command: ocm-container --cluster-id %%CLUSTER_ID%%
+terminal: kitty
+editor: nano
+`
+
+// A preset is a team-published YAML fragment of policy decisions — the
+// "have to know to know" values. It pre-seeds the wizard; every value is
+// still confirmed by the user.
+
+func TestParsePreset_Valid(t *testing.T) {
+	p, err := ParsePreset([]byte(validPreset), "team-docs.yaml")
+
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"PTEAM99"}, p.Teams)
+	assert.Equal(t, "PSILENT9", p.SilentPolicy)
+	assert.Equal(t, map[string]string{"PSVC1": "PPOL1"}, p.CustomPolicies)
+	assert.Equal(t, "ocm-container --cluster-id %%CLUSTER_ID%%", p.ClusterLoginCommand)
+	assert.Equal(t, "kitty", p.Terminal)
+	assert.Equal(t, "nano", p.Editor)
+	assert.Equal(t, "team-docs.yaml", p.Source)
+}
+
+// Secrets and personal credentials must never ride in on a preset.
+func TestParsePreset_RejectsToken(t *testing.T) {
+	_, err := ParsePreset([]byte("token: stolen\nteams: [T1]\n"), "x")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "token")
+}
+
+func TestParsePreset_RejectsLLMAPI(t *testing.T) {
+	_, err := ParsePreset([]byte("llm_api:\n  api_key_env: SECRET\n"), "x")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "llm_api")
+}
+
+// Strict allowlist: anything unrecognized is rejected loudly rather than
+// silently ignored — a typoed key in a team preset should not pass review.
+func TestParsePreset_RejectsUnknownKeys(t *testing.T) {
+	_, err := ParsePreset([]byte("teams: [T1]\nsurprise_key: value\n"), "x")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "surprise_key")
+}
+
+func TestParsePreset_InvalidYAML(t *testing.T) {
+	_, err := ParsePreset([]byte("{{nope"), "x")
+	assert.Error(t, err)
+}
+
+// ApplyPreset overlays preset values only where the existing config is
+// empty: the user's real config always wins over team defaults.
+func TestApplyPreset_FillsEmptyFieldsOnly(t *testing.T) {
+	p, err := ParsePreset([]byte(validPreset), "team-docs.yaml")
+	assert.NoError(t, err)
+
+	existing := ExistingConfig{
+		Token:  "usertoken",
+		Teams:  []string{"PMYTEAM"}, // user already picked a team
+		Editor: "emacs",             // and an editor
+	}
+
+	merged, applied := ApplyPreset(existing, p)
+
+	assert.Equal(t, []string{"PMYTEAM"}, merged.Teams, "existing teams win")
+	assert.False(t, applied.Teams)
+	assert.Equal(t, "emacs", merged.Editor, "existing editor wins")
+	assert.False(t, applied.Editor)
+
+	assert.Equal(t, "PSILENT9", merged.SilentPolicy, "empty fields take preset values")
+	assert.True(t, applied.Silent)
+	assert.Equal(t, map[string]string{"PSVC1": "PPOL1"}, merged.CustomPolicies)
+	assert.True(t, applied.Custom)
+	assert.Equal(t, "kitty", merged.Terminal)
+	assert.True(t, applied.Terminal)
+	assert.Equal(t, "ocm-container --cluster-id %%CLUSTER_ID%%", merged.ClusterLoginCommand)
+	assert.True(t, applied.ClusterLogin)
+	assert.Equal(t, "team-docs.yaml", applied.Source)
+}
+
+func TestApplyPreset_NilPresetNoOp(t *testing.T) {
+	existing := ExistingConfig{Token: "t"}
+	merged, applied := ApplyPreset(existing, nil)
+	assert.Equal(t, existing, merged)
+	assert.False(t, applied.Any())
+}
+
+func TestLoadPreset_File(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "preset.yaml")
+	assert.NoError(t, os.WriteFile(path, []byte(validPreset), 0644))
+
+	p, err := LoadPreset(path, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"PTEAM99"}, p.Teams)
+	assert.Equal(t, path, p.Source)
+}
+
+func TestLoadPreset_HTTPSOnly(t *testing.T) {
+	_, err := LoadPreset("http://example.com/preset.yaml", http.DefaultClient)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "https")
+}
+
+func TestLoadPreset_URLFetch(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, validPreset) //nolint:errcheck
+	}))
+	defer ts.Close()
+
+	p, err := LoadPreset(ts.URL, ts.Client())
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"PTEAM99"}, p.Teams)
+	assert.Equal(t, ts.URL, p.Source)
+}
+
+func TestLoadPreset_URLSizeCap(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "teams: [T1]\n# %s\n", strings.Repeat("x", presetMaxBytes)) //nolint:errcheck
+	}))
+	defer ts.Close()
+
+	_, err := LoadPreset(ts.URL, ts.Client())
+	assert.Error(t, err, "oversized presets must be rejected")
+}
+
+func TestLoadPreset_URLNon200(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer ts.Close()
+
+	_, err := LoadPreset(ts.URL, ts.Client())
+	assert.Error(t, err)
+}
+
+// Preset-applied fields must be persisted even when they equal the seeded
+// "existing" values (the file doesn't actually contain them yet).
+func TestForcePresetChanges(t *testing.T) {
+	changes := ConfigChanges{}
+	applied := PresetApplied{Teams: true, Silent: true, Custom: true, Terminal: true, Editor: true}
+
+	forced := ForcePresetChanges(changes, applied)
+
+	assert.True(t, forced.TeamsChanged)
+	assert.True(t, forced.SilentChanged)
+	assert.True(t, forced.CustomChanged)
+	assert.True(t, forced.TerminalChanged)
+	assert.True(t, forced.EditorChanged)
+	assert.False(t, forced.TokenChanged, "token is never preset-driven")
+}

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -1433,11 +1433,12 @@ type configFormState struct {
 // configWizardReadyMsg is sent when the existing config has been resolved
 // and is ready to build the config wizard form.
 type configWizardReadyMsg struct {
-	existing    pkgconfig.ExistingConfig
-	kd          pkgconfig.KeepDefaults
-	isNewFile   bool
-	teamNames   map[string]string
-	policyNames map[string]string
+	existing      pkgconfig.ExistingConfig
+	kd            pkgconfig.KeepDefaults
+	isNewFile     bool
+	teamNames     map[string]string
+	policyNames   map[string]string
+	presetApplied pkgconfig.PresetApplied
 	// wizardReason explains why the wizard auto-launched (e.g. YAML parse
 	// error, missing/placeholder token). Surfaced in the token step description
 	// so the user understands what happened. Empty for explicit `srepd config`.
@@ -1469,9 +1470,20 @@ func prepareConfigWizardCmd(m model) tea.Cmd {
 			viper.GetString("custom_service_escalation_policies"),
 			viper.GetStringMapString("service_escalation_policies"),
 		)
-		existing.Terminal = viper.GetString("terminal")
-		existing.Editor = viper.GetString("editor")
+		existing.Terminal = viperConfiguredString("terminal")
+		existing.Editor = viperConfiguredString("editor")
+		existing.ClusterLoginCommand = viperConfiguredString("cluster_login_command")
 		existing.AgentCLICommand = viper.GetString("agent_cli_command")
+
+		var presetApplied pkgconfig.PresetApplied
+		if ref := viper.GetString("config_preset"); ref != "" {
+			preset, presetErr := pkgconfig.LoadPreset(ref, nil)
+			if presetErr != nil {
+				return errMsg{fmt.Errorf("failed to load preset: %w", presetErr)}
+			}
+			existing, presetApplied = pkgconfig.ApplyPreset(existing, preset)
+		}
+
 		kd := pkgconfig.ResolveKeepDefaults(existing.Teams, existing.SilentPolicy, existing.CustomPolicies)
 
 		home, _ := os.UserHomeDir()
@@ -1508,14 +1520,28 @@ func prepareConfigWizardCmd(m model) tea.Cmd {
 		}
 
 		return configWizardReadyMsg{
-			existing:     existing,
-			kd:           kd,
-			isNewFile:    isNewFile,
-			teamNames:    teamNames,
-			policyNames:  policyNames,
-			wizardReason: viper.GetString("config_wizard_reason"),
+			existing:      existing,
+			kd:            kd,
+			isNewFile:     isNewFile,
+			teamNames:     teamNames,
+			policyNames:   policyNames,
+			presetApplied: presetApplied,
+			wizardReason:  viper.GetString("config_wizard_reason"),
 		}
 	}
+}
+
+// viperConfiguredString returns the value for key only when the user set it
+// (config file, env var, or an explicit flag) — not when it merely carries
+// an in-process default from ensureViperDefaults/validateConfig.
+func viperConfiguredString(key string) string {
+	if viper.InConfig(key) {
+		return viper.GetString(key)
+	}
+	if v := os.Getenv("SREPD_" + strings.ToUpper(key)); v != "" {
+		return v
+	}
+	return ""
 }
 
 // realFS implements pkgconfig.ConfigFS using the real filesystem.

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -205,6 +205,9 @@ type model struct {
 	configPolicyNames   map[string]string
 	configModeRequested bool
 	configWizardPending *configWizardReadyMsg
+	// configPresetApplied records which wizard values were seeded from a
+	// team preset (--preset), for tagging and change forcing.
+	configPresetApplied pkgconfig.PresetApplied
 
 	// OCM enrichment state
 	ocmClient      ocm.OCMClient

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -347,6 +347,9 @@ func switchConfigFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			changes = pkgconfig.DetectChanges(m.configExisting, final, strings.TrimSpace(m.configState.TokenInput))
 		}
+		// Preset-seeded values equal the seeded "existing" state but are not
+		// in the file yet — force them into the write set.
+		changes = pkgconfig.ForcePresetChanges(changes, m.configPresetApplied)
 
 		if m.configExisting.OldFormatDetected {
 			if final.SilentPolicy != "" {

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -306,6 +306,14 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			tokenDesc = fmt.Sprintf("⚠ %s\n\n%s", msg.wizardReason, tokenDesc)
 		}
 
+		m.configPresetApplied = msg.presetApplied
+		presetTag := func(applied bool) string {
+			if applied {
+				return fmt.Sprintf(" (from preset: %s)", msg.presetApplied.Source)
+			}
+			return ""
+		}
+
 		var teamDisplayList []string
 		for _, id := range msg.existing.Teams {
 			if name, ok := msg.teamNames[id]; ok {
@@ -314,13 +322,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				teamDisplayList = append(teamDisplayList, id)
 			}
 		}
-		keepTeamsDesc := fmt.Sprintf("Current teams: %s", strings.Join(teamDisplayList, ", "))
+		keepTeamsDesc := fmt.Sprintf("Current teams: %s%s", strings.Join(teamDisplayList, ", "), presetTag(msg.presetApplied.Teams))
 
 		silentDisplay := msg.existing.SilentPolicy
 		if name, ok := msg.policyNames[msg.existing.SilentPolicy]; ok {
 			silentDisplay = fmt.Sprintf("%s (%s)", name, msg.existing.SilentPolicy)
 		}
-		keepSilentDesc := fmt.Sprintf("Current: %s", silentDisplay)
+		keepSilentDesc := fmt.Sprintf("Current: %s%s", silentDisplay, presetTag(msg.presetApplied.Silent))
 
 		var customDisplayParts []string
 		for svcID, polID := range msg.existing.CustomPolicies {
@@ -330,7 +338,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			customDisplayParts = append(customDisplayParts, fmt.Sprintf("%s → %s", svcID, polDisplay))
 		}
-		keepCustomDesc := fmt.Sprintf("Current: %s", strings.Join(customDisplayParts, ", "))
+		keepCustomDesc := fmt.Sprintf("Current: %s%s", strings.Join(customDisplayParts, ", "), presetTag(msg.presetApplied.Custom))
 
 		m.configForm = m.buildConfigForm(msg, tokenDesc, keepTeamsDesc, keepSilentDesc, keepCustomDesc, existingTeamSet)
 		m.configMode = true
@@ -2364,7 +2372,12 @@ func (m *model) buildConfigForm(msg configWizardReadyMsg, tokenDesc, keepTeamsDe
 					} else {
 						tmpChanges = pkgconfig.DetectChanges(m.configExisting, tmpFinal, strings.TrimSpace(m.configState.TokenInput))
 					}
-					return pkgconfig.BuildSummary(m.configExisting, tmpFinal, tmpChanges, tmpNames, m.configPolicyNames)
+					tmpChanges = pkgconfig.ForcePresetChanges(tmpChanges, m.configPresetApplied)
+					summary := pkgconfig.BuildSummary(m.configExisting, tmpFinal, tmpChanges, tmpNames, m.configPolicyNames)
+					if m.configPresetApplied.Any() {
+						summary = fmt.Sprintf("  Preset applied: %s\n%s", m.configPresetApplied.Source, summary)
+					}
+					return summary
 				}, &m.configState.CustomInput),
 			huh.NewConfirm().
 				Title("Save changes?").

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -2303,6 +2303,16 @@ func (m *model) buildConfigForm(msg configWizardReadyMsg, tokenDesc, keepTeamsDe
 		).WithHideFunc(func() bool { return msg.kd.HasCustom }),
 		huh.NewGroup(
 			huh.NewConfirm().
+				Title("Configure advanced options?").
+				Description(
+					"Custom service-to-policy silence overrides — a team-policy\n"+
+						"setting most users don't need. Skip unless your team's\n"+
+						"onboarding docs say otherwise.",
+				).
+				Value(&m.configState.AdvancedOptions),
+		).WithHideFunc(func() bool { return msg.kd.HasCustom }),
+		huh.NewGroup(
+			huh.NewConfirm().
 				Title("Keep current custom service-to-policy mappings?").
 				Description(keepCustomDesc).
 				Value(&m.configState.KeepCustom),


### PR DESCRIPTION
> **Stacked on #370** (← #369 ← #368 ← #367 ← #366 ← #365 ← #364 ← #363). Review/merge in order. Part of the onboarding overhaul (#353, #324).

## The "have to know to know" problem

Some wizard values are pure team policy and fundamentally undiscoverable: `custom_service_escalation_policies` mappings, an org `cluster_login_command`, which silent policy a team uses. No heuristic can derive them, and hardcoding any org's choices into SREPD would be wrong.

## Solution: policy-as-artifact

A team publishes one YAML fragment in its onboarding docs. New SREs run:

```
srepd config --preset https://team-docs.example.com/srep-preset.yaml
```

and inherit the decisions — pre-seeded into the wizard, tagged "(from preset: <source>)", every value still confirmed by the user.

Guardrails:

- **Strict allowlist**: teams, silent policy, custom mappings, cluster login command, terminal, editor. `token` and `llm_api` are always rejected; *unknown keys fail the whole preset loudly* (a typo should fail review, not be silently dropped)
- **HTTPS-only**, 64KB cap, non-200 rejected, explicit flag only — never auto-fetched
- **Existing config always wins** — a preset only fills values the user hasn't set (`viperConfiguredString` distinguishes user-set values from in-process defaults)
- Load failure is a hard error — the user explicitly asked for team policy; silently dropping it would be worse
- `ForcePresetChanges` ensures seeded values are actually persisted; `cluster_login_command` is threaded through the write pipeline (it has no wizard step)

## Tests (TDD)

`pkg/config/preset_test.go` — parse/allowlist/rejection table, overlay semantics, file + TLS fetch via `httptest`, size cap, change forcing. Full suite, `-race`, lint green. README documents the feature.

## Plan doc

`docs/plans/370-team-preset.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BtcSJfWWcDKL4rSNNH1cN