### PR TITLE
Harden supply chain: SHA-pin actions, dependency review rules

### DIFF
--- a/.github/actions/setup-go-from-mod/action.yml
+++ b/.github/actions/setup-go-from-mod/action.yml
@@ -9,6 +9,6 @@ runs:
         echo "GO_VERSION=$(grep '^go ' go.mod | awk '{print $2}')" >> $GITHUB_ENV
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
       with:
         go-version: ${{ env.GO_VERSION }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,13 @@
 version: 2
 updates:
   - package-ecosystem: "gomod"
-    directory: "/" 
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # Keeps the SHA-pinned actions fresh: dependabot bumps the commit SHA and
+  # maintains the trailing version comment.
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up Go from go.mod
         uses: ./.github/actions/setup-go-from-mod
@@ -78,7 +78,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up Go from go.mod
         uses: ./.github/actions/setup-go-from-mod
@@ -92,7 +92,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       # Pure grep; no Go toolchain required. Ensures no real customer UUIDs or
       # domains leak into testdata fixtures — previously only enforced locally.
@@ -105,13 +105,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up Go from go.mod
         uses: ./.github/actions/setup-go-from-mod
 
       - name: Cache Go modules
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: |
             ~/.cache/go-build
@@ -129,7 +129,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up Go from go.mod
         uses: ./.github/actions/setup-go-from-mod
@@ -144,13 +144,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up Go from go.mod
         uses: ./.github/actions/setup-go-from-mod
 
       - name: Cache Go modules
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: |
             ~/.cache/go-build
@@ -169,13 +169,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up Go from go.mod
         uses: ./.github/actions/setup-go-from-mod
 
       - name: Cache Go modules
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: |
             ~/.cache/go-build
@@ -204,7 +204,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up Go from go.mod
         uses: ./.github/actions/setup-go-from-mod
@@ -219,7 +219,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up Go from go.mod
         uses: ./.github/actions/setup-go-from-mod

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,23 @@ Pass extra test flags via `TESTOPTS`, e.g.:
   original PR's plan) describing what went wrong and how to
   prevent it
 
+## Dependencies (supply-chain rules)
+
+- **Adding a new module to go.mod requires explicit human review** of the
+  import path and repository provenance before merge: verify the path
+  matches the intended upstream exactly (typosquats imitate well-known
+  tools — e.g. the 2026 "Operation Muck and Load" fake `dnsub` scanner),
+  check the repo's owner, history, and release cadence, and be suspicious
+  of abnormal version volume.
+- **AI agents MUST call out any dependency addition prominently in the PR
+  description** — never bury a new module in an unrelated change.
+- Prefer the standard library or an existing dependency over adding a new
+  one; the current direct deps are all org-backed, well-known modules and
+  should stay that way.
+- GitHub Actions in workflows are **pinned to full commit SHAs** with a
+  trailing `# vN` comment; keep that style for any new action (dependabot
+  maintains the pins).
+
 ## Pre-Commit Checks (MANDATORY)
 
 Run ALL of these in parallel before every commit/push:

--- a/docs/plans/374-supply-chain-hardening.md
+++ b/docs/plans/374-supply-chain-hardening.md
@@ -1,0 +1,42 @@
+# 374: Supply-chain hardening — SHA-pinned actions, dependency rules
+
+Prompted by: "Operation Muck and Load" (fake Go DNS scanner
+`github.com/kaleidora/dnsub-scanning-tool` typosquatting `dnsub`; 700+
+malicious versions across 222 GitHub lure repos; Socket research).
+Branch: `srepd/supply-chain-hardening`
+
+## Audit result (context)
+
+srepd is clean: no IOC matches in go.mod/go.sum, the onboarding PR stack
+(#363–#374) added zero dependencies, all direct deps are org-backed
+well-known modules, go.sum + the Go checksum DB give tamper-evidence, and
+CI runs govulncheck. govulncheck does NOT catch typosquat malware, though —
+that class is only defended at dependency-add time, which motivates the
+rules below.
+
+## Changes
+
+1. **GitHub Actions pinned to full commit SHAs** (the same style as the
+   already-pinned codecov action), so a hijacked or force-moved tag cannot
+   swap code into CI:
+   - `actions/checkout@v6` → `df4cb1c069e1874edd31b4311f1884172cec0e10 # v6` (×12)
+   - `actions/cache@v5` → `caa296126883cff596d87d8935842f9db880ef25 # v5` (×3)
+   - `actions/setup-go@v6` → `924ae3a1cded613372ab5595356fb5720e22ba16 # v6`
+     (inside the local `setup-go-from-mod` composite action)
+   SHAs resolved from the official repos via `gh api repos/<owner>/<repo>/commits/<tag>`.
+2. **dependabot `github-actions` ecosystem** (weekly) added so the SHA pins
+   are maintained automatically (dependabot bumps the SHA and keeps the
+   `# vN` comment).
+3. **AGENTS.md "Dependencies (supply-chain rules)" section**: new go.mod
+   modules require explicit human provenance review (exact-path typosquat
+   check, owner/history/version-volume scrutiny); AI agents must call out
+   dependency additions prominently in PR descriptions; prefer stdlib or
+   existing deps; keep the SHA-pin style for any new action.
+
+## Verification
+
+- `grep -r "uses:" .github/` shows only SHA-pinned third-party actions and
+  the local composite action.
+- Full local CI suite green (no Go code changed; suite run regardless).
+- Remote CI green on the PR — the workflow parses and the pinned actions
+  resolve.


### PR DESCRIPTION
Prompted by the ["Operation Muck and Load"](https://socket.dev/blog/malicious-go-module-exposes-github-malware-lure-network) Go typosquat campaign (fake `dnsub` DNS scanner, 700+ malicious versions, 222 GitHub lure repos). **Audit result: srepd is clean** — no IOC matches in go.mod/go.sum, the onboarding stack (#363–#374) added zero dependencies, and all direct deps are org-backed, well-known modules. This PR closes the residual gaps.

> Independent of the onboarding stack — based directly on `main`, mergeable any time.

## Changes

1. **All GitHub Actions pinned to full commit SHAs** (same style as the already-pinned codecov action) — a hijacked or force-moved tag can no longer swap code into CI:
   - `actions/checkout` ×12, `actions/cache` ×3, and `actions/setup-go` (inside the local composite action), SHAs resolved from the official repos
2. **dependabot `github-actions` ecosystem** (weekly) so the pins stay maintained automatically
3. **AGENTS.md "Dependencies (supply-chain rules)"**: new go.mod modules require explicit human provenance review (exact-path typosquat check, owner/history/version-volume scrutiny); AI agents must call out dependency additions prominently in PR descriptions; prefer stdlib/existing deps; keep the SHA-pin style for new actions

Context worth noting: govulncheck (already in CI) catches known CVEs but **not** typosquat malware — that class is only defensible at dependency-add time, which is what the AGENTS.md rules encode.

## Verification

- `grep -r "uses:" .github/` → only SHA-pinned third-party actions + the local composite
- Full local CI suite green (no Go code changed)

## Plan doc

`docs/plans/374-supply-chain-hardening.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BtcSJfWWcDKL4rSNNH1cN