### PR TITLE
Fix policy picker visibility, scope, and wizard flow (OB-4 follow-up)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -568,7 +568,7 @@ func initConfig() {
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			fmt.Fprintln(os.Stderr, "Config file not found: "+err.Error())
+			fmt.Fprintln(os.Stderr, "Config file not found: "+err.Error()+" -- generating...")
 		} else {
 			// YAML parse failure: viper holds nothing, but the file may
 			// contain perfectly good values (e.g. a valid token with a

--- a/docs/plans/366-escalation-policy-picker.md
+++ b/docs/plans/366-escalation-policy-picker.md
@@ -47,3 +47,18 @@ exists to eliminate. The plumbing to do better already existed:
   only; API error → classified, skip-valued row + escapes
 - `resolveSilentPolicyChoice`: picker wins / skip empty / manual trimmed /
   manual blank
+
+## Post-mortem (fixed by plan 378)
+
+Placing the skip/manual escapes *after* the policies broke the picker in
+production: the bound value starts as the skip sentinel (`""`), and huh
+v1.0.0's `Select.selectOption()` scrolls the viewport to the matching
+option unclamped (`viewport.YOffset = s.selected`) when async options
+arrive. The cursor jumped to "Skip" below the policies and the viewport
+scrolled every fetched policy out of view — the picker looked like the
+fetch never landed. Four binding-hash fix attempts chased the wrong
+mechanism. Lesson: when a widget "doesn't show" async data, verify
+whether the data was rejected or merely rendered off-screen (assert on
+the rendered view in a pump test) before touching the plumbing; and be
+suspicious of sentinel values that equal a field's zero value when a
+library selects-by-value.

--- a/docs/plans/369-config-generate.md
+++ b/docs/plans/369-config-generate.md
@@ -34,3 +34,15 @@ partial (and its placeholders created OB-1's broken-config trap), and
   `HealthNeedsWizard`.
 - `cmd/generate_test.go`: stdout write; `--out` file with 0600 perms;
   refuses overwrite without `--force`; `--force` overwrites.
+
+## Post-mortem (duplicate group, fixed alongside plan 378)
+
+This PR's merge re-added the "Configure advanced options?" confirm group
+to `buildConfigForm` while resolving conflicts with the #368 gating work,
+leaving two identical copies bound to the same value (PR #371's merge
+added a third). Users had to answer the same prompt repeatedly before
+reaching the summary. Lesson: when resolving conflicts in the wizard's
+group list, diff the *count* of groups against both parents — identical
+adjacent groups are silent in review diffs and every test passed because
+each copy individually behaved correctly. A walk-the-wizard regression
+test now asserts one enter dismisses the prompt.

--- a/docs/plans/370-team-preset.md
+++ b/docs/plans/370-team-preset.md
@@ -49,3 +49,14 @@ unknown/invalid YAML), apply (existing wins, empty fills, applied flags, nil
 no-op), file load, HTTPS-only, TLS fetch via httptest, size cap, non-200,
 change forcing. README documents the feature (config.go changed →
 readme-check).
+
+## Post-mortem (duplicate group, fixed alongside plan 378)
+
+This PR's merge re-added the "Configure advanced options?" confirm group
+to `buildConfigForm` during conflict resolution — the third identical
+copy (see plan 369's post-mortem for the second). Users answered the
+same prompt three times before the summary. Lesson: conflict resolutions
+that re-apply a hunk "to be safe" duplicate silently when the hunk is an
+element in a list literal; check group counts against both parents. A
+walk-the-wizard regression test now asserts one enter dismisses the
+prompt.

--- a/docs/plans/378-policy-picker-viewport-scroll-fix.md
+++ b/docs/plans/378-policy-picker-viewport-scroll-fix.md
@@ -1,0 +1,116 @@
+# 378: Policy picker cursor and team-scope fixes (OB-4 follow-up)
+
+Issue: follow-up to #367 (OB-4 picker); the picker appeared to show only
+the skip/manual escapes, and the fetched list missed the actual silent
+policy
+Branch: `srepd/ob4-policy-picker-optionsfunc`
+
+## Problems
+
+1. **Picker appeared to show only the escapes.** After the OB-4 picker
+   shipped (#367), the policy Select never appeared to show the fetched
+   escalation policies — only "Skip — configure later" and "Enter an ID
+   manually…" — until the user pressed an arrow key. Four different
+   `OptionsFunc` binding strategies all "failed" identically, which
+   pointed away from the suspected binding-hash instability.
+2. **The fetched list missed the real silent policy.** With team
+   `PASPK4G` (Platform SRE) selected, the team-filtered query returned 6
+   policies — none of them the intended silent policy `PCGXUDY`.
+
+## Root causes
+
+1. A deterministic message-pump test
+   (`config_policy_picker_repro_test.go`) driving the real wizard form
+   proved the async `updateOptionsMsg` was **accepted** by huh
+   (`msg.hash == bindingsHash`, options installed). The policies were
+   rendering all along — scrolled out of view: huh v1.0.0
+   `Select.selectOption()` (field_select.go:191) moves the cursor to the
+   option whose value equals the current bound value, then sets
+   `viewport.YOffset = s.selected` **unclamped** (line 203;
+   `updateViewportHeight` repeats the unclamped assignment on every
+   Update, line 543). The picker's bound value starts as `""`, which was
+   also the skip sentinel's value, so the cursor jumped to "Skip" below
+   the policies and the viewport scrolled past every policy. The
+   binding-hash mechanism was never the problem.
+2. Verified against the live PagerDuty API (shim-mcp): `PCGXUDY`
+   ("Silent Test - Non-Actionable") belongs to team `PRSN7UG`
+   "Platform SRE - Non-actionable" — a companion team the user is a
+   member of but never selects for incident filtering. A
+   selected-teams-filtered `/escalation_policies` query can never return
+   it. Querying across all 6 of the user's teams returned 18 policies
+   including `PCGXUDY` and `PVBANNN` (the DMS silent-test policy from
+   the user's custom mappings), with 8 SILENT-classified candidates.
+
+## Approach
+
+- `policyChoiceSkip` becomes a non-empty sentinel (`"__skip__"`), so the
+  initial empty bound value matches **no** option and huh leaves the
+  cursor at index 0 with the viewport at the top.
+  `resolveSilentPolicyChoice` maps skip and the untouched empty choice to
+  `""` — the saved format is unchanged.
+- `buildPolicyOptions` keeps the original recommended-first ordering
+  (SILENT-classified annotated, then the rest, then the escapes); the
+  cursor now starts on the first recommended policy. When an existing
+  config's silent policy is in the list, the cursor lands on it instead.
+- `fetchPolicyOptions` drops its selected-teams parameter and fetches
+  policies for **all** of the user's PagerDuty teams
+  (`GetCurrentUserTeams` → `GetTeamEscalationPolicies`), since silent
+  policies conventionally live on companion non-actionable teams. The
+  `OptionsFunc` binding moves to the token input (the fetch no longer
+  depends on team selection).
+- Mock gains `RecordedListEscalationPoliciesOpts` so tests can assert
+  the team scope actually sent.
+
+### UX polish (from live testing)
+
+- **Loading indicator**: huh natively renders a spinner + "Loading..."
+  row while an async OptionsFunc fetch is in flight, but it only appears
+  once a message arrives >25ms after dispatch — and srepd's Update loop
+  intercepted every `spinner.TickMsg` and returned early, so the form
+  received nothing and the list stayed blank during the fetch. The
+  spinner case now forwards ticks to the config form; the loading row
+  renders and animates, and is replaced when the list arrives.
+- **Annotation**: "(recommended — no schedules notified)" →
+  "(possible candidate — does not page)".
+- **Ordering**: within the SILENT-classified candidates, policies with
+  "silent" in the name (case-insensitive) sort first — the strongest
+  signal of intent — so the cursor starts on the likeliest pick.
+- **Height and scrolling**: huh defaults a dynamic-options Select to 10
+  lines; title plus the 5-line description left only 4 visible options.
+  Worse, any *explicit* field height routes huh v1.0.0 through an
+  unclamped `viewport.YOffset = selected` on every update
+  (updateViewportHeight, field_select.go:543), pinning the selected row
+  to the top so arrow keys scrolled the list under a stationary cursor.
+  The picker now sets `Height(0)` (after OptionsFunc, which
+  force-defaults zero heights to 10): the field auto-sizes to the full
+  list, arrows move the cursor naturally, and the group layout clamps
+  the field back to scrolling mode only when the window is too short.
+
+## Tests (TDD — written first)
+
+- `config_policy_picker_repro_test.go`: deterministic bubbletea pump that
+  drives the real form (token → teams → policy) with async fetch results
+  arriving late; asserts fetched policies render, render *above* the
+  escapes, and the cursor preselects the first recommended policy.
+- `config_policy_picker_test.go`: ordering (silent-annotated first,
+  escapes last, no empty-valued options), all-user-teams fetch scope,
+  no-token escapes, classified error row, resolve mapping incl. the new
+  skip sentinel and untouched-empty choice.
+
+## Lessons learned
+
+- "Options never render" had two plausible mechanisms (message dropped
+  vs. rendered-but-hidden); four fix attempts targeted the wrong one
+  because the diagnosis was never verified against huh's actual guard.
+  Instrumenting the vendored dependency and asserting on the *rendered
+  view* settled it in one run.
+- Verify data-shape assumptions against the live API before shipping a
+  fetch-driven UI: the "obvious" scope (selected teams) structurally
+  excluded the one policy the feature exists to find.
+- The srepd Update loop intercepts `spinner.TickMsg` (tui.go) and returns
+  early, so huh's loading spinner never animates in config mode and the
+  form receives almost no messages while a fetch is in flight.
+- Upstream: huh v1.0.0 should clamp the viewport offset in
+  `selectOption`/`updateViewportHeight` (`viewport.SetYOffset` clamps;
+  direct assignment does not). Worth an upstream issue; v2 may already
+  differ.

--- a/pkg/pd/mock.go
+++ b/pkg/pd/mock.go
@@ -58,6 +58,11 @@ type MockPagerDutyClient struct {
 	// ListEscalationPoliciesResponses is a queue of responses for ListEscalationPoliciesWithContext.
 	ListEscalationPoliciesResponses []pagerduty.ListEscalationPoliciesResponse
 
+	// RecordedListEscalationPoliciesOpts records the options from every
+	// ListEscalationPoliciesWithContext call, in order, so tests can assert
+	// exactly what was sent (e.g. TeamIDs scope).
+	RecordedListEscalationPoliciesOpts []pagerduty.ListEscalationPoliciesOptions
+
 	// ListEscalationPoliciesErr, when non-nil, causes
 	// ListEscalationPoliciesWithContext to return this error.
 	ListEscalationPoliciesErr error
@@ -304,6 +309,7 @@ func (m *MockPagerDutyClient) GetUserWithContext(ctx context.Context, id string,
 
 func (m *MockPagerDutyClient) ListEscalationPoliciesWithContext(ctx context.Context, opts pagerduty.ListEscalationPoliciesOptions) (*pagerduty.ListEscalationPoliciesResponse, error) {
 	m.recordCall("ListEscalationPoliciesWithContext")
+	m.RecordedListEscalationPoliciesOpts = append(m.RecordedListEscalationPoliciesOpts, opts)
 
 	if m.ListEscalationPoliciesErr != nil {
 		return nil, m.ListEscalationPoliciesErr

--- a/pkg/tui/config_policy_picker_repro_test.go
+++ b/pkg/tui/config_policy_picker_repro_test.go
@@ -1,0 +1,259 @@
+package tui
+
+// Deterministic regression harness for the OB-4 policy picker bug: the
+// policy Select's async OptionsFunc fetch completed and was accepted by
+// huh, but the picker appeared to show only the skip/manual escapes.
+// Root cause: huh's Select.selectOption() moves the cursor to the option
+// matching the current bound value and sets viewport.YOffset to it
+// unclamped; the bound value started as "" which was also the skip
+// sentinel's value, so the cursor (and viewport) jumped to Skip, hiding
+// every policy above it. The fix gives the skip sentinel a non-empty
+// value so the initial empty choice matches no option and the cursor
+// stays on index 0 — the first recommended policy (see
+// buildPolicyOptions).
+//
+// The pump emulates the bubbletea runtime: Update() is called with each
+// delivered message, returned commands are executed immediately (like
+// goroutine start), and the resulting messages are queued FIFO — except
+// huh's async updateOptionsMsg results, which are held back and released
+// only on request, simulating a slow API fetch relative to other traffic.
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/PagerDuty/go-pagerduty"
+	"github.com/charmbracelet/bubbles/cursor"
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	pkgconfig "github.com/clcollins/srepd/pkg/config"
+	"github.com/clcollins/srepd/pkg/pd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const maxTicksPerPhase = 4
+
+type wizardPump struct {
+	t      *testing.T
+	m      tea.Model
+	queue  []tea.Msg
+	held   []tea.Msg
+	ticks  int
+	blinks int
+}
+
+// execCmd runs a command tree, flattening tea.Batch and tea.Sequence
+// (the latter via reflection — sequenceMsg is unexported) into the
+// ordered list of messages it produces.
+func execCmd(cmd tea.Cmd) []tea.Msg {
+	if cmd == nil {
+		return nil
+	}
+	msg := cmd()
+	if msg == nil {
+		return nil
+	}
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		var out []tea.Msg
+		for _, c := range batch {
+			out = append(out, execCmd(c)...)
+		}
+		return out
+	}
+	rv := reflect.ValueOf(msg)
+	cmdType := reflect.TypeOf((*tea.Cmd)(nil)).Elem()
+	if rv.Kind() == reflect.Slice && rv.Type().Elem() == cmdType {
+		// tea.sequenceMsg
+		var out []tea.Msg
+		for i := 0; i < rv.Len(); i++ {
+			if c, ok := rv.Index(i).Interface().(tea.Cmd); ok {
+				out = append(out, execCmd(c)...)
+			}
+		}
+		return out
+	}
+	return []tea.Msg{msg}
+}
+
+func isAsyncOptionsMsg(msg tea.Msg) bool {
+	return strings.Contains(reflect.TypeOf(msg).String(), "updateOptionsMsg")
+}
+
+func (p *wizardPump) collect(cmd tea.Cmd) {
+	for _, msg := range execCmd(cmd) {
+		switch msg.(type) {
+		case tea.WindowSizeMsg:
+			// tea.WindowSize() queries the real terminal; tests inject
+			// their own size, so drop command-produced ones.
+			continue
+		}
+		if isAsyncOptionsMsg(msg) {
+			p.t.Logf("pump: holding async %s", reflect.TypeOf(msg))
+			p.held = append(p.held, msg)
+			continue
+		}
+		p.queue = append(p.queue, msg)
+	}
+}
+
+func (p *wizardPump) drain() {
+	for i := 0; i < 200 && len(p.queue) > 0; i++ {
+		msg := p.queue[0]
+		p.queue = p.queue[1:]
+		if _, ok := msg.(spinner.TickMsg); ok {
+			p.ticks++
+			if p.ticks > maxTicksPerPhase {
+				continue
+			}
+		}
+		if _, ok := msg.(cursor.BlinkMsg); ok {
+			p.blinks++
+			if p.blinks > 2 {
+				continue
+			}
+		}
+		p.t.Logf("pump: deliver %s", reflect.TypeOf(msg))
+		var cmd tea.Cmd
+		p.m, cmd = p.m.Update(msg)
+		p.collect(cmd)
+	}
+}
+
+func (p *wizardPump) send(msg tea.Msg) {
+	p.queue = append(p.queue, msg)
+	p.drain()
+}
+
+// releaseHeld delivers the held async fetch results, simulating the
+// slow API call finally returning after other traffic has settled.
+func (p *wizardPump) releaseHeld() {
+	held := p.held
+	p.held = nil
+	p.ticks = 0
+	p.blinks = 0
+	for _, msg := range held {
+		p.t.Logf("pump: releasing async %s", reflect.TypeOf(msg))
+		p.queue = append(p.queue, msg)
+	}
+	p.drain()
+}
+
+func (p *wizardPump) view() string {
+	return p.m.(model).View()
+}
+
+// logState dumps the shared wizard state so the trace shows exactly what
+// the async OptionsFunc closures could observe at each step.
+func (p *wizardPump) logState(label string) {
+	mm := p.m.(model)
+	p.t.Logf("state[%s]: SelectedTeams=%v TokenInput=%q SilentPolicyChoice=%q",
+		label, mm.configState.SelectedTeams, mm.configState.TokenInput, mm.configState.SilentPolicyChoice)
+}
+
+func keyEnter() tea.Msg { return tea.KeyMsg{Type: tea.KeyEnter} }
+
+func keyRunes(s string) tea.Msg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+}
+
+func policyPickerMockClient() *pd.MockPagerDutyClient {
+	// Enough policies that the pre-fix 4-line viewport could not show them
+	// all: 1 silent-named + 5 other silent candidates + 2 real.
+	policies := []pagerduty.EscalationPolicy{
+		{APIObject: pagerduty.APIObject{ID: "POL_NULL_1"}, Name: "Null Route Alpha"},
+		{APIObject: pagerduty.APIObject{ID: "POL_NULL_2"}, Name: "Null Route Bravo"},
+		{APIObject: pagerduty.APIObject{ID: "POL_NULL_3"}, Name: "Null Route Charlie"},
+		{APIObject: pagerduty.APIObject{ID: "POL_NULL_4"}, Name: "Null Route Delta"},
+		{APIObject: pagerduty.APIObject{ID: "POL_NULL_5"}, Name: "Null Route Echo"},
+		{APIObject: pagerduty.APIObject{ID: "POL_SILENT"}, Name: "CAD Silent Test"},
+		{
+			APIObject: pagerduty.APIObject{ID: "POL_HUMAN"},
+			Name:      "Humans On Call",
+			EscalationRules: []pagerduty.EscalationRule{
+				{Targets: []pagerduty.APIObject{{Type: "schedule_reference", ID: "SCHED_1"}}},
+			},
+		},
+		{
+			APIObject: pagerduty.APIObject{ID: "POL_HUMAN_2"},
+			Name:      "Secondary On-Call",
+			EscalationRules: []pagerduty.EscalationRule{
+				{Targets: []pagerduty.APIObject{{Type: "schedule_reference", ID: "SCHED_2"}}},
+			},
+		},
+	}
+	return &pd.MockPagerDutyClient{
+		ListEscalationPoliciesResponses: []pagerduty.ListEscalationPoliciesResponse{
+			{EscalationPolicies: policies},
+		},
+	}
+}
+
+// TestConfigWizardPolicyPickerRendersFetchedPolicies drives the real
+// wizard form end-to-end (token → teams → policy) with async fetches
+// arriving late, and requires the fetched policies to appear in the
+// policy picker.
+func TestConfigWizardPolicyPickerRendersFetchedPolicies(t *testing.T) {
+	m := createConfigTestModel()
+	mock := policyPickerMockClient()
+	m.pdClientFactory = func(_ string) pd.PagerDutyClient { return mock }
+
+	p := &wizardPump{t: t, m: m}
+
+	p.send(tea.WindowSizeMsg{Width: 120, Height: 50})
+	p.send(newConfigWizardReadyMsg(pkgconfig.ExistingConfig{}, pkgconfig.KeepDefaults{}, true))
+
+	// Token step: type a token and advance. Validation hits the mock.
+	p.send(keyRunes("mock-token"))
+	p.send(keyEnter())
+	p.releaseHeld() // teams fetch returns
+
+	view := p.view()
+	require.Contains(t, view, "Mock Team Alpha", "teams should render after the async fetch lands")
+
+	// Teams step: toggle the first team and advance to the policy picker.
+	p.send(keyRunes("x"))
+	p.logState("after toggle")
+	p.send(keyEnter())
+	p.logState("after enter to policy group")
+
+	// The fetch is in flight (held); huh's native loading indicator must
+	// render. It only appears once a message arrives >25ms after dispatch,
+	// which is why srepd must forward spinner ticks to the form.
+	assert.Contains(t, p.view(), "Loading",
+		"picker must show a loading indicator while the fetch is in flight")
+
+	p.releaseHeld() // policy fetch returns
+	p.logState("after policy fetch release")
+
+	t.Logf("mock call counts: %v", mock.CallCounts)
+
+	view = p.view()
+	assert.Contains(t, view, "CAD Silent Test",
+		"fetched policies must render in the picker after the async fetch lands")
+	assert.NotContains(t, view, "Loading",
+		"loading indicator must be replaced by the fetched list")
+	assert.Contains(t, view, "Skip — configure later",
+		"static escape options should always be present")
+	assert.Less(t, strings.Index(view, "CAD Silent Test"), strings.Index(view, "Null Route Alpha"),
+		`silent-named candidates must render above the other candidates`)
+	assert.Less(t, strings.Index(view, "Null Route Echo"), strings.Index(view, "Skip — configure later"),
+		"candidates must render above the escape options")
+	assert.Contains(t, view, "Secondary On-Call",
+		"the picker must use the available window height — with 8 policies the pre-fix 4-line viewport would hide the later entries")
+	assert.Equal(t, "POL_SILENT", p.m.(model).configState.SilentPolicyChoice,
+		"cursor must start on the first recommended policy (index 0)")
+
+	// Arrow keys must move the cursor through the list, not scroll the
+	// list under a top-pinned cursor. With an explicit field height, huh
+	// v1.0.0 re-pins viewport.YOffset to the selected index on every
+	// update, so two downs would scroll the first option out of view.
+	p.send(tea.KeyMsg{Type: tea.KeyDown})
+	p.send(tea.KeyMsg{Type: tea.KeyDown})
+	view = p.view()
+	assert.Equal(t, "POL_NULL_2", p.m.(model).configState.SilentPolicyChoice,
+		"two downs must land on the third option")
+	assert.Contains(t, view, "CAD Silent Test",
+		"moving the cursor down must not scroll the top of the list out of view")
+}

--- a/pkg/tui/config_policy_picker_repro_test.go
+++ b/pkg/tui/config_policy_picker_repro_test.go
@@ -154,6 +154,22 @@ func (p *wizardPump) logState(label string) {
 
 func keyEnter() tea.Msg { return tea.KeyMsg{Type: tea.KeyEnter} }
 
+// enterUntil presses enter (releasing held async fetches between presses)
+// until the rendered view contains substr, failing after max presses. It
+// lets walk-the-wizard tests tolerate environment-dependent groups (e.g.
+// the agent confirm only appears when the claude CLI is detected).
+func (p *wizardPump) enterUntil(t *testing.T, substr string, max int) {
+	t.Helper()
+	for i := 0; i < max; i++ {
+		if strings.Contains(p.view(), substr) {
+			return
+		}
+		p.send(keyEnter())
+		p.releaseHeld()
+	}
+	t.Fatalf("never reached %q after %d enters; last view:\n%s", substr, max, p.view())
+}
+
 func keyRunes(s string) tea.Msg {
 	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
 }
@@ -256,4 +272,33 @@ func TestConfigWizardPolicyPickerRendersFetchedPolicies(t *testing.T) {
 		"two downs must land on the third option")
 	assert.Contains(t, view, "CAD Silent Test",
 		"moving the cursor down must not scroll the top of the list out of view")
+}
+
+// Regression: three identical "Configure advanced options?" confirm groups
+// shipped on main (one duplicate re-added per merge in PRs #370 and #371),
+// forcing users to answer the same prompt three times. Exactly one enter
+// must dismiss it.
+func TestConfigWizardAdvancedOptionsConfirmAdvancesInOneEnter(t *testing.T) {
+	m := createConfigTestModel()
+	mock := policyPickerMockClient()
+	m.pdClientFactory = func(_ string) pd.PagerDutyClient { return mock }
+
+	p := &wizardPump{t: t, m: m}
+	p.send(tea.WindowSizeMsg{Width: 120, Height: 50})
+	p.send(newConfigWizardReadyMsg(pkgconfig.ExistingConfig{}, pkgconfig.KeepDefaults{}, true))
+
+	// Token and teams steps, as in the main walk.
+	p.send(keyRunes("mock-token"))
+	p.send(keyEnter())
+	p.releaseHeld() // teams fetch returns
+	p.send(keyRunes("x"))
+	p.send(keyEnter())
+	p.releaseHeld() // policy fetch returns
+
+	p.enterUntil(t, "Configure advanced options?", 12)
+	p.send(keyEnter()) // answer the confirm (default: No)
+	p.releaseHeld()
+
+	assert.NotContains(t, p.view(), "Configure advanced options?",
+		"one enter must dismiss the advanced-options confirm — the group must exist exactly once")
 }

--- a/pkg/tui/config_policy_picker_test.go
+++ b/pkg/tui/config_policy_picker_test.go
@@ -30,8 +30,13 @@ func realPolicy(id, name string) pagerduty.EscalationPolicy {
 
 // OB-4: the silent-policy step becomes a fetched picker. SILENT-classified
 // policies (no schedules notified) lead the list with a recommendation
-// annotation; skip and manual-entry escapes are always present.
-func TestBuildPolicyOptions_SilentFirstWithAnnotation(t *testing.T) {
+// annotation so the cursor starts on the best candidate, then the rest,
+// then the skip and manual-entry escapes. No option value may equal the
+// empty string: huh's Select moves the cursor (and scrolls the viewport)
+// to the option matching the current bound value when async options
+// arrive, and the bound value starts empty — an empty-valued option would
+// yank the viewport away from the top (the "picker only shows Skip" bug).
+func TestBuildPolicyOptions_SilentFirstEscapesLast(t *testing.T) {
 	opts := buildPolicyOptions([]pagerduty.EscalationPolicy{
 		realPolicy("PREAL1", "Primary On-Call"),
 		silentPolicy("PSILENT1", "Silent Test"),
@@ -44,9 +49,37 @@ func TestBuildPolicyOptions_SilentFirstWithAnnotation(t *testing.T) {
 	assert.Equal(t, "PSILENT1", opts[0].Value, "silent policies must come first")
 	assert.Equal(t, "PSILENT2", opts[1].Value)
 	assert.Contains(t, opts[0].Key, "Silent Test")
-	assert.Contains(t, opts[0].Key, "recommended", "silent candidates must be annotated")
+	assert.Contains(t, opts[0].Key, "possible candidate", "silent candidates must be annotated")
 	assert.Equal(t, "PREAL1", opts[2].Value)
-	assert.NotContains(t, opts[2].Key, "recommended")
+	assert.NotContains(t, opts[2].Key, "possible candidate")
+	assert.Equal(t, policyChoiceSkip, opts[4].Value)
+	assert.Equal(t, policyChoiceManual, opts[5].Value)
+
+	for _, o := range opts {
+		assert.NotEmpty(t, o.Value,
+			"no option value may be empty or the initial cursor jumps off the top")
+	}
+}
+
+// Within the silent candidates, policies with "silent" in the name lead:
+// they are the strongest signal of intent, so the cursor starts on the
+// likeliest pick even when the API returns them in another order.
+func TestBuildPolicyOptions_SilentNamePriority(t *testing.T) {
+	opts := buildPolicyOptions([]pagerduty.EscalationPolicy{
+		silentPolicy("PNULL1", "Null Route"),
+		silentPolicy("PSIL1", "Team Silent Test"),
+		silentPolicy("PNONACT1", "Non-Actionable"),
+		silentPolicy("PSIL2", "SILENT stage"),
+		realPolicy("PREAL1", "Primary On-Call"),
+	})
+
+	// silent-named candidates, then other candidates, then real, then escapes
+	assert.Equal(t, "PSIL1", opts[0].Value, `names containing "silent" lead (case-insensitive)`)
+	assert.Equal(t, "PSIL2", opts[1].Value)
+	assert.Equal(t, "PNULL1", opts[2].Value)
+	assert.Equal(t, "PNONACT1", opts[3].Value)
+	assert.Equal(t, "PREAL1", opts[4].Value)
+	assert.Equal(t, policyChoiceSkip, opts[5].Value)
 }
 
 func TestBuildPolicyOptions_SentinelsAlwaysPresent(t *testing.T) {
@@ -59,7 +92,11 @@ func TestBuildPolicyOptions_SentinelsAlwaysPresent(t *testing.T) {
 	assert.Equal(t, policyChoiceManual, opts[1].Value)
 }
 
-func TestFetchPolicyOptions_UsesTeamFilter(t *testing.T) {
+// The silent policy conventionally lives on a companion team (e.g.
+// "<team> - Non-actionable") that the user belongs to but does not select
+// for incident filtering. Fetching policies for only the selected teams
+// missed it, so the picker fetches across ALL of the user's teams.
+func TestFetchPolicyOptions_FetchesAllUserTeams(t *testing.T) {
 	mock := &pd.MockPagerDutyClient{
 		ListEscalationPoliciesResponses: []pagerduty.ListEscalationPoliciesResponse{
 			{EscalationPolicies: []pagerduty.EscalationPolicy{
@@ -70,17 +107,23 @@ func TestFetchPolicyOptions_UsesTeamFilter(t *testing.T) {
 	}
 	factory := func(string) pd.PagerDutyClient { return mock }
 
-	opts := fetchPolicyOptions(factory, "u+token", "", []string{"TEAM_001"})
+	opts := fetchPolicyOptions(factory, "u+token", "")
 
 	assert.Len(t, opts, 4, "two policies + skip + manual")
 	assert.Equal(t, "PSILENT1", opts[0].Value)
+	// The mock user belongs to TEAM_001 and TEAM_002; both must be queried
+	// even though a wizard selection would typically cover only one.
+	if assert.Len(t, mock.RecordedListEscalationPoliciesOpts, 1) {
+		assert.ElementsMatch(t, []string{"TEAM_001", "TEAM_002"},
+			mock.RecordedListEscalationPoliciesOpts[0].TeamIDs)
+	}
 }
 
-func TestFetchPolicyOptions_NoTeamsStillOffersEscapes(t *testing.T) {
-	opts := fetchPolicyOptions(mockFactoryOK(), "u+token", "", nil)
+func TestFetchPolicyOptions_NoTokenStillOffersEscapes(t *testing.T) {
+	opts := fetchPolicyOptions(mockFactoryOK(), "", "")
 
-	// GetTeamEscalationPolicies with no teams returns no policies; the user
-	// must still be able to skip or enter manually.
+	// Without a token there is nothing to fetch; the user must still be
+	// able to skip or enter manually.
 	assert.Len(t, opts, 2)
 	assert.Equal(t, policyChoiceSkip, opts[0].Value)
 	assert.Equal(t, policyChoiceManual, opts[1].Value)
@@ -90,7 +133,7 @@ func TestFetchPolicyOptions_ErrorClassifiedAndEscapesKept(t *testing.T) {
 	mock := &pd.MockPagerDutyClient{ListEscalationPoliciesErr: pagerduty.APIError{StatusCode: 429}}
 	factory := func(string) pd.PagerDutyClient { return mock }
 
-	opts := fetchPolicyOptions(factory, "u+token", "", []string{"TEAM_001"})
+	opts := fetchPolicyOptions(factory, "u+token", "")
 
 	// The classified error is shown as a disabled-style row, and the user can
 	// still skip or enter an ID manually.
@@ -106,6 +149,8 @@ func TestResolveSilentPolicyChoice(t *testing.T) {
 		"picker choice wins")
 	assert.Equal(t, "", resolveSilentPolicyChoice(policyChoiceSkip, "ignored"),
 		"skip means no policy")
+	assert.Equal(t, "", resolveSilentPolicyChoice("", "ignored"),
+		"untouched picker (empty choice) means no policy")
 	assert.Equal(t, "PMANUAL9", resolveSilentPolicyChoice(policyChoiceManual, "  PMANUAL9  "),
 		"manual choice uses the trimmed free-text input")
 	assert.Equal(t, "", resolveSilentPolicyChoice(policyChoiceManual, "   "),

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"runtime"
 	"slices"
+	"sort"
 	"strings"
 	"time"
 
@@ -532,6 +533,17 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case spinner.TickMsg:
 		var cmd tea.Cmd
 		m.spinner, cmd = m.spinner.Update(msg)
+		// huh forms run their own spinners for async OptionsFunc fetches
+		// (the "Loading..." row); without forwarding the ticks, the form
+		// receives no messages while a fetch is in flight and the loading
+		// indicator never renders.
+		if m.configMode && m.configForm != nil {
+			form, formCmd := m.configForm.Update(msg)
+			if f, ok := form.(*huh.Form); ok {
+				m.configForm = f
+			}
+			return m, tea.Batch(cmd, formCmd)
+		}
 		return m, cmd
 
 	case TickMsg:
@@ -2011,22 +2023,39 @@ func fetchTeamOptions(clientFactory func(string) pd.PagerDutyClient, tokenInput,
 
 // Sentinel values for the silent-policy picker (OB-4). Skip maps to the
 // empty policy ID (silencing disabled until configured); manual reveals the
-// free-text ID input for policies the picker cannot discover.
+// free-text ID input for policies the picker cannot discover. Neither
+// sentinel may be the empty string: the picker's bound value starts empty,
+// and huh's Select moves the cursor (and scrolls the viewport, unclamped)
+// to the option matching the current value when async options arrive — an
+// empty-valued option would yank the cursor off the top of the list.
 const (
-	policyChoiceSkip   = ""
+	policyChoiceSkip   = "__skip__"
 	policyChoiceManual = "__manual__"
 )
 
 // buildPolicyOptions turns fetched escalation policies into picker options:
 // SILENT-classified policies (no schedules notified — the right target for
-// silencing) lead the list with a recommendation annotation, then the rest,
+// silencing) lead the list with a candidate annotation so the cursor
+// starts on the best pick — those with "silent" in the name first (the
+// strongest signal of intent), then the other candidates, then the rest,
 // then the skip and manual-entry escapes.
 func buildPolicyOptions(policies []pagerduty.EscalationPolicy) []huh.Option[string] {
+	candidateOption := func(p pagerduty.EscalationPolicy) huh.Option[string] {
+		return huh.NewOption(
+			fmt.Sprintf("%s — %s (possible candidate — does not page)", p.Name, p.ID), p.ID)
+	}
+
 	var opts []huh.Option[string]
 	for _, p := range policies {
-		if pd.ClassifyEscalationPolicy(&p) == pd.PolicyClassSilent {
-			opts = append(opts, huh.NewOption(
-				fmt.Sprintf("%s — %s (recommended — no schedules notified)", p.Name, p.ID), p.ID))
+		if pd.ClassifyEscalationPolicy(&p) == pd.PolicyClassSilent &&
+			strings.Contains(strings.ToLower(p.Name), "silent") {
+			opts = append(opts, candidateOption(p))
+		}
+	}
+	for _, p := range policies {
+		if pd.ClassifyEscalationPolicy(&p) == pd.PolicyClassSilent &&
+			!strings.Contains(strings.ToLower(p.Name), "silent") {
+			opts = append(opts, candidateOption(p))
 		}
 	}
 	for _, p := range policies {
@@ -2041,20 +2070,39 @@ func buildPolicyOptions(policies []pagerduty.EscalationPolicy) []huh.Option[stri
 	return opts
 }
 
-// fetchPolicyOptions fetches the escalation policies for the selected teams
-// and builds the picker options. Errors are classified (OB-3) and rendered
-// as a skip-valued row so selecting them is harmless; the skip and manual
-// escapes are always present.
-func fetchPolicyOptions(clientFactory func(string) pd.PagerDutyClient, tokenInput, existingToken string, teams []string) []huh.Option[string] {
+// fetchPolicyOptions fetches the escalation policies for ALL of the user's
+// PagerDuty teams and builds the picker options. The fetch deliberately
+// ignores the wizard's team selection: silent policies conventionally live
+// on a companion team (e.g. "<team> - Non-actionable") that the user
+// belongs to but does not select for incident filtering, so a
+// selected-teams filter misses exactly the policies this picker exists to
+// find. Errors are classified (OB-3) and rendered as a skip-valued row so
+// selecting them is harmless; the skip and manual escapes are always
+// present.
+func fetchPolicyOptions(clientFactory func(string) pd.PagerDutyClient, tokenInput, existingToken string) []huh.Option[string] {
 	token := strings.TrimSpace(tokenInput)
 	if token == "" {
 		token = existingToken
 	}
-	if token == "" || len(teams) == 0 {
+	if token == "" {
 		return buildPolicyOptions(nil)
 	}
 
-	policies, err := pd.GetTeamEscalationPolicies(clientFactory(token), teams)
+	client := clientFactory(token)
+	teams, err := pd.GetCurrentUserTeams(client)
+	if err != nil {
+		return append(
+			[]huh.Option[string]{huh.NewOption("Error: "+pd.ClassifyAPIError(err), policyChoiceSkip)},
+			buildPolicyOptions(nil)...,
+		)
+	}
+	teamIDs := make([]string, 0, len(teams))
+	for _, t := range teams {
+		teamIDs = append(teamIDs, t.ID)
+	}
+	sort.Strings(teamIDs)
+
+	policies, err := pd.GetTeamEscalationPolicies(client, teamIDs)
 	if err != nil {
 		return append(
 			[]huh.Option[string]{huh.NewOption("Error: "+pd.ClassifyAPIError(err), policyChoiceSkip)},
@@ -2067,9 +2115,15 @@ func fetchPolicyOptions(clientFactory func(string) pd.PagerDutyClient, tokenInpu
 // resolveSilentPolicyChoice maps the picker choice (plus the manual free-text
 // input) to the final policy ID. Emits the same bare ID string the free-text
 // step produced, so the save format and runtime consumption are unchanged.
+// An empty choice means the picker was never touched (e.g. the step was
+// hidden or skipped before options arrived) and resolves to no policy, same
+// as skip.
 func resolveSilentPolicyChoice(choice, manualInput string) string {
-	if choice == policyChoiceManual {
+	switch choice {
+	case policyChoiceManual:
 		return strings.TrimSpace(manualInput)
+	case policyChoiceSkip, "":
+		return ""
 	}
 	return choice
 }
@@ -2242,16 +2296,24 @@ func (m *model) buildConfigForm(msg configWizardReadyMsg, tokenDesc, keepTeamsDe
 				Description(
 					"When you silence an incident, it gets reassigned to this policy —\n"+
 						"one that routes only to bot users, not on-call humans.\n"+
-						"Policies are fetched from your selected teams; ones with no\n"+
-						"schedules (nobody gets paged) are recommended.",
+						"Policies are fetched from all your PagerDuty teams (silent\n"+
+						"policies often live on a companion non-actionable team); ones\n"+
+						"with no schedules (nobody gets paged) are candidates.",
 				).
 				OptionsFunc(func() []huh.Option[string] {
-					teams := m.configState.SelectedTeams
-					if m.configState.KeepTeams || len(teams) == 0 {
-						teams = msg.existing.Teams
-					}
-					return fetchPolicyOptions(clientFactory, m.configState.TokenInput, msg.existing.Token, teams)
-				}, &m.configState.SelectedTeams).
+					return fetchPolicyOptions(clientFactory, m.configState.TokenInput, msg.existing.Token)
+				}, &m.configState.TokenInput).
+				// Height(0) — after OptionsFunc, which force-defaults a zero
+				// height to 10 lines (only 4 visible under the title and
+				// description). Zero auto-sizes the field to the full list,
+				// which both shows every option the window can fit AND keeps
+				// the arrow cursor moving naturally: any explicit height
+				// routes huh v1.0.0 through an unclamped
+				// viewport.YOffset = selected on every update, pinning the
+				// selected row to the top so arrows scroll the list instead
+				// of the cursor. The group layout still clamps the field on
+				// windows too short for the list.
+				Height(0).
 				Value(&m.configState.SilentPolicyChoice),
 		).WithHideFunc(func() bool { return m.configState.KeepSilent }),
 		huh.NewGroup(

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -2363,26 +2363,6 @@ func (m *model) buildConfigForm(msg configWizardReadyMsg, tokenDesc, keepTeamsDe
 		).WithHideFunc(func() bool { return msg.kd.HasCustom }),
 		huh.NewGroup(
 			huh.NewConfirm().
-				Title("Configure advanced options?").
-				Description(
-					"Custom service-to-policy silence overrides — a team-policy\n"+
-						"setting most users don't need. Skip unless your team's\n"+
-						"onboarding docs say otherwise.",
-				).
-				Value(&m.configState.AdvancedOptions),
-		).WithHideFunc(func() bool { return msg.kd.HasCustom }),
-		huh.NewGroup(
-			huh.NewConfirm().
-				Title("Configure advanced options?").
-				Description(
-					"Custom service-to-policy silence overrides — a team-policy\n"+
-						"setting most users don't need. Skip unless your team's\n"+
-						"onboarding docs say otherwise.",
-				).
-				Value(&m.configState.AdvancedOptions),
-		).WithHideFunc(func() bool { return msg.kd.HasCustom }),
-		huh.NewGroup(
-			huh.NewConfirm().
 				Title("Keep current custom service-to-policy mappings?").
 				Description(keepCustomDesc).
 				Value(&m.configState.KeepCustom),


### PR DESCRIPTION
## Problem

After the OB-4 picker shipped (#367), live testing surfaced four defects:

1. **Fetched policies never appeared** — the picker showed only the skip/manual escapes. Root cause (proven with a deterministic bubbletea pump test): the async options were *accepted* by huh, but huh v1.0.0 scrolls the Select viewport (unclamped) to the option matching the bound value, and the initial empty value matched the empty-string skip sentinel below the policies — everything scrolled out of view.
2. **The fetch missed real silent policies** — verified against the live PagerDuty API: silent policies conventionally live on companion non-actionable teams (e.g. `Platform SRE - Non-actionable`) that users belong to but never select for incident filtering, so a selected-teams filter structurally excludes them.
3. **Arrow keys scrolled the list under a top-pinned cursor** — any explicit field height routes huh v1.0.0 through an unclamped `viewport.YOffset = selected` on every update.
4. **The "Configure advanced options?" confirm had to be answered three times** — three identical groups shipped on main, one from #368 plus one re-added by each of the #370 and #371 merge resolutions.

## Fix

- Non-empty skip sentinel (`__skip__`) so the initial empty choice matches no option: cursor starts at index 0, viewport at the top. Saved config format unchanged.
- `fetchPolicyOptions` queries **all of the user's PagerDuty teams** (`GetCurrentUserTeams` → `GetTeamEscalationPolicies`) instead of the wizard selection.
- Candidates annotated "(possible candidate — does not page)", silent-named ones sorted first; skip/manual escapes last.
- `Height(0)` auto-sizes the picker to the window and keeps arrow keys moving the cursor naturally; spinner ticks are forwarded to the config form so huh's native Loading row renders during fetches.
- Deduplicated the advanced-options confirm to a single group; post-mortems added to the plan docs of the merges that introduced the copies.
- Missing-config stderr notice now ends with "-- generating..." so a new user's first run doesn't read as a failure.

## Tests

Deterministic bubbletea message-pump harness (`config_policy_picker_repro_test.go`) drives the real wizard form with late-arriving async fetches: loading row shown then replaced, policies visible above escapes, silent-name ordering, cursor preselection, no scroll-under-cursor, and single-enter advance past the advanced-options confirm. Plan doc: `docs/plans/378-policy-picker-viewport-scroll-fix.md`.

Created with assistance from Claude 🤖 <claude@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVGJhen8cGnEfbxJ9VYpAE