### PR TITLE
Fix infinite pagination loop and 414 errors for large teams

### DIFF
--- a/docs/plans/377-fix-incident-pagination-loop.md
+++ b/docs/plans/377-fix-incident-pagination-loop.md
@@ -1,0 +1,119 @@
+# 377: Fix infinite pagination loop in incident fetching
+
+## Problem
+
+srepd v1.5.0 fails on startup with `pd.GetIncidents(): failed to get
+incidents: failed to read response body: context deadline exceeded` for users
+on large teams (e.g. PASPK4G, 175 members) who don't have
+`default_silent_escalation_policy` configured. Reported by Shawn Bai.
+
+Root cause: `updateIncidentList` built `ListIncidentsOptions` with only
+`TeamIDs` and `UserIDs` — no `Limit`, no `Statuses`. go-pagerduty's
+`url:"limit,omitempty"` tag drops zero-valued fields, so PagerDuty defaulted
+to `limit=25` across all statuses. `GetIncidents` advanced pagination via
+`opts.Offset += opts.Limit`, adding zero — any `more=true` response refetched
+page 1 forever until the 30-second context deadline expired.
+
+Trigger condition: team query returns >25 incidents (any status). PASPK4G
+currently has 27–29 open. Users with a silent escalation policy configured
+happen to filter out enough assignees to stay under 25 results, masking the
+bug.
+
+## Constraints
+
+- PagerDuty rejects request URIs over ~4096 bytes with HTTP 414.
+  175 members × ~23 bytes/`user_ids[]` param ≈ 4KB. The prior per-team fix
+  (commit 1d935de) fit by a few bytes; adding `limit=100&statuses[]=...`
+  params to that URL 414s immediately (probe-verified against live API).
+- Incident filtering must stay server-side per project requirements — no
+  client-side assignee filtering.
+
+## Approach
+
+### 1. Chunk user_ids[] queries (pkg/tui/commands.go)
+
+Rewrote `updateIncidentList` to:
+- Start from `pd.NewListIncidentOptsFromDefaults()` (Limit=100,
+  Statuses=triggered/acknowledged) as base options for every query
+- Split the non-ignored member list into batches of ≤100 user IDs
+  (`maxUserIDsInQuery` constant). 100 IDs ≈ 2.5KB, well under the 4KB limit
+  even with limit/statuses/team params
+- Issue one query per (team, chunk), merging results through the existing
+  dedup map
+- Empty member list (no team members returned) falls back to a single query
+  with no user_ids, preserving parity with old behavior
+
+New helper: `chunkStrings(items []string, size int) [][]string`
+
+### 2. Guard all pagination loops against Limit=0 (pkg/pd/pd.go)
+
+Added `if opts.Limit == 0 { opts.Limit = defaultPageLimit }` to all four
+functions that paginate with caller-supplied options: `GetIncidents`,
+`GetAlerts`, `GetUserOnCalls`, `GetTeamMemberIDs`. This is a defense-in-depth
+fix — the callers now send correct limits, but the pagination loops themselves
+can no longer spin on zero-increment offsets regardless of how they're called.
+
+Reworded the HTTP 414 error message to describe the actual failure
+("PagerDuty rejected the query URI as too long") rather than prescribing a
+user action that may not apply.
+
+### 3. Mock recording for test observability (pkg/pd/mock.go)
+
+Added `RecordedListIncidentsOpts`, `RecordedListAlertsOpts`, and
+`RecordedListOnCallOpts` fields to `MockPagerDutyClient`, populated in their
+respective mock methods. Tests assert on the recorded options to verify
+correct Limit, Statuses, TeamIDs, and UserIDs values.
+
+## Testing
+
+All tests written first (TDD), verified red before implementation.
+
+### pkg/pd/pd_test.go (4 new tests)
+
+- `TestGetIncidents_DefaultsLimitAndAdvancesOffset`: two-page mock,
+  verifies Limit=100 applied and offset advances to 100
+- `TestGetAlerts_DefaultsLimitWhenZero`: verifies Limit guard
+- `TestGetUserOnCalls_DefaultsLimitWhenZero`: verifies Limit guard
+- `TestGetTeamMemberIDs_DefaultsLimitWhenZero`: two-page mock, verifies
+  offsets [0, 100]
+
+### pkg/tui/commands_test.go (4 new subtests + 1 new test)
+
+- "sends default limit and statuses on every query": verifies Limit=100,
+  Statuses=triggered/acknowledged, correct TeamIDs/UserIDs
+- "chunks large member lists across queries": 250 members → 3 queries of
+  ≤100 each, dedup collapses to 2 unique incidents
+- "queries once without user_ids when team has no members": empty
+  TeamMembersByTeam → single query, no UserIDs
+- Strengthened "excludes ignored users" subtest to assert recorded opts
+- `TestChunkStrings`: nil input, under size, exact size, over size with
+  remainder
+
+### Live verification
+
+- API probe confirmed: bare v1.5.0 opts → `more=true total=28`; chunked fix
+  → chunk[0:100] + chunk[100:175], no 414, 28 unique merged
+- End-to-end: fixed binary loaded 27 incidents in 2 seconds against the
+  vulnerable token-only config
+
+## Lessons learned from commit 1d935de
+
+The June per-team 414 fix (1d935de) restructured queries to issue one request
+per team instead of combining all teams. This solved the immediate 414 for
+multi-team configs, but:
+
+1. **Left the URL within bytes of the 4KB limit** for single large teams —
+   adding any params (Limit, Statuses) pushed it over. The fix was validated
+   against the specific failing config but not against the worst-case URL
+   length with all default params populated.
+2. **Did not set Limit or Statuses** on the options, preserving the zero-Limit
+   infinite-loop vulnerability. The per-team restructuring changed *which*
+   queries ran, not *how* they were built.
+3. **No plan document existed** (predates the plan-doc requirement), so there
+   was no recorded reasoning about URL budget, pagination behavior, or
+   constraint margins to reference when this failure surfaced.
+
+Takeaway: when fixing a URL-length issue, budget for the *maximum* encoded
+URL including all params that could be populated, not just the params present
+at failure time. And always leave margin — fitting "by a few bytes" means the
+next feature or default change breaks it.

