### PR TITLE
Add a guided tour via :tour

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ go install .        # standard go install
 
 That's it. Your team may also publish a preset with its policy decisions — if so, run `srepd config --preset <url>` from your team's onboarding docs instead.
 
+New to srepd? Type `:tour` inside the app for a guided walkthrough of the incident table, actions, command mode, chords, flags, and the AI watcher.
+
 ## Configuration
 
 SREPD reads `~/.config/srepd/srepd.yaml` and supports `SREPD_` environment variable prefix. Run `srepd config` to create or update your config interactively. Values from environment variables (e.g., `SREPD_TOKEN`) are pre-filled automatically.
@@ -87,6 +89,7 @@ If no config file exists — or the config file is incomplete or still contains 
 | `emoji` | `bool` | `true` | Use emoji markers or text fallbacks for flags/agent/watcher |
 | `reescalate_level` | `int` | `2` | Escalation level `ctrl+e` re-escalates to, skipping lower placeholder tiers (e.g. level 1 "Nobody") |
 | `stream_responses` | `bool` | `true` | Stream `:watcher`/LLM responses token-by-token when the provider supports it; set `false` for blocking responses |
+| `tour_seen` | `bool` | `false` | Set automatically after the guided tour is first started; suppresses the one-time post-setup `:tour` suggestion |
 | `agent_system_prompt` | `string` | (read-only investigation) | System prompt for `:agent` CLI queries |
 | `watcher_system_prompt` | `string` | (SRE assistant) | System prompt for `:watcher` LLM queries |
 | `colors` | `map[string]string` | (defaults) | Custom color scheme (hex values) |

