### PR TITLE
Defer OCM auth until the config wizard completes (OB-6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ When running inside a Fedora Toolbox, terminal commands are automatically prefix
 
 ## OCM Integration
 
-SREPD enriches PagerDuty incident data with cluster details from the OpenShift Cluster Manager (OCM) API. On startup, it connects to the production OCM API using tokens from `~/.config/ocm/ocm.json`. If tokens are expired, a browser window opens for auth code login in the background — the TUI starts immediately with PagerDuty incidents visible, and OCM enrichment populates once authentication completes.
+SREPD enriches PagerDuty incident data with cluster details from the OpenShift Cluster Manager (OCM) API. On startup, it connects to the production OCM API using tokens from `~/.config/ocm/ocm.json`. If tokens are expired, a browser window opens for auth code login in the background — the TUI starts immediately with PagerDuty incidents visible, and OCM enrichment populates once authentication completes. OCM authentication is skipped while the configuration wizard is on screen (`srepd config` and first-run setup) so new users aren't interrupted before saving a token; it runs automatically as soon as the wizard completes and the live session begins.
 
 Enriched data includes:
 * **Cluster display names** replace PD service names in the incident table (e.g., `mycluster.abc1.p1.example.org` instead of `osd-mycluster.abc1.p1.example.org-hive-cluster`)

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -6,7 +6,6 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 	"time"
@@ -15,7 +14,6 @@ import (
 	pkgconfig "github.com/clcollins/srepd/pkg/config"
 	"github.com/clcollins/srepd/pkg/deprecation"
 	"github.com/clcollins/srepd/pkg/launcher"
-	"github.com/clcollins/srepd/pkg/ocm"
 	"github.com/clcollins/srepd/pkg/tui"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -102,27 +100,6 @@ func launchTUIWithConfig() {
 		log.Fatal(err)
 	}
 
-	var ocmClient ocm.OCMClient
-	var ocmAuthPending bool
-	var asyncOCMClient *ocm.Client
-
-	cfg, armed, checkErr := ocm.CheckTokens()
-	if checkErr != nil {
-		log.Warn("OCM config check failed", "error", checkErr)
-	} else if armed {
-		client, connErr := ocm.NewClientFromConfig(cfg, tui.Version)
-		if connErr != nil {
-			log.Warn("OCM connection failed", "error", connErr)
-		} else {
-			ocmClient = client
-			asyncOCMClient = client
-			log.Info("OCM connected")
-		}
-	} else {
-		ocmAuthPending = true
-		log.Info("OCM tokens not valid — will authenticate async")
-	}
-
 	m, _ := tui.InitialModel(
 		viper.GetString("token"),
 		viper.GetStringSlice("teams"),
@@ -132,40 +109,19 @@ func launchTUIWithConfig() {
 		l,
 		launcher.ClusterLauncher{}, // rosa-boundary not needed in config mode
 		viper.GetBool("debug"),
-		ocmClient,
+		nil, // ocmClient — no OCM auth in config mode (OB-6)
 		viper.GetStringMapString("colors"),
 		viper.GetString("default_silent_escalation_policy"),
 		viper.GetStringMapString("custom_service_escalation_policies"),
-		true, // configMode
-		ocmAuthPending,
-		nil, // aiProvider — not needed in config mode
-		"",  // agentCLICommand — not needed in config mode
-		nil, // backplaneClient — not needed in config mode
-		nil, // backplaneConfig — not needed in config mode
+		true,  // configMode
+		false, // ocmAuthPending — never authenticate during config mode
+		nil,   // aiProvider — not needed in config mode
+		"",    // agentCLICommand — not needed in config mode
+		nil,   // backplaneClient — not needed in config mode
+		nil,   // backplaneConfig — not needed in config mode
 	)
 
 	p := tea.NewProgram(m, tea.WithAltScreen())
-
-	if ocmAuthPending {
-		go func() {
-			fmt.Fprintln(os.Stderr, "OCM tokens expired — opening browser for authentication...")
-			token, authErr := ocm.AuthenticateAsync(cfg)
-			if authErr != nil {
-				log.Debug("OCM browser auth failed", "error", authErr)
-				p.Send(tui.OCMClientReadyMsg{Err: authErr})
-				return
-			}
-			fmt.Fprintln(os.Stderr, "OCM authentication successful.")
-			ocm.ApplyAuthToken(cfg, token)
-			client, connErr := ocm.NewClientFromConfig(cfg, tui.Version)
-			if connErr != nil {
-				p.Send(tui.OCMClientReadyMsg{Err: connErr})
-				return
-			}
-			asyncOCMClient = client
-			p.Send(tui.OCMClientReadyMsg{Client: client})
-		}()
-	}
 
 	go func() {
 		for {
@@ -175,10 +131,6 @@ func launchTUIWithConfig() {
 	}()
 
 	_, err = p.Run()
-
-	if asyncOCMClient != nil {
-		asyncOCMClient.Close()
-	}
 
 	if err != nil {
 		fmt.Println(err)

--- a/cmd/config_ocm_test.go
+++ b/cmd/config_ocm_test.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// OB-6 regression guard: config-wizard mode must never trigger OCM auth. A
+// brand-new user setting up srepd should not see "OCM tokens expired —
+// opening browser" or OCM warnings before they have even saved a token.
+// launchTUIWithConfig lives in config.go; the OCM setup must stay out of it.
+func TestConfigMode_NoOCMAuth(t *testing.T) {
+	src, err := os.ReadFile("config.go")
+	assert.NoError(t, err)
+
+	content := string(src)
+	for _, forbidden := range []string{
+		"ocm.CheckTokens",
+		"ocm.AuthenticateAsync",
+		"ocm.NewClientFromConfig",
+		"ocm.ApplyAuthToken",
+		"OCMClientReadyMsg",
+	} {
+		assert.NotContains(t, content, forbidden,
+			"config mode must not perform OCM auth (%s found in cmd/config.go)", forbidden)
+	}
+}
+
+// The OCM startup logic must live in exactly one place: the setupOCM helper
+// used by the normal launch path.
+func TestSetupOCM_SingleCallSite(t *testing.T) {
+	src, err := os.ReadFile("root.go")
+	assert.NoError(t, err)
+
+	content := string(src)
+	assert.Contains(t, content, "func setupOCM(", "setupOCM helper must exist in root.go")
+	assert.Equal(t, 1, strings.Count(content, "ocm.CheckTokens"),
+		"ocm.CheckTokens must be called only inside setupOCM")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,6 +35,8 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/log"
+	ocmconfig "github.com/openshift-online/ocm-common/pkg/ocm/config"
+
 	"github.com/clcollins/srepd/pkg/ai"
 	"github.com/clcollins/srepd/pkg/backplane"
 	pkgconfig "github.com/clcollins/srepd/pkg/config"
@@ -222,26 +224,7 @@ func launchTUI() {
 		log.Fatal(err)
 	}
 
-	var ocmClient ocm.OCMClient
-	var ocmAuthPending bool
-	var asyncOCMClient *ocm.Client
-
-	cfg, armed, checkErr := ocm.CheckTokens()
-	if checkErr != nil {
-		log.Warn("OCM config check failed", "error", checkErr)
-	} else if armed {
-		client, connErr := ocm.NewClientFromConfig(cfg, tui.Version)
-		if connErr != nil {
-			log.Warn("OCM connection failed", "error", connErr)
-		} else {
-			ocmClient = client
-			asyncOCMClient = client
-			log.Info("OCM connected")
-		}
-	} else {
-		ocmAuthPending = true
-		log.Info("OCM tokens not valid — will authenticate async")
-	}
+	ocmClient, asyncOCMClient, ocmAuthPending, cfg := setupOCM()
 
 	var aiProvider ai.Provider
 	llmCfg := ai.Config{
@@ -363,6 +346,37 @@ func launchTUI() {
 		fmt.Println(err)
 		log.Fatal(err)
 	}
+}
+
+// setupOCM checks OCM tokens and connects when possible. It returns the
+// client handed to the TUI, the concrete client for lifecycle cleanup,
+// whether async browser auth is still required, and the OCM config needed to
+// complete that auth. Config-wizard mode deliberately skips this (OB-6): a
+// brand-new user must not see browser-auth prompts or OCM warnings before
+// they have even saved a PagerDuty token.
+func setupOCM() (ocm.OCMClient, *ocm.Client, bool, *ocmconfig.Config) {
+	var ocmClient ocm.OCMClient
+	var concreteClient *ocm.Client
+	var authPending bool
+
+	cfg, armed, checkErr := ocm.CheckTokens()
+	if checkErr != nil {
+		log.Warn("OCM config check failed", "error", checkErr)
+	} else if armed {
+		client, connErr := ocm.NewClientFromConfig(cfg, tui.Version)
+		if connErr != nil {
+			log.Warn("OCM connection failed", "error", connErr)
+		} else {
+			ocmClient = client
+			concreteClient = client
+			log.Info("OCM connected")
+		}
+	} else {
+		authPending = true
+		log.Info("OCM tokens not valid — will authenticate async")
+	}
+
+	return ocmClient, concreteClient, authPending, cfg
 }
 
 // logWriter holds the active asyncWriter so it can be flushed on shutdown.

--- a/docs/plans/363-config-mode-no-ocm.md
+++ b/docs/plans/363-config-mode-no-ocm.md
@@ -1,0 +1,58 @@
+# 363: No OCM auth in config-wizard mode (OB-6)
+
+Issue: #353 (OB-6), part of the onboarding overhaul (#353, #324)
+Branch: `srepd/config-mode-no-ocm`
+
+## Problem
+
+`launchTUIWithConfig()` — the config-wizard entry point — ran the same OCM
+startup as the normal launch path: `ocm.CheckTokens()` plus an async
+browser-auth goroutine. A brand-new user running `srepd config` (or hitting
+the first-run wizard) saw "OCM tokens expired — opening browser for
+authentication..." and OCM warnings before they had even saved a PagerDuty
+token. Confusing at best, alarming at worst — and entirely unnecessary, since
+config mode makes no OCM calls.
+
+## Approach
+
+Defer OCM, don't drop it. The wizard itself is OCM-free, and the session
+that continues after the wizard connects OCM exactly like a normal launch —
+a first-run user must not get a degraded (enrichment-less) srepd, or they
+try it once, get underwhelmed, and never come back.
+
+- `cmd/config.go` `launchTUIWithConfig()`: delete the OCM token-check block
+  and the async browser-auth goroutine; pass `nil` ocmClient and `false`
+  ocmAuthPending to `tui.InitialModel`. Config mode is now OCM-free.
+- `cmd/root.go`: extract the (previously duplicated) OCM startup into a
+  `setupOCM()` helper returning `(ocm.OCMClient, *ocm.Client, authPending,
+  *ocmconfig.Config)`. `launchTUI()` — the normal path — is its only caller,
+  with behavior unchanged.
+- `pkg/ocm`: new `Connect(agentVersion)` — CheckTokens → browser auth if
+  expired → NewClientFromConfig, blocking; for use inside a tea.Cmd.
+- `pkg/tui`: post-wizard OCM handoff. `connectOCMCmdIfNeeded()` (nil when
+  connected or dev mode; result flows through the existing
+  `OCMClientReadyMsg` handler, which already wires the client, deferred
+  backplane, and cluster enrichment). `ocmHandoffCmd(requirePDConfig)` sets
+  `ocmAuthPending` and gates on a usable PD config. Wired into all four
+  wizard-exit paths: save (`configSavedMsg`, batched with PD init), discard,
+  no-changes, and abort — the last three require an existing PD config so a
+  brand-new user backing out never gets a browser-auth prompt on the way out.
+  Injectable `model.ocmConnect` for tests.
+
+## Tests (TDD — written first)
+
+`cmd/config_ocm_test.go` source-scan regression guards (pattern from plan 086
+verification):
+- `TestConfigMode_NoOCMAuth` — `cmd/config.go` must not reference
+  `ocm.CheckTokens`, `ocm.AuthenticateAsync`, `ocm.NewClientFromConfig`,
+  `ocm.ApplyAuthToken`, or `OCMClientReadyMsg`.
+- `TestSetupOCM_SingleCallSite` — `setupOCM` exists in root.go and is the
+  single `ocm.CheckTokens` call site.
+
+`pkg/tui/config_ocm_handoff_test.go` (mock OCM client via injectable
+`ocmConnect`):
+- connect cmd produced when no client; nil when connected / dev mode; error
+  surfaces as `OCMClientReadyMsg.Err`
+- `configSavedMsg` success queues the connect (`ocmAuthPending` set); save
+  error and already-connected cases do not
+- wizard abort without a PD config performs no OCM handoff

--- a/pkg/ocm/client.go
+++ b/pkg/ocm/client.go
@@ -87,6 +87,25 @@ func AuthenticateAsync(cfg *ocmconfig.Config) (string, error) {
 	return token, nil
 }
 
+// Connect checks OCM tokens and returns a connected client, running the
+// interactive browser authentication flow when tokens are expired. It blocks
+// until authentication completes, so callers must run it off the UI thread
+// (e.g. inside a tea.Cmd).
+func Connect(agentVersion string) (*Client, error) {
+	cfg, armed, err := CheckTokens()
+	if err != nil {
+		return nil, fmt.Errorf("OCM config check failed: %w", err)
+	}
+	if !armed {
+		token, authErr := AuthenticateAsync(cfg)
+		if authErr != nil {
+			return nil, fmt.Errorf("OCM authentication failed: %w", authErr)
+		}
+		ApplyAuthToken(cfg, token)
+	}
+	return NewClientFromConfig(cfg, agentVersion)
+}
+
 // ApplyAuthToken classifies a raw auth token and sets the appropriate
 // field on the OCM config (RefreshToken or AccessToken).
 func ApplyAuthToken(cfg *ocmconfig.Config, token string) {

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -1559,6 +1559,53 @@ type OCMClientReadyMsg struct {
 	Err    error
 }
 
+// connectOCMCmdIfNeeded returns a command that connects OCM after the config
+// wizard exits into a live session, so cluster enrichment works exactly like
+// a normal launch. OCM auth is deliberately skipped while the wizard runs
+// (OB-6); this is the follow-through that keeps the first session fully
+// functional. Returns nil when OCM is already connected or in dev mode. The
+// connection (including browser auth for expired tokens) blocks inside the
+// tea.Cmd goroutine, and the result flows through the existing
+// OCMClientReadyMsg handler (client, deferred backplane, enrichment).
+func (m model) connectOCMCmdIfNeeded() tea.Cmd {
+	if m.ocmClient != nil || m.devMode {
+		return nil
+	}
+	connect := m.ocmConnect
+	if connect == nil {
+		connect = func() (ocm.OCMClient, error) {
+			client, err := ocm.Connect(Version)
+			if err != nil {
+				return nil, err
+			}
+			return client, nil
+		}
+	}
+	return func() tea.Msg {
+		client, err := connect()
+		if err != nil || client == nil {
+			return OCMClientReadyMsg{Err: err}
+		}
+		return OCMClientReadyMsg{Client: client}
+	}
+}
+
+// ocmHandoffCmd wraps connectOCMCmdIfNeeded for the wizard-exit paths,
+// setting ocmAuthPending so the UI reflects the in-flight connection. When
+// requirePDConfig is true (discard/no-changes/abort paths), the handoff only
+// happens if a usable PD config exists — a brand-new user backing out of the
+// wizard must not get a browser-auth prompt on the way out.
+func (m *model) ocmHandoffCmd(requirePDConfig bool) tea.Cmd {
+	if requirePDConfig && (m.config == nil || m.config.Client == nil) {
+		return nil
+	}
+	cmd := m.connectOCMCmdIfNeeded()
+	if cmd != nil {
+		m.ocmAuthPending = true
+	}
+	return cmd
+}
+
 type pdClientInitializedMsg struct {
 	config *pd.Config
 	err    error

--- a/pkg/tui/config_ocm_handoff_test.go
+++ b/pkg/tui/config_ocm_handoff_test.go
@@ -1,0 +1,121 @@
+package tui
+
+import (
+	"fmt"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/huh"
+	"github.com/clcollins/srepd/pkg/ocm"
+	"github.com/stretchr/testify/assert"
+)
+
+// OB-6 follow-through: OCM auth is skipped while the config wizard runs, but
+// the session that continues after the wizard must get OCM enrichment exactly
+// like a normal launch — otherwise first-run users see a degraded srepd and
+// never come back.
+
+func TestConnectOCMCmdIfNeeded_ReturnsCmdWhenNoClient(t *testing.T) {
+	mock := createMockOCMClient()
+	m := createConfigTestModel()
+	m.ocmClient = nil
+	m.ocmConnect = func() (ocm.OCMClient, error) { return mock, nil }
+
+	cmd := m.connectOCMCmdIfNeeded()
+
+	assert.NotNil(t, cmd, "should return a connect command when no OCM client exists")
+	msg := cmd()
+	ready, ok := msg.(OCMClientReadyMsg)
+	assert.True(t, ok, "command must produce OCMClientReadyMsg, got %T", msg)
+	assert.NoError(t, ready.Err)
+	assert.Equal(t, ocm.OCMClient(mock), ready.Client)
+}
+
+func TestConnectOCMCmdIfNeeded_NilWhenClientPresent(t *testing.T) {
+	m := createConfigTestModel()
+	m.ocmClient = createMockOCMClient()
+
+	assert.Nil(t, m.connectOCMCmdIfNeeded(), "must not reconnect when OCM client already exists")
+}
+
+func TestConnectOCMCmdIfNeeded_NilInDevMode(t *testing.T) {
+	m := createConfigTestModel()
+	m.ocmClient = nil
+	m.devMode = true
+
+	assert.Nil(t, m.connectOCMCmdIfNeeded(), "dev mode must not attempt OCM connections")
+}
+
+func TestConnectOCMCmdIfNeeded_ErrorProducesErrMsg(t *testing.T) {
+	m := createConfigTestModel()
+	m.ocmClient = nil
+	m.ocmConnect = func() (ocm.OCMClient, error) { return nil, fmt.Errorf("auth cancelled") }
+
+	cmd := m.connectOCMCmdIfNeeded()
+	assert.NotNil(t, cmd)
+
+	msg := cmd()
+	ready, ok := msg.(OCMClientReadyMsg)
+	assert.True(t, ok, "command must produce OCMClientReadyMsg, got %T", msg)
+	assert.Error(t, ready.Err)
+	assert.Nil(t, ready.Client)
+}
+
+// Saving the wizard must queue the OCM connect alongside PD init, flagged via
+// ocmAuthPending so the UI reflects the in-flight connection.
+func TestConfigSaved_TriggersOCMConnect(t *testing.T) {
+	mock := createMockOCMClient()
+	m := createConfigTestModel()
+	m.ocmClient = nil
+	m.ocmConnect = func() (ocm.OCMClient, error) { return mock, nil }
+
+	result, cmd := m.Update(configSavedMsg{err: nil})
+	updated := result.(model)
+
+	assert.NotNil(t, cmd)
+	assert.True(t, updated.ocmAuthPending, "OCM connect must be queued after config save")
+}
+
+func TestConfigSaved_NoOCMConnectWhenAlreadyConnected(t *testing.T) {
+	m := createConfigTestModel()
+	m.ocmClient = createMockOCMClient()
+
+	result, cmd := m.Update(configSavedMsg{err: nil})
+	updated := result.(model)
+
+	assert.NotNil(t, cmd, "PD init must still be dispatched")
+	assert.False(t, updated.ocmAuthPending, "no OCM connect when a client already exists")
+}
+
+func TestConfigSaved_NoOCMConnectOnSaveError(t *testing.T) {
+	m := createConfigTestModel()
+	m.ocmClient = nil
+	m.ocmConnect = func() (ocm.OCMClient, error) { return createMockOCMClient(), nil }
+
+	result, _ := m.Update(configSavedMsg{err: fmt.Errorf("disk full")})
+	updated := result.(model)
+
+	assert.False(t, updated.ocmAuthPending, "failed save must not trigger OCM connect")
+}
+
+// A brand-new user aborting the wizard has no usable session — do not pop
+// browser auth at them on the way out.
+func TestConfigAborted_NoOCMConnectWithoutPDConfig(t *testing.T) {
+	m := createConfigTestModel()
+	m.configMode = true
+	m.ocmClient = nil
+	m.config = nil
+	m.ocmConnect = func() (ocm.OCMClient, error) { return createMockOCMClient(), nil }
+
+	form := huh.NewForm(huh.NewGroup(huh.NewNote().Title("test")))
+	form.Init()
+	form.State = huh.StateAborted
+	m.configForm = form
+
+	result, cmd := switchConfigFocusMode(m, tea.KeyMsg{Type: tea.KeyEscape})
+	updated := result.(model)
+
+	assert.False(t, updated.configMode)
+	assert.Nil(t, cmd)
+	assert.False(t, updated.ocmAuthPending, "abort without a PD config must not connect OCM")
+}

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -207,8 +207,11 @@ type model struct {
 	configWizardPending *configWizardReadyMsg
 
 	// OCM enrichment state
-	ocmClient             ocm.OCMClient
-	ocmAuthPending        bool
+	ocmClient      ocm.OCMClient
+	ocmAuthPending bool
+	// ocmConnect overrides the post-wizard OCM connection for tests; nil
+	// means the real ocm.Connect (which may run browser auth).
+	ocmConnect            func() (ocm.OCMClient, error)
 	incidentClusterMap    map[string][]string // incident ID → cluster IDs
 	clusterEnrichInFlight map[string]bool     // cluster IDs currently being enriched
 	clusterEnrichFailed   map[string]int      // failure count per cluster ID

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -316,7 +316,11 @@ func switchConfigFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		if !m.configState.Confirm {
 			m.setStatus("config changes discarded")
-			return m, func() tea.Msg { return updateIncidentListMsg("config discarded") }
+			cmds := []tea.Cmd{func() tea.Msg { return updateIncidentListMsg("config discarded") }}
+			if ocmCmd := m.ocmHandoffCmd(true); ocmCmd != nil {
+				cmds = append(cmds, ocmCmd)
+			}
+			return m, tea.Batch(cmds...)
 		}
 
 		final, err := pkgconfig.ResolveFinalValues(m.configExisting, pkgconfig.WizardInputs{
@@ -351,7 +355,11 @@ func switchConfigFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		if !changes.AnyChanged() {
 			m.setStatus("config is valid, no changes needed")
-			return m, func() tea.Msg { return updateIncidentListMsg("config unchanged") }
+			cmds := []tea.Cmd{func() tea.Msg { return updateIncidentListMsg("config unchanged") }}
+			if ocmCmd := m.ocmHandoffCmd(true); ocmCmd != nil {
+				cmds = append(cmds, ocmCmd)
+			}
+			return m, tea.Batch(cmds...)
 		}
 
 		teamNames := make(map[string]string)
@@ -385,7 +393,7 @@ func switchConfigFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.configModeRequested = false
 		m.table.Focus()
 		m.setStatus("config cancelled")
-		return m, nil
+		return m, m.ocmHandoffCmd(true)
 	}
 	return m, cmd
 }

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -354,7 +354,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.setStatus("config saved — initializing...")
 		m.table.Focus()
-		return m, initPDClientCmd()
+		cmds := []tea.Cmd{initPDClientCmd()}
+		if ocmCmd := m.ocmHandoffCmd(false); ocmCmd != nil {
+			cmds = append(cmds, ocmCmd)
+		}
+		return m, tea.Batch(cmds...)
 
 	case pdClientInitializedMsg:
 		if msg.err != nil {


### PR DESCRIPTION
Replaces #364 (closed when #363's branch was deleted on squash-merge). Rebased cleanly onto main with all #363 improvements preserved.

## Problem

`launchTUIWithConfig()` ran OCM startup (token check + browser-auth goroutine) during the config wizard — a brand-new user saw "OCM tokens expired — opening browser..." before saving a PagerDuty token.

Closes OB-6 of #353.

## Design: defer, don't drop

OCM is silent during the wizard; the moment the wizard exits into a live session, OCM connects exactly like a normal launch — first-run users get the full enriched experience.

## Changes

- **`cmd/config.go`**: OCM block removed from `launchTUIWithConfig()`; nil/false to the model
- **`cmd/root.go`**: OCM startup extracted into `setupOCM()` helper; `launchTUI()` is its only caller
- **`pkg/ocm`**: new `Connect(agentVersion)` — blocking token check + browser auth + connect, for use in `tea.Cmd`
- **`pkg/tui`**: `connectOCMCmdIfNeeded()` feeds `OCMClientReadyMsg` (existing handler wires client + backplane + enrichment); `ocmHandoffCmd(requirePDConfig)` wired into all four wizard-exit paths (save, no-changes, discard, cancel); injectable `ocmConnect` for tests

## Tests (TDD)

- `cmd/config_ocm_test.go` — source-scan guards (no OCM in config.go; setupOCM is single call site)
- `pkg/tui/config_ocm_handoff_test.go` — 8 tests: connect queued/not-queued/error/dev-mode/abort
- Full suite, `-race`, lint green

## Plan doc

`docs/plans/363-config-mode-no-ocm.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)