--- a/pkg/pd/mock.go
+++ b/pkg/pd/mock.go
@@ -63,10 +63,23 @@ type MockPagerDutyClient struct {
 	// front. When empty or nil, the default hardcoded response is returned.
 	ListIncidentsResponses []pagerduty.ListIncidentsResponse
 
+	// RecordedListIncidentsOpts records the options from every
+	// ListIncidentsWithContext call, in order, so tests can assert exactly
+	// what was sent (e.g. Limit, Statuses, Offset, and user_ids chunking).
+	RecordedListIncidentsOpts []pagerduty.ListIncidentsOptions
+
 	// ListIncidentAlertsResponses maps incident ID to a specific alerts response
 	// for ListIncidentAlertsWithContext. When non-nil and a matching key exists,
 	// that response is returned. Otherwise falls back to the default response.
 	ListIncidentAlertsResponses map[string]*pagerduty.ListAlertsResponse
+
+	// RecordedListAlertsOpts records the options from every
+	// ListIncidentAlertsWithContext call, in order.
+	RecordedListAlertsOpts []pagerduty.ListIncidentAlertsOptions
+
+	// RecordedListOnCallOpts records the options from every
+	// ListOnCallsWithContext call, in order.
+	RecordedListOnCallOpts []pagerduty.ListOnCallOptions
 }
 
 // recordCall increments the call count for the named method, lazily
