### PR TITLE
Use annotated generate template for new config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ go install .        # standard go install
 
 SREPD reads `~/.config/srepd/srepd.yaml` and supports `SREPD_` environment variable prefix. Run `srepd config` to create or update your config interactively. Values from environment variables (e.g., `SREPD_TOKEN`) are pre-filled automatically.
 
-If no config file exists — or the config file is incomplete or still contains placeholder values — running `srepd` automatically enters the configuration wizard. The wizard validates your token, greets you by name, auto-selects your team when you belong to exactly one, and gates advanced options (custom service-to-policy mappings) behind a default-No confirm so most users never see them. The form resizes dynamically when the terminal window changes size.
+If no config file exists — or the config file is incomplete or still contains placeholder values — running `srepd` automatically enters the configuration wizard. The wizard validates your token, greets you by name, auto-selects your team when you belong to exactly one, and gates advanced options (custom service-to-policy mappings) behind a default-No confirm so most users never see them. New config files are written using the same annotated template as `srepd config generate` — with section headers, detected terminal alternatives as comments, and environment-aware defaults. The form resizes dynamically when the terminal window changes size.
 
 **Migrating from old config format:** If your config uses the deprecated `service_escalation_policies` key, running `srepd config` will automatically migrate to the new `default_silent_escalation_policy` and `custom_service_escalation_policies` keys. The old block is commented out with a deprecation note.
 

--- a/docs/plans/380-new-config-uses-generate.md
+++ b/docs/plans/380-new-config-uses-generate.md
@@ -1,0 +1,32 @@
+# 380: New config files use the annotated generate template
+
+Branch: `srepd/new-config-uses-generate`
+
+## Problem
+
+When the wizard saved a brand-new config file, `BuildFullConfig` wrote a bare
+YAML with no section headers, no comments, and no detected alternatives.
+Meanwhile `srepd config generate` produced a richly annotated file with
+environment detection (terminals, editor, cluster login, agent), commented
+alternatives, and section headers. The first config a new user created was
+the least helpful format.
+
+## Approach
+
+`WriteConfig` for `isNewFile` now generates the annotated template via
+`GenerateAnnotatedConfig(env)` — the same output as `srepd config generate`
+— then overlays the wizard's resolved values using `MergeIntoExistingConfig`.
+The result has both the annotations AND the real values.
+
+`detectGenerateEnvironment()` in `pkg/tui/commands.go` probes terminals,
+$EDITOR, claude, and ocm/ocm-container — reusing the same detection from
+`cmd/generate.go` but callable from the TUI package.
+
+`WriteConfig` gains an `env *GenerateEnvironment` parameter; existing-file
+writes pass nil (no template needed). All test callers updated.
+
+## Files
+
+- `pkg/config/config.go` — `WriteConfig` signature + new-file path
+- `pkg/tui/commands.go` — `detectGenerateEnvironment` + env plumbing
+- `pkg/config/config_test.go` — updated callers + annotation assertion

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -347,11 +347,20 @@ func ParseCustomMappingsStrict(raw string) (map[string]string, error) {
 	return result, nil
 }
 
