### PR TITLE
Reframe onboarding docs around the wizard (OB-2, OB-7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,18 @@ go install .        # standard go install
 | `srepd config` | Interactive configuration wizard (`--preset <file\|https-url>` to pre-seed from a team preset) |
 | `srepd config generate` | Print a complete annotated config with defaults (`--out <path>` to write a file) |
 
+## Getting Started
+
+1. **Create a PagerDuty API User Token**: PagerDuty web → My Profile → User Settings → API Access → Create New API User Token.
+2. **Run `srepd`** — the setup wizard does the rest: it validates your token, discovers your teams and escalation policies, detects your terminal and editor, and drops you straight into the live incident view when you save.
+
+That's it. Your team may also publish a preset with its policy decisions — if so, run `srepd config --preset <url>` from your team's onboarding docs instead.
+
 ## Configuration
 
 SREPD reads `~/.config/srepd/srepd.yaml` and supports `SREPD_` environment variable prefix. Run `srepd config` to create or update your config interactively. Values from environment variables (e.g., `SREPD_TOKEN`) are pre-filled automatically.
 
-If no config file exists — or the config file is incomplete or still contains placeholder values (e.g. `<PagerDuty API token>`) — running `srepd` automatically enters the configuration wizard. The wizard form resizes dynamically when the terminal window changes size.
+If no config file exists — or the config file is incomplete or still contains placeholder values — running `srepd` automatically enters the configuration wizard. The wizard form resizes dynamically when the terminal window changes size.
 
 **Migrating from old config format:** If your config uses the deprecated `service_escalation_policies` key, running `srepd config` will automatically migrate to the new `default_silent_escalation_policy` and `custom_service_escalation_policies` keys. The old block is commented out with a deprecation note.
 
@@ -71,13 +78,12 @@ If no config file exists — or the config file is incomplete or still contains 
 | `default_silent_escalation_policy` | `string` | (none) | Silent escalation policy ID for silencing incidents. Set via `srepd config`. |
 | `custom_service_escalation_policies` | `map[string]string` | (none) | Per-service silent policy overrides (service ID to policy ID) |
 | `editor` | `string` | `vim` | Editor for incident notes |
-| `terminal` | `string` | `gnome-terminal` | Terminal emulator for cluster login |
+| `terminal` | `string` | `gnome-terminal --` | Terminal emulator for cluster login (detected and offered by the wizard) |
 | `cluster_login_command` | `string` | `ocm backplane login %%CLUSTER_ID%%` | Cluster login command |
 | `rosa_boundary_command` | `string` | `rosa-boundary start-task --cluster-id %%CLUSTER_ID%% --connect` | rosa-boundary cluster login command |
 | `toolbox_mode` | `string` | `auto` | Toolbox detection: `auto`, `true`, or `false` |
 | `chord_prefix` | `string` | `ctrl+x` | Prefix key for chord commands |
-| `flag_marker` | `string` | `🚩 ` | Prefix marker for flagged incidents (alt: `\|►`) |
-| `agent_cli_command` | `string` | `claude --print` | CLI agent command for `:agent` queries |
+| `agent_cli_command` | `string` | `claude --print` | CLI agent command for `:agent` queries (set to `""` to disable AI features) |
 | `emoji` | `bool` | `true` | Use emoji markers or text fallbacks for flags/agent/watcher |
 | `reescalate_level` | `int` | `2` | Escalation level `ctrl+e` re-escalates to, skipping lower placeholder tiers (e.g. level 1 "Nobody") |
 | `stream_responses` | `bool` | `true` | Stream `:watcher`/LLM responses token-by-token when the provider supports it; set `false` for blocking responses |
@@ -103,14 +109,22 @@ colors:
   tab: "#7D56F4"        # Reserved for future use
 ```
 
-### Example
+### Advanced: manual configuration
+
+Prefer editing a file over the wizard? Generate a complete, annotated config with every supported key and its default:
+
+```bash
+srepd config generate --out ~/.config/srepd/srepd.yaml
+```
+
+Then fill in `token` and `teams`. **Do not copy placeholder values** like `<PagerDuty API token>` into the file — srepd treats them as unconfigured and routes you into the wizard. A minimal working config looks like:
 
 ```yaml
-token: <PagerDuty API token>
+token: u+yourRealTokenHere
 teams:
-  - <team ID>
+  - PABC123
 default_silent_escalation_policy: P654321
-terminal: gnome-terminal
+terminal: gnome-terminal --
 cluster_login_command: ocm-container --cluster-id %%CLUSTER_ID%%
 rosa_boundary_command: rosa-boundary start-task --cluster-id %%CLUSTER_ID%% --connect
 toolbox_mode: auto

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2025 NAME HERE <EMAIL ADDRESS>
+Copyright © 2023 Chris Collins 'collins.christopher@gmail.com'
 */
 package cmd
 
@@ -23,7 +23,12 @@ import (
 
 const description = `The config command is used to create or validate the SREPD config file.
 The config file is located at ~/.config/srepd/srepd.yaml and is used to store
-the configuration options for the SREPD application.`
+the configuration options for the SREPD application.
+
+You will need a PagerDuty API User Token: create one at PagerDuty web →
+My Profile → User Settings → API Access → Create New API User Token.
+Everything else — teams, escalation policies, terminal, editor — is
+discovered by the wizard, or pre-seeded from a team preset via --preset.`
 
 // safeToLogConfigKeys is the allowlist of config keys whose values are safe to log
 // verbatim under --debug. Any key not in this set is masked, so secret-bearing keys

--- a/docs/plans/372-onboarding-docs.md
+++ b/docs/plans/372-onboarding-docs.md
@@ -1,0 +1,38 @@
+# 372: Onboarding docs and headers (OB-2 + OB-7)
+
+Issue: #353 (OB-2, OB-7); final documentation pass of the onboarding overhaul
+Branch: `srepd/onboarding-docs`
+
+## Problem
+
+- OB-2: the README's getting-started path was a hand-edited YAML example
+  with `token: <PagerDuty API token>` — following it created exactly the
+  broken-but-present config OB-1 had to defend against, and it contradicted
+  the README's own note that the wizard auto-launches.
+- OB-7: the token-acquisition help lived only inside the wizard; the cobra
+  `config` long description said nothing; two files still carried the
+  `Copyright © 2025 NAME HERE <EMAIL ADDRESS>` placeholder header.
+- Drift: the README's `terminal` default lacked the ` --`; the dead
+  `flag_marker` key (issue #322) was still documented as live.
+
+## Changes (docs land last so they describe the finished flow)
+
+- **README "Getting Started"**: two steps — create a User Token (with the
+  path), run `srepd`. Mentions team presets for orgs that publish one.
+- **README "Advanced: manual configuration"**: the YAML example is demoted
+  here, now led by `srepd config generate --out ...` and an explicit "do not
+  copy placeholder values" warning; the example itself uses realistic
+  non-placeholder forms and the correct `gnome-terminal --` default.
+- Options table: `terminal` default corrected to `gnome-terminal --`;
+  `flag_marker` row removed (dead key, markers follow `emoji`);
+  `agent_cli_command` documents `""` = disabled.
+- **`configCmd` long description** gains the token-acquisition path and the
+  discovery/preset summary (OB-7).
+- **Copyright headers** fixed in `cmd/config.go` and `pkg/config/config.go`.
+
+## Verification
+
+Docs-only plus comment/description strings — full CI suite still runs; the
+`TestGenerateAnnotatedConfig_ActiveKeysMatchDefaults` guard keeps the
+generate output aligned, and `TestClassifyConfigHealth_ReadmeExample...`
+still pins that any legacy placeholder-styled config routes to the wizard.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 NAME HERE <EMAIL ADDRESS>
+Copyright © 2023 Chris Collins 'collins.christopher@gmail.com'
 */
 package config
 


### PR DESCRIPTION
> **Stacked on #372** (← #371 ← #370 ← #369 ← #368 ← #367 ← #366 ← #365 ← #364 ← #363). Review/merge in order. Part of the onboarding overhaul (#353, #324).

## Problem

- **OB-2**: the README's getting-started path was hand-edited YAML with `token: <PagerDuty API token>` — following the docs faithfully produced exactly the broken config OB-1 defends against
- **OB-7**: token-acquisition help only existed inside the wizard; two files still carried `Copyright © 2025 NAME HERE <EMAIL ADDRESS>`
- Drift: README's `terminal` default lacked ` --`; the dead `flag_marker` key (#322) was documented as live

## Changes (docs last, describing the finished flow)

- **Getting Started**: two steps — create a User Token (with the click-path), run `srepd`. Team presets mentioned for orgs that publish one.
- **Advanced: manual configuration**: YAML demoted here, led by `srepd config generate --out …`, with an explicit "do not copy placeholder values" warning and a realistic example
- Options table: `terminal` default corrected, `flag_marker` row removed, `agent_cli_command` documents `""` = disabled
- `configCmd` long description gains the token path + discovery/preset summary
- Copyright headers fixed in `cmd/config.go` and `pkg/config/config.go`

## Plan doc

`docs/plans/372-onboarding-docs.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BtcSJfWWcDKL4rSNNH1cN