@@ -98,6 +111,7 @@ func (m *MockPagerDutyClient) GetIncidentWithContext(ctx context.Context, id str
 
 func (m *MockPagerDutyClient) ListIncidentsWithContext(ctx context.Context, opts pagerduty.ListIncidentsOptions) (*pagerduty.ListIncidentsResponse, error) {
 	m.recordCall("ListIncidentsWithContext")
+	m.RecordedListIncidentsOpts = append(m.RecordedListIncidentsOpts, opts)
 	if opts.UserIDs != nil && opts.UserIDs[0] == "err" {
 		return &pagerduty.ListIncidentsResponse{}, ErrMockError
 	}
@@ -126,6 +140,7 @@ func (m *MockPagerDutyClient) ListIncidentsWithContext(ctx context.Context, opts
 
 func (m *MockPagerDutyClient) ListIncidentAlertsWithContext(ctx context.Context, id string, opts pagerduty.ListIncidentAlertsOptions) (*pagerduty.ListAlertsResponse, error) {
 	m.recordCall("ListIncidentAlertsWithContext")
+	m.RecordedListAlertsOpts = append(m.RecordedListAlertsOpts, opts)
 	if id == "err" {
 		return &pagerduty.ListAlertsResponse{}, ErrMockError
 	}
@@ -298,6 +313,7 @@ func (m *MockPagerDutyClient) ListEscalationPoliciesWithContext(ctx context.Cont
 
 func (m *MockPagerDutyClient) ListOnCallsWithContext(ctx context.Context, opts pagerduty.ListOnCallOptions) (*pagerduty.ListOnCallsResponse, error) {
 	m.recordCall("ListOnCallsWithContext")
+	m.RecordedListOnCallOpts = append(m.RecordedListOnCallOpts, opts)
 
 	// If the response queue is configured, pop the first response
 	if len(m.ListOnCallsResponses) > 0 {

--- a/pkg/pd/pd.go
+++ b/pkg/pd/pd.go
@@ -224,6 +224,12 @@ func GetAlerts(client PagerDutyClient, id string, opts pagerduty.ListIncidentAle
 	defer cancel()
 	var a []pagerduty.IncidentAlert
 
+	// A zero Limit would advance the offset by zero each page, refetching
+	// page one forever whenever the response reports more=true
+	if opts.Limit == 0 {
+		opts.Limit = defaultPageLimit
+	}
+
 	for {
 		response, err := client.ListIncidentAlertsWithContext(ctx, id, opts)
 		if err != nil {
@@ -273,11 +279,17 @@ func GetIncidents(client PagerDutyClient, opts pagerduty.ListIncidentsOptions) (
 	defer cancel()
 	var i []pagerduty.Incident
 
+	// A zero Limit would advance the offset by zero each page, refetching
+	// page one forever whenever the response reports more=true
+	if opts.Limit == 0 {
+		opts.Limit = defaultPageLimit
+	}
+
 	for {
 		response, err := client.ListIncidentsWithContext(ctx, opts)
 		if err != nil {
 			if strings.Contains(err.Error(), "414") {
-				return i, fmt.Errorf("pd.GetIncidents(): too many team members (%d) for PagerDuty API query — try selecting fewer teams: %w", len(opts.UserIDs), err)
+				return i, fmt.Errorf("pd.GetIncidents(): PagerDuty rejected the query URI as too long (HTTP 414; %d user IDs in query): %w", len(opts.UserIDs), err)
 			}
 			return i, fmt.Errorf("pd.GetIncidents(): failed to get incidents: %w", err)
 		}
@@ -328,6 +340,12 @@ func GetTeamMemberIDs(client PagerDutyClient, teams []*pagerduty.Team, opts page
 	defer cancel()
 	var allIDs []string
 	byTeam := make(map[string][]string)
+
+	// A zero Limit would advance the offset by zero each page, refetching
+	// page one forever whenever the response reports more=true
+	if opts.Limit == 0 {
+		opts.Limit = defaultPageLimit
+	}
 
 	for _, team := range teams {
 		opts.Offset = defaultOffset
@@ -399,6 +417,12 @@ func GetUserOnCalls(client PagerDutyClient, id string, opts pagerduty.ListOnCall
 	ctx, cancel := contextWithTimeout()
 	defer cancel()
 	var o []pagerduty.OnCall
+
+	// A zero Limit would advance the offset by zero each page, refetching
+	// page one forever whenever the response reports more=true
+	if opts.Limit == 0 {
+		opts.Limit = defaultPageLimit
+	}
 
 	for {
 		response, err := client.ListOnCallsWithContext(ctx, opts)

--- a/pkg/pd/pd_test.go
+++ b/pkg/pd/pd_test.go
@@ -373,6 +373,86 @@ func TestGetIncidents_Error(t *testing.T) {
 	assert.Empty(t, incidents)
 }
 
+// TestGetIncidents_DefaultsLimitAndAdvancesOffset reproduces the v1.5.0
+// startup timeout: with Limit omitted the API pages at 25 results, and
+// `opts.Offset += opts.Limit` advanced the offset by zero, so a more=true
+// response refetched page one forever until the context deadline expired.
+// GetIncidents must apply defaultPageLimit when Limit is unset and advance
+// the offset between pages.
+func TestGetIncidents_DefaultsLimitAndAdvancesOffset(t *testing.T) {
+	mockClient := &MockPagerDutyClient{
+		ListIncidentsResponses: []pagerduty.ListIncidentsResponse{
+			{
+				APIListObject: pagerduty.APIListObject{More: true},
+				Incidents:     []pagerduty.Incident{{APIObject: pagerduty.APIObject{ID: "PAGE1INCIDENT"}}},
+			},
+			{
+				Incidents: []pagerduty.Incident{{APIObject: pagerduty.APIObject{ID: "PAGE2INCIDENT"}}},
+			},
+		},
+	}
+
+	incidents, err := GetIncidents(mockClient, pagerduty.ListIncidentsOptions{})
+
+	assert.NoError(t, err)
+	assert.Len(t, incidents, 2)
+	if assert.Len(t, mockClient.RecordedListIncidentsOpts, 2) {
+		assert.Equal(t, uint(defaultPageLimit), mockClient.RecordedListIncidentsOpts[0].Limit)
+		assert.Equal(t, uint(defaultPageLimit), mockClient.RecordedListIncidentsOpts[1].Offset)
+	}
+}
+
+// TestGetAlerts_DefaultsLimitWhenZero guards against the same
+// zero-Limit infinite pagination loop in GetAlerts.
+func TestGetAlerts_DefaultsLimitWhenZero(t *testing.T) {
+	mockClient := new(MockPagerDutyClient)
+
+	_, err := GetAlerts(mockClient, "INCIDENT1", pagerduty.ListIncidentAlertsOptions{})
+
+	assert.NoError(t, err)
+	if assert.Len(t, mockClient.RecordedListAlertsOpts, 1) {
+		assert.Equal(t, uint(defaultPageLimit), mockClient.RecordedListAlertsOpts[0].Limit)
+	}
+}
+
+// TestGetUserOnCalls_DefaultsLimitWhenZero guards against the same
+// zero-Limit infinite pagination loop in GetUserOnCalls.
+func TestGetUserOnCalls_DefaultsLimitWhenZero(t *testing.T) {
+	mockClient := new(MockPagerDutyClient)
+
+	_, err := GetUserOnCalls(mockClient, "USER1", pagerduty.ListOnCallOptions{})
+
+	assert.NoError(t, err)
+	if assert.Len(t, mockClient.RecordedListOnCallOpts, 1) {
+		assert.Equal(t, uint(defaultPageLimit), mockClient.RecordedListOnCallOpts[0].Limit)
+	}
+}
+
+// TestGetTeamMemberIDs_DefaultsLimitWhenZero guards against the same
+// zero-Limit infinite pagination loop in GetTeamMemberIDs: with a more=true
+// first page and no explicit Limit, the second request must advance to
+// offset defaultPageLimit rather than refetching offset 0.
+func TestGetTeamMemberIDs_DefaultsLimitWhenZero(t *testing.T) {
+	mockClient := &MockPagerDutyClient{
+		ListMembersResponses: []ListMembersResponse{
+			{Response: &pagerduty.ListTeamMembersResponse{
+				APIListObject: pagerduty.APIListObject{More: true},
+				Members:       []pagerduty.Member{{User: pagerduty.APIObject{ID: "U1"}}},
+			}},
+			{Response: &pagerduty.ListTeamMembersResponse{
+				Members: []pagerduty.Member{{User: pagerduty.APIObject{ID: "U2"}}},
+			}},
+		},
+	}
+	teams := []*pagerduty.Team{{APIObject: pagerduty.APIObject{ID: "TEAM1"}}}
+
+	ids, _, err := GetTeamMemberIDs(mockClient, teams, pagerduty.ListTeamMembersOptions{})
+
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"U1", "U2"}, ids)
+	assert.Equal(t, []uint{0, uint(defaultPageLimit)}, mockClient.ListMembersOffsets)
+}
+
 func TestGetNotes_Success(t *testing.T) {
 	mockClient := new(MockPagerDutyClient)
 

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -138,8 +138,16 @@ type updatedIncidentListMsg struct {
 	err       error
 }
 
+// maxUserIDsInQuery is the maximum number of user IDs to include in a single
+// PagerDuty API query. PagerDuty rejects request URIs over ~4096 bytes with
+// HTTP 414 (URI Too Long); 100 user_ids[] params plus the team, status, and
+// pagination params stay well under that limit.
+const maxUserIDsInQuery = 100
+
 // updateIncidentList returns a command that fetches the incident list from the PagerDuty API.
-// It queries per-team to avoid HTTP 414 (URI Too Long) when teams have many members.
+// It queries per-team, splitting large member lists into chunks of at most
+// maxUserIDsInQuery user IDs per query to avoid HTTP 414 (URI Too Long),
+// and deduplicates the merged results.
 func updateIncidentList(p *pd.Config) tea.Cmd {
 	return func() tea.Msg {
 		if p == nil {
@@ -153,20 +161,28 @@ func updateIncidentList(p *pd.Config) tea.Cmd {
 		for _, team := range p.Teams {
 			memberIDs := filterUserIDs(p.TeamMembersByTeam[team.ID], ignoredIDs)
 
-			opts := pagerduty.ListIncidentsOptions{
-				TeamIDs: []string{team.ID},
-				UserIDs: memberIDs,
+			chunks := chunkStrings(memberIDs, maxUserIDsInQuery)
+			if len(chunks) == 0 {
+				// No members to filter by: query the team alone, matching
+				// the API behavior when user_ids[] is omitted
+				chunks = [][]string{nil}
 			}
 
-			incidents, err := pd.GetIncidents(p.Client, opts)
-			if err != nil {
-				return updatedIncidentListMsg{err: err}
-			}
+			for _, chunk := range chunks {
+				opts := pd.NewListIncidentOptsFromDefaults()
+				opts.TeamIDs = []string{team.ID}
+				opts.UserIDs = chunk
 
-			for _, inc := range incidents {
-				if !seen[inc.ID] {
-					seen[inc.ID] = true
-					allIncidents = append(allIncidents, inc)
+				incidents, err := pd.GetIncidents(p.Client, opts)
+				if err != nil {
+					return updatedIncidentListMsg{err: err}
+				}
+
+				for _, inc := range incidents {
+					if !seen[inc.ID] {
+						seen[inc.ID] = true
+						allIncidents = append(allIncidents, inc)
+					}
 				}
 			}
 		}
@@ -191,6 +207,18 @@ func filterUserIDs(memberIDs []string, ignored []string) []string {
 		}
 	}
 	return filtered
+}
+
+func chunkStrings(items []string, size int) [][]string {
+	var chunks [][]string
+	for len(items) > size {
+		chunks = append(chunks, items[:size])
+		items = items[size:]
+	}
+	if len(items) > 0 {
+		chunks = append(chunks, items)
+	}
+	return chunks
 }
 
 // HOUSEKEEPING: The above are commands that have complete unit tests and incoming

--- a/pkg/tui/commands_test.go
+++ b/pkg/tui/commands_test.go
@@ -362,6 +362,28 @@ func TestFilterUserIDs(t *testing.T) {
 	})
 }
 
+func TestChunkStrings(t *testing.T) {
+	t.Run("returns nil for empty input", func(t *testing.T) {
+		assert.Nil(t, chunkStrings(nil, 3))
+		assert.Nil(t, chunkStrings([]string{}, 3))
+	})
+
+	t.Run("single chunk when under size", func(t *testing.T) {
+		chunks := chunkStrings([]string{"a", "b"}, 3)
+		assert.Equal(t, [][]string{{"a", "b"}}, chunks)
+	})
+
+	t.Run("single chunk at exactly size", func(t *testing.T) {
+		chunks := chunkStrings([]string{"a", "b", "c"}, 3)
+		assert.Equal(t, [][]string{{"a", "b", "c"}}, chunks)
+	})
+
+	t.Run("splits over size with remainder", func(t *testing.T) {
+		chunks := chunkStrings([]string{"a", "b", "c", "d"}, 3)
+		assert.Equal(t, [][]string{{"a", "b", "c"}, {"d"}}, chunks)
+	})
+}
+
 func TestUpdateIncidentList_PerTeamQuery(t *testing.T) {
 	t.Run("queries per team and deduplicates", func(t *testing.T) {
 		config := &pd.Config{
@@ -397,8 +419,9 @@ func TestUpdateIncidentList_PerTeamQuery(t *testing.T) {
 	})
 
 	t.Run("excludes ignored users from per-team queries", func(t *testing.T) {
+		mock := &pd.MockPagerDutyClient{}
 		config := &pd.Config{
-			Client: &pd.MockPagerDutyClient{},
+			Client: mock,
 			Teams: []*pagerduty.Team{
 				{APIObject: pagerduty.APIObject{ID: "TEAM1"}},
 			},
@@ -415,6 +438,104 @@ func TestUpdateIncidentList_PerTeamQuery(t *testing.T) {
 		result, ok := msg.(updatedIncidentListMsg)
 		assert.True(t, ok)
 		assert.NoError(t, result.err)
+		if assert.Len(t, mock.RecordedListIncidentsOpts, 1) {
+			assert.Equal(t, []string{"U1"}, mock.RecordedListIncidentsOpts[0].UserIDs)
+		}
+	})
+
+	// The v1.5.0 startup timeout: queries were sent with no Limit and no
+	// Statuses, so PagerDuty paged at 25 results across all incident statuses
+	// and GetIncidents looped forever when a team had >25 incidents. Every
+	// query must carry the defaults from pd.NewListIncidentOptsFromDefaults().
+	t.Run("sends default limit and statuses on every query", func(t *testing.T) {
+		mock := &pd.MockPagerDutyClient{}
+		config := &pd.Config{
+			Client: mock,
+			Teams: []*pagerduty.Team{
+				{APIObject: pagerduty.APIObject{ID: "TEAM1"}},
+			},
+			TeamMembersByTeam: map[string][]string{
+				"TEAM1": {"U1", "U2"},
+			},
+		}
+
+		cmd := updateIncidentList(config)
+		msg := cmd()
+		result, ok := msg.(updatedIncidentListMsg)
+		assert.True(t, ok)
+		assert.NoError(t, result.err)
+		if assert.Len(t, mock.RecordedListIncidentsOpts, 1) {
+			opts := mock.RecordedListIncidentsOpts[0]
+			assert.Equal(t, uint(100), opts.Limit)
+			assert.Equal(t, []string{"triggered", "acknowledged"}, opts.Statuses)
+			assert.Equal(t, []string{"TEAM1"}, opts.TeamIDs)
+			assert.Equal(t, []string{"U1", "U2"}, opts.UserIDs)
+		}
+	})
+
+	// PagerDuty rejects request URIs over ~4096 bytes with HTTP 414. A team
+	// of 175 members produces ~4KB of user_ids[] params, so large member
+	// lists must be split across multiple queries of at most
+	// maxUserIDsInQuery IDs each, then merged through the dedup pass.
+	t.Run("chunks large member lists across queries", func(t *testing.T) {
+		members := make([]string, 250)
+		for i := range members {
+			members[i] = fmt.Sprintf("P%06d", i)
+		}
+		mock := &pd.MockPagerDutyClient{}
+		config := &pd.Config{
+			Client: mock,
+			Teams: []*pagerduty.Team{
+				{APIObject: pagerduty.APIObject{ID: "TEAM1"}},
+			},
+			TeamMembersByTeam: map[string][]string{
+				"TEAM1": members,
+			},
+		}
+
+		cmd := updateIncidentList(config)
+		msg := cmd()
+		result, ok := msg.(updatedIncidentListMsg)
+		assert.True(t, ok)
+		assert.NoError(t, result.err)
+
+		if assert.Len(t, mock.RecordedListIncidentsOpts, 3) {
+			var queried []string
+			for _, opts := range mock.RecordedListIncidentsOpts {
+				assert.LessOrEqual(t, len(opts.UserIDs), maxUserIDsInQuery)
+				assert.Equal(t, []string{"TEAM1"}, opts.TeamIDs)
+				assert.Equal(t, uint(100), opts.Limit)
+				assert.Equal(t, []string{"triggered", "acknowledged"}, opts.Statuses)
+				queried = append(queried, opts.UserIDs...)
+			}
+			assert.Equal(t, members, queried)
+		}
+		// The mock returns the same two incidents for every chunk, so the
+		// dedup pass must collapse them to two unique incidents.
+		assert.Len(t, result.incidents, 2)
+	})
+
+	// Parity with the single-query behavior: an empty member list omits
+	// user_ids[] entirely (team-only filtering) rather than sending no query.
+	t.Run("queries once without user_ids when team has no members", func(t *testing.T) {
+		mock := &pd.MockPagerDutyClient{}
+		config := &pd.Config{
+			Client: mock,
+			Teams: []*pagerduty.Team{
+				{APIObject: pagerduty.APIObject{ID: "TEAM1"}},
+			},
+		}
+
+		cmd := updateIncidentList(config)
+		msg := cmd()
+		result, ok := msg.(updatedIncidentListMsg)
+		assert.True(t, ok)
+		assert.NoError(t, result.err)
+		if assert.Len(t, mock.RecordedListIncidentsOpts, 1) {
+			assert.Empty(t, mock.RecordedListIncidentsOpts[0].UserIDs)
+			assert.Equal(t, []string{"TEAM1"}, mock.RecordedListIncidentsOpts[0].TeamIDs)
+		}
+		assert.Len(t, result.incidents, 2)
 	})
 
 	t.Run("propagates API error", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Bug**: srepd v1.5.0 fails on startup with `context deadline exceeded` for users on large PagerDuty teams (e.g. PASPK4G, 175 members) without `default_silent_escalation_policy` configured. `GetIncidents` looped forever at offset 0 because `updateIncidentList` never set `Limit` on the options struct.
- **Fix**: Guard all four pagination loops (`GetIncidents`, `GetAlerts`, `GetUserOnCalls`, `GetTeamMemberIDs`) against `Limit==0`, chunk `user_ids[]` queries into batches of ≤100 to stay under PagerDuty's ~4KB URI limit, and always send `Limit=100` + `Statuses=triggered,acknowledged` defaults.
- **Verified**: unit tests (TDD), race detector, live API probe (28 incidents merged across 2 chunks, no 414), and end-to-end binary run (27 incidents loaded in 2s against the vulnerable config).

## Test plan

- [x] `go test ./...` passes (4 new pd tests + 5 new tui tests)
- [x] `go test -race ./...` passes
- [x] `gofmt -s -l` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run` 0 issues (in this worktree)
- [x] Plan document included (`docs/plans/377-fix-incident-pagination-loop.md`)
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)