-func WriteConfig(fs ConfigFS, baseDir string, final ResolvedValues, changes ConfigChanges, teamNames map[string]string, customPolicies map[string]string, isNewFile bool) error {
+func WriteConfig(fs ConfigFS, baseDir string, final ResolvedValues, changes ConfigChanges, teamNames map[string]string, customPolicies map[string]string, isNewFile bool, env *GenerateEnvironment) error {
 	configFile := filepath.Join(baseDir, CfgFileDir, CfgFileName)
 
 	if isNewFile {
-		data := BuildFullConfig(final, teamNames, final.SilentPolicy, customPolicies)
+		// Start from the annotated template (with detected environment,
+		// section headers, and commented alternatives) then overlay the
+		// wizard's resolved values so the first config file looks like
+		// `srepd config generate` output with real values filled in.
+		base := GenerateAnnotatedConfig(env)
+		allChanged := DetectChangesForNewFile(final)
+		data, err := MergeIntoExistingConfig(base, final, allChanged, teamNames, customPolicies)
+		if err != nil {
+			return fmt.Errorf("failed to build config from template: %w", err)
+		}
 		if err := writeSecretFile(fs, configFile, data); err != nil {
 			return fmt.Errorf("failed to write config file: %w", err)
 		}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1291,15 +1291,16 @@ func TestWriteConfig_NewFile(t *testing.T) {
 	changes := ConfigChanges{TokenChanged: true, TeamsChanged: true}
 	teamNames := map[string]string{"TEAM1": "My Team"}
 
-	err := WriteConfig(m, "/fake/home", final, changes, teamNames, nil, true)
+	err := WriteConfig(m, "/fake/home", final, changes, teamNames, nil, true, nil)
 
 	require.NoError(t, err)
 	output := string(m.writeData)
-	assert.Contains(t, output, "token: my-token")
+	assert.Contains(t, output, "my-token", "token value must be present")
 	assert.Contains(t, output, "- TEAM1 # My Team")
 	assert.Contains(t, output, "editor: vim")
 	assert.Contains(t, output, "terminal: gnome-terminal --")
 	assert.Contains(t, output, "cluster_login_command:")
+	assert.Contains(t, output, "# --- Required ---", "new files use the annotated template")
 }
 
 func TestWriteConfig_NewFileNoBackup(t *testing.T) {
@@ -1307,7 +1308,7 @@ func TestWriteConfig_NewFileNoBackup(t *testing.T) {
 	final := ResolvedValues{Token: "my-token", Teams: []string{"TEAM1"}}
 	changes := ConfigChanges{TokenChanged: true, TeamsChanged: true}
 
-	err := WriteConfig(m, "/fake/home", final, changes, nil, nil, true)
+	err := WriteConfig(m, "/fake/home", final, changes, nil, nil, true, nil)
 
 	require.NoError(t, err)
 	assert.Empty(t, m.backupData)
@@ -1319,7 +1320,7 @@ func TestWriteConfig_ExistingFileCreatesBackup(t *testing.T) {
 	final := ResolvedValues{Token: "new-token", Teams: []string{"TEAM1"}}
 	changes := ConfigChanges{TokenChanged: true}
 
-	err := WriteConfig(m, "/fake/home", final, changes, nil, nil, false)
+	err := WriteConfig(m, "/fake/home", final, changes, nil, nil, false, nil)
 
 	require.NoError(t, err)
 	assert.Equal(t, string(existingData), string(m.backupData))
@@ -1332,7 +1333,7 @@ func TestWriteConfig_ExistingFilePreservesStructure(t *testing.T) {
 	final := ResolvedValues{Token: "new-token", Teams: []string{"TEAM1"}, SilentPolicy: "PCGXUDY"}
 	changes := ConfigChanges{TokenChanged: true}
 
-	err := WriteConfig(m, "/fake/home", final, changes, nil, nil, false)
+	err := WriteConfig(m, "/fake/home", final, changes, nil, nil, false, nil)
 
 	require.NoError(t, err)
 	output := string(m.writeData)
@@ -1348,7 +1349,7 @@ func TestWriteConfig_ReadError(t *testing.T) {
 	final := ResolvedValues{Token: "tok", Teams: []string{"T1"}}
 	changes := ConfigChanges{TokenChanged: true}
 
-	err := WriteConfig(m, "/fake/home", final, changes, nil, nil, false)
+	err := WriteConfig(m, "/fake/home", final, changes, nil, nil, false, nil)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to read")
@@ -1359,7 +1360,7 @@ func TestWriteConfig_WriteError(t *testing.T) {
 	final := ResolvedValues{Token: "tok", Teams: []string{"T1"}}
 	changes := ConfigChanges{TokenChanged: true}
 
-	err := WriteConfig(m, "/fake/home", final, changes, nil, nil, true)
+	err := WriteConfig(m, "/fake/home", final, changes, nil, nil, true, nil)
 
 	require.Error(t, err)
 }
@@ -1374,7 +1375,7 @@ func TestWriteConfig_NewFile_Uses0600(t *testing.T) {
 	final := ResolvedValues{Token: "my-token", Teams: []string{"TEAM1"}}
 	changes := ConfigChanges{TokenChanged: true, TeamsChanged: true}
 
-	err := WriteConfig(m, "/fake/home", final, changes, nil, nil, true)
+	err := WriteConfig(m, "/fake/home", final, changes, nil, nil, true, nil)
 
 	require.NoError(t, err)
 	assert.Equal(t, os.FileMode(0600), m.writePerm, "new config file must be written 0600")
@@ -1388,7 +1389,7 @@ func TestWriteConfig_ExistingFileAndBackup_Use0600(t *testing.T) {
 	final := ResolvedValues{Token: "new-token", Teams: []string{"TEAM1"}}
 	changes := ConfigChanges{TokenChanged: true}
 
-	err := WriteConfig(m, "/fake/home", final, changes, nil, nil, false)
+	err := WriteConfig(m, "/fake/home", final, changes, nil, nil, false, nil)
 
 	require.NoError(t, err)
 	assert.Equal(t, os.FileMode(0600), m.chmodPerm, "config file must be chmod'd 0600")
@@ -1439,7 +1440,7 @@ func TestEndToEnd_NewUserAllFields(t *testing.T) {
 	teamNames := map[string]string{"PASPK4G": "Platform SRE"}
 	customPolicies := map[string]string{"P5LAB5Y": "PVBANNN"}
 
-	err := WriteConfig(m, "/fake/home", final, changes, teamNames, customPolicies, true)
+	err := WriteConfig(m, "/fake/home", final, changes, teamNames, customPolicies, true, nil)
 
 	require.NoError(t, err)
 	output := string(m.writeData)
@@ -1465,7 +1466,7 @@ func TestEndToEnd_ExistingUserChangesToken(t *testing.T) {
 	final := ResolvedValues{Token: "changed-token", Teams: []string{"TEAM1"}, SilentPolicy: "PCGXUDY"}
 	changes := ConfigChanges{TokenChanged: true}
 
-	err := WriteConfig(m, "/fake/home", final, changes, nil, nil, false)
+	err := WriteConfig(m, "/fake/home", final, changes, nil, nil, false, nil)
 
 	require.NoError(t, err)
 	output := string(m.writeData)
@@ -1482,7 +1483,7 @@ func TestEndToEnd_ExistingUserChangesTeams(t *testing.T) {
 	changes := ConfigChanges{TeamsChanged: true}
 	teamNames := map[string]string{"TEAM2": "Beta", "TEAM3": "Gamma"}
 
-	err := WriteConfig(m, "/fake/home", final, changes, teamNames, nil, false)
+	err := WriteConfig(m, "/fake/home", final, changes, teamNames, nil, false, nil)
 
 	require.NoError(t, err)
 	output := string(m.writeData)
@@ -1502,11 +1503,11 @@ func TestEndToEnd_EnvVarUserFirstSave(t *testing.T) {
 	changes := ConfigChanges{TokenChanged: true, TeamsChanged: true, SilentChanged: true}
 	teamNames := map[string]string{"ENV_TEAM": "Env Team"}
 
-	err := WriteConfig(m, "/fake/home", final, changes, teamNames, nil, true)
+	err := WriteConfig(m, "/fake/home", final, changes, teamNames, nil, true, nil)
 
 	require.NoError(t, err)
 	output := string(m.writeData)
-	assert.Contains(t, output, "token: env-token")
+	assert.Contains(t, output, "env-token", "token value must be present")
 	assert.Contains(t, output, "- ENV_TEAM # Env Team")
 	assert.Contains(t, output, "default_silent_escalation_policy: ENV_POL")
 	assert.Contains(t, output, "editor: vim")
@@ -1573,7 +1574,7 @@ func TestEndToEnd_NewFileWritesRealDefaults(t *testing.T) {
 	changes := DetectChangesForNewFile(final)
 	teamNames := map[string]string{"TEAM1": "My Team"}
 
-	err := WriteConfig(m, "/fake/home", final, changes, teamNames, nil, true)
+	err := WriteConfig(m, "/fake/home", final, changes, teamNames, nil, true, nil)
 
 	require.NoError(t, err)
 

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -1567,6 +1568,33 @@ func (realFS) Chmod(name string, mode os.FileMode) error {
 	return os.Chmod(name, mode)
 }
 
+// detectGenerateEnvironment probes the current system for terminals, editor,
+// agent CLI, and cluster login commands — the same detection that
+// `srepd config generate` uses — so a brand-new config file includes
+// commented alternatives and detected values.
+func detectGenerateEnvironment() *pkgconfig.GenerateEnvironment {
+	env := &pkgconfig.GenerateEnvironment{}
+	detected := launcher.DetectTerminals(exec.LookPath, os.Getenv, runtime.GOOS)
+	for _, dt := range detected {
+		env.Terminals = append(env.Terminals, dt.Command)
+	}
+	if e := os.Getenv("EDITOR"); e != "" {
+		env.Editor = e
+	} else if v := os.Getenv("VISUAL"); v != "" {
+		env.Editor = v
+	}
+	if _, err := exec.LookPath("claude"); err == nil {
+		env.AgentCLI = pkgconfig.DefaultOptionalKeys["agent_cli_command"]
+	}
+	if _, err := exec.LookPath("ocm"); err == nil {
+		env.ClusterLoginCmds = append(env.ClusterLoginCmds, "ocm backplane login %%CLUSTER_ID%%")
+	}
+	if _, err := exec.LookPath("ocm-container"); err == nil {
+		env.ClusterLoginCmds = append(env.ClusterLoginCmds, "ocm-container --cluster-id %%CLUSTER_ID%%")
+	}
+	return env
+}
+
 // writeConfigCmd writes the config to disk using the resolved values.
 func writeConfigCmd(final pkgconfig.ResolvedValues, changes pkgconfig.ConfigChanges, teamNames map[string]string, customPolicies map[string]string, isNewFile bool, fs pkgconfig.ConfigFS) tea.Cmd {
 	return func() tea.Msg {
@@ -1580,7 +1608,14 @@ func writeConfigCmd(final pkgconfig.ResolvedValues, changes pkgconfig.ConfigChan
 		if err := fs.MkdirAll(configDir, 0700); err != nil {
 			return configSavedMsg{err: err}
 		}
-		if err := pkgconfig.WriteConfig(fs, home, final, changes, teamNames, customPolicies, isNewFile); err != nil {
+		// For new files, detect the environment so the generated config
+		// includes commented alternatives (detected terminals, etc.)
+		// matching `srepd config generate` output.
+		var env *pkgconfig.GenerateEnvironment
+		if isNewFile {
+			env = detectGenerateEnvironment()
+		}
+		if err := pkgconfig.WriteConfig(fs, home, final, changes, teamNames, customPolicies, isNewFile, env); err != nil {
 			return configSavedMsg{err: err}
 		}
 		// Update Viper with new values


### PR DESCRIPTION
## Problem

The wizard wrote bare YAML for new configs (no headers, no comments, no detected alternatives) while `srepd config generate` produced a richly annotated file. The first config a new user created was the least helpful format.

## Fix

`WriteConfig` for new files now generates the annotated template via `GenerateAnnotatedConfig(env)` — same output as `srepd config generate` with environment detection — then overlays the wizard's resolved values using `MergeIntoExistingConfig`. Result: section headers, token acquisition help, detected terminal alternatives as comments, and real values.

## Tests

Updated `WriteConfig` callers with new `env` parameter; assertion that new files contain the annotated template markers. Full suite green.

## Plan doc

`docs/plans/380-new-config-uses-generate.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)