--- a/docs/plans/373-guided-tour.md
+++ b/docs/plans/373-guided-tour.md
@@ -1,0 +1,43 @@
+# 373: In-TUI guided tour (:tour)
+
+Issue: #324 item 3; final phase of the onboarding overhaul (#353, #324)
+Branch: `srepd/guided-tour`
+
+## Problem
+
+srepd has dozens of features (8 detail tabs, chord commands, flags, :agent,
+bulk silence, the watcher) but a new user has no way to learn them beyond
+the README or stumbling onto `h`. #324 asks for an in-app tour that teaches
+by showing.
+
+## Approach
+
+A tour mode following the established mode pattern (model flag →
+`keyMsgHandler` dispatch case → `views.go` case):
+
+- **Content**: 9 steps (`tourSteps()`) — incident table, navigation, viewer
+  tabs, key actions (a / ctrl+s / ctrl+e / n / l), command mode
+  (:agent/:watcher), chords (ctrl+x ?), flags, the watcher, and a closer
+  pointing at `h` and `:tour`.
+- **Rendering**: the live incident table stays on screen for context with
+  the step panel beneath it in the app's `FormContainer` pane language:
+  bold title, muted "n/9" progress, body, and the key hints. Keys are
+  DESCRIBED, never executed — safe with live incidents; works fine with an
+  empty table or `--dev` fixtures.
+- **Controls**: any key advances, shift+tab/left goes back, esc/q exits;
+  advancing past the last step completes ("tour complete").
+- **Entry points**: `:tour` in command mode (registered beside
+  :agent/:watcher/:flag), plus a one-time suggestion appended to the
+  post-setup status line ("config saved — new here? type :tour…") when
+  `tour_seen` is unset. Never auto-forced.
+- **`tour_seen`**: persisted via `UpsertScalarInConfig` (comment-preserving)
+  the first time the tour starts, so the suggestion shows at most once.
+
+## Tests (TDD — written first)
+
+`pkg/tui/tour_test.go`: step content covers the feature set (≥8 steps;
+acknowledge/silence/:agent/chord/flag/watcher/tab all mentioned);
+`isTourCommand`; start sets mode + persists; advance/back/floor semantics;
+esc exits with status; completion past the last step; panel render contains
+title, progress, and exit hint. Existing config-mode tests pin the combined
+post-setup status line.

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -201,6 +201,10 @@ type model struct {
 	// team preset (--preset), for tagging and change forcing.
 	configPresetApplied pkgconfig.PresetApplied
 
+	// Guided tour state (#324) — active step of the :tour walkthrough.
+	tourMode bool
+	tourStep int
+
 	// OCM enrichment state
 	ocmClient      ocm.OCMClient
 	ocmAuthPending bool

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -192,6 +192,9 @@ func (m model) keyMsgHandler(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	// Default commands for the table view
 	switch {
+	case m.tourMode:
+		return switchTourFocusMode(m, msg)
+
 	case m.configMode:
 		return switchConfigFocusMode(m, msg)
 
@@ -811,8 +814,12 @@ func switchInputFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, m.dispatchFlagCommand(prompt)
 			}
 
+			if isTourCommand(prompt) {
+				return m.startTour()
+			}
+
 			log.Debug("switchInputFocusMode", "msg", "unknown command", "prompt", prompt)
-			m.setStatus("unknown command — try :agent, :watcher, or :flag")
+			m.setStatus("unknown command — try :agent, :watcher, :flag, or :tour")
 			return m, nil
 
 		default:

--- a/pkg/tui/tour.go
+++ b/pkg/tui/tour.go
@@ -1,0 +1,172 @@
+package tui
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/log"
+	pkgconfig "github.com/clcollins/srepd/pkg/config"
+	"github.com/spf13/viper"
+)
+
+// The guided tour (#324): an in-app walkthrough of srepd's features,
+// launched via :tour or suggested once after the first config save. It
+// renders the incident table for context with an explanation panel beneath —
+// keys are described, never executed, so it is safe with live incidents.
+
+type tourStep struct {
+	Title string
+	Body  string
+}
+
+func tourSteps() []tourStep {
+	return []tourStep{
+		{
+			Title: "The incident table",
+			Body: "This is your incident list: ID, cluster/service, and title.\n" +
+				"● marks incidents assigned to you; the view auto-refreshes.\n" +
+				"Press t to toggle between your incidents and the whole team's.",
+		},
+		{
+			Title: "Navigation",
+			Body: "Move with j/k or the arrow keys. Press enter on an incident\n" +
+				"to open it, and esc to come back to this table.",
+		},
+		{
+			Title: "The incident viewer tabs",
+			Body: "An open incident has tabs — Details, Alerts, Notes, Cluster,\n" +
+				"Service Logs, LS History, Reports, and PD History — switch with\n" +
+				"tab/shift+tab or number keys. Cluster data is enriched from OCM.",
+		},
+		{
+			Title: "Key actions",
+			Body: "a — acknowledge the selected incident.\n" +
+				"ctrl+s — silence it (reassigns to your silent escalation policy).\n" +
+				"ctrl+e — re-escalate to the next level.\n" +
+				"n — add a note. l — log into the incident's cluster.",
+		},
+		{
+			Title: "Command mode",
+			Body: "Press : to enter command mode. :agent <question> asks the AI\n" +
+				"agent for read-only incident investigation; :watcher <question>\n" +
+				"queries the ambient LLM watcher.",
+		},
+		{
+			Title: "Chord commands",
+			Body: "Less-common actions live behind a chord prefix (default ctrl+x).\n" +
+				"Press ctrl+x then ? to see every chord — for example ctrl+x s\n" +
+				"for bulk silence.",
+		},
+		{
+			Title: "Flags",
+			Body: "Mark incidents matching patterns with :flag (e.g. a cluster ID\n" +
+				"or org name) — matches get a marker in the table. :flags lists\n" +
+				"conditions; :unflag removes them.",
+		},
+		{
+			Title: "The watcher",
+			Body: "Press w to toggle the AI watcher pane: ambient analysis of\n" +
+				"incoming incidents and pattern detection across your queue,\n" +
+				"streamed below the table.",
+		},
+		{
+			Title: "That's the tour!",
+			Body: "Press h any time for the full help view, and re-run this tour\n" +
+				"with :tour. Happy on-calling!",
+		},
+	}
+}
+
+// isTourCommand reports whether the command input starts the tour.
+func isTourCommand(input string) bool {
+	return strings.TrimSpace(input) == ":tour"
+}
+
+// startTour enters tour mode and persists tour_seen so the one-time
+// post-setup suggestion never repeats.
+func (m model) startTour() (model, tea.Cmd) {
+	m.tourMode = true
+	m.tourStep = 0
+	m.table.Blur()
+	return m, markTourSeenCmd()
+}
+
+// switchTourFocusMode handles keys while the tour is active: esc/q/ctrl+c
+// exits, shift+tab goes back, anything else advances; advancing past the
+// last step completes the tour.
+func switchTourFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
+	keyMsg, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return m, nil
+	}
+
+	switch keyMsg.String() {
+	case "esc", "q", "ctrl+c":
+		m.tourMode = false
+		m.table.Focus()
+		m.setStatus("tour ended — re-run any time with :tour")
+		return m, nil
+	case "shift+tab", "left":
+		if m.tourStep > 0 {
+			m.tourStep--
+		}
+		return m, nil
+	default:
+		m.tourStep++
+		if m.tourStep >= len(tourSteps()) {
+			m.tourMode = false
+			m.table.Focus()
+			m.setStatus("tour complete — press h for help any time")
+		}
+		return m, nil
+	}
+}
+
+// renderTourPanel renders the current tour step in the app's pane language.
+func (m model) renderTourPanel() string {
+	steps := tourSteps()
+	if m.tourStep < 0 || m.tourStep >= len(steps) {
+		return ""
+	}
+	step := steps[m.tourStep]
+
+	title := m.styles.Main.Bold(true).Render(step.Title)
+	progress := m.styles.Muted.Render(fmt.Sprintf("%d/%d", m.tourStep+1, len(steps)))
+	help := m.styles.Muted.Render("any key: next • shift+tab: back • esc: exit")
+
+	content := fmt.Sprintf("%s  %s\n\n%s\n\n%s", title, progress, step.Body, help)
+	return m.styles.FormContainer.Render(content)
+}
+
+// markTourSeenCmd persists tour_seen: true so the post-setup tour
+// suggestion is shown at most once.
+func markTourSeenCmd() tea.Cmd {
+	return func() tea.Msg {
+		viper.Set("tour_seen", true)
+
+		home, err := os.UserHomeDir()
+		if err != nil {
+			log.Debug("markTourSeen", "error", err)
+			return nil
+		}
+		configFile := filepath.Join(home, pkgconfig.CfgFileDir, pkgconfig.CfgFileName)
+		data, err := os.ReadFile(configFile)
+		if err != nil {
+			log.Debug("markTourSeen", "error", err)
+			return nil
+		}
+		updated, err := pkgconfig.UpsertScalarInConfig(data, "tour_seen", "true")
+		if err != nil {
+			log.Debug("markTourSeen", "error", err)
+			return nil
+		}
+		// 0600: the config file holds the PagerDuty token.
+		if err := os.WriteFile(configFile, updated, 0600); err != nil {
+			log.Debug("markTourSeen", "error", err)
+		}
+		return nil
+	}
+}

--- a/pkg/tui/tour_test.go
+++ b/pkg/tui/tour_test.go
@@ -1,0 +1,102 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+)
+
+// #324 item 3: an in-TUI guided tour that teaches by showing. Steps cover
+// the incident table, navigation, detail tabs, key actions, command mode,
+// chords, flags, and the watcher.
+func TestTourSteps_CoverTheFeatureSet(t *testing.T) {
+	steps := tourSteps()
+
+	assert.GreaterOrEqual(t, len(steps), 8, "#324 asks for ~8-10 steps")
+
+	var all strings.Builder
+	for _, s := range steps {
+		assert.NotEmpty(t, s.Title)
+		assert.NotEmpty(t, s.Body)
+		all.WriteString(s.Title + " " + s.Body + " ")
+	}
+	content := all.String()
+	for _, want := range []string{"acknowledge", "silence", ":agent", "chord", "flag", "watcher", "tab"} {
+		assert.Contains(t, strings.ToLower(content), want, "tour must cover %q", want)
+	}
+}
+
+func TestIsTourCommand(t *testing.T) {
+	assert.True(t, isTourCommand(":tour"))
+	assert.True(t, isTourCommand("  :tour  "))
+	assert.False(t, isTourCommand(":tourism"))
+	assert.False(t, isTourCommand("tour"))
+}
+
+func TestStartTour(t *testing.T) {
+	m := createConfigTestModel()
+
+	m2, cmd := m.startTour()
+
+	assert.True(t, m2.tourMode)
+	assert.Equal(t, 0, m2.tourStep)
+	assert.NotNil(t, cmd, "starting the tour persists tour_seen")
+}
+
+func TestSwitchTourFocusMode_AdvanceAndBack(t *testing.T) {
+	m := createConfigTestModel()
+	m.tourMode = true
+	m.tourStep = 0
+
+	result, _ := switchTourFocusMode(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	updated := result.(model)
+	assert.Equal(t, 1, updated.tourStep, "any ordinary key advances")
+
+	result, _ = switchTourFocusMode(updated, tea.KeyMsg{Type: tea.KeyShiftTab})
+	updated = result.(model)
+	assert.Equal(t, 0, updated.tourStep, "shift+tab goes back")
+
+	result, _ = switchTourFocusMode(updated, tea.KeyMsg{Type: tea.KeyShiftTab})
+	updated = result.(model)
+	assert.Equal(t, 0, updated.tourStep, "back at the first step stays put")
+}
+
+func TestSwitchTourFocusMode_EscExits(t *testing.T) {
+	m := createConfigTestModel()
+	m.tourMode = true
+	m.tourStep = 3
+
+	result, _ := switchTourFocusMode(m, tea.KeyMsg{Type: tea.KeyEscape})
+	updated := result.(model)
+
+	assert.False(t, updated.tourMode)
+	assert.Contains(t, updated.status, "tour")
+}
+
+func TestSwitchTourFocusMode_CompletesPastLastStep(t *testing.T) {
+	m := createConfigTestModel()
+	m.tourMode = true
+	m.tourStep = len(tourSteps()) - 1
+
+	result, _ := switchTourFocusMode(m, tea.KeyMsg{Type: tea.KeyEnter})
+	updated := result.(model)
+
+	assert.False(t, updated.tourMode, "advancing past the last step ends the tour")
+	assert.Contains(t, updated.status, "complete")
+}
+
+func TestRenderTourPanel(t *testing.T) {
+	m := createConfigTestModel()
+	m.tourMode = true
+	m.tourStep = 0
+
+	out := m.renderTourPanel()
+
+	steps := tourSteps()
+	assert.Contains(t, out, steps[0].Title)
+	assert.Contains(t, out, fmt.Sprintf("1/%d", len(steps)), "progress indicator must be shown")
+	assert.Contains(t, out, "esc", "must show how to exit")
+}

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -372,7 +372,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.config = msg.config
-		m.setStatus("config saved")
+		// One-time suggestion after first setup; never auto-forced (#324).
+		if !viper.GetBool("tour_seen") {
+			m.setStatus("config saved — new here? type :tour for a 2-minute walkthrough")
+		} else {
+			m.setStatus("config saved")
+		}
 		return m, tea.Batch(
 			func() tea.Msg { return updateIncidentListMsg("config saved") },
 			func() tea.Msg { return tea.WindowSizeMsg{Width: windowSize.Width, Height: windowSize.Height} },

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -58,6 +58,11 @@ func (m model) View() string {
 	case m.viewingLog:
 		s.WriteString(m.styles.TableContainer.Render(m.logViewer.View()))
 
+	case m.tourMode:
+		s.WriteString(m.styles.TableContainer.Render(m.table.View()))
+		s.WriteString("\n")
+		s.WriteString(m.renderTourPanel())
+
 	case m.configMode:
 		s.WriteString(m.styles.FormContainer.Render(m.configForm.View()))
 


### PR DESCRIPTION
> **Stacked on #373** (← #372 ← #371 ← #370 ← #369 ← #368 ← #367 ← #366 ← #365 ← #364 ← #363). Final PR of the onboarding overhaul (#353, #324).

## What

#324 item 3: an in-app guided tour that teaches by showing. Nine steps — incident table, navigation, viewer tabs, key actions (`a`/`ctrl+s`/`ctrl+e`/`n`/`l`), command mode (`:agent`/`:watcher`), chords (`ctrl+x ?`), flags, the watcher, and a closer.

- **Mode pattern**: model flag → `keyMsgHandler` dispatch → `views.go` case, like every other srepd mode
- **Rendering**: the live incident table stays on screen for context, with the step panel beneath in the app's pane language (bold title, muted `n/9` progress, exit hints). **Keys are described, never executed** — safe with live incidents, works with an empty table or `--dev` fixtures
- **Controls**: any key advances, `shift+tab` back, `esc` exits, past-the-end completes
- **Entry**: `:tour` (registered beside `:agent`/`:watcher`/`:flag`) plus a one-time post-setup status suggestion — never auto-forced; `tour_seen` is persisted (comment-preserving upsert) so the suggestion shows at most once

## Tests (TDD)

`tour_test.go`: content-coverage assertions (all major features mentioned), command parsing, start/advance/back/exit/complete semantics, panel render. Full suite, `-race`, lint green.

## Plan doc

`docs/plans/373-guided-tour.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BtcSJfWWcDKL4rSNNH1cN