### PR TITLE
Add welcome step and step breadcrumbs to the config wizard

### DIFF
--- a/docs/plans/381-first-run-polish-v2.md
+++ b/docs/plans/381-first-run-polish-v2.md
@@ -1,0 +1,24 @@
+# 381: First-run polish — welcome step and step breadcrumbs
+
+Branch: `srepd/first-run-polish-v2`
+
+## Problem
+
+The wizard opened cold on a password input — no orientation, no token help
+before the field demanding it, no explanation when auto-launched over a
+broken config. No sense of progress through the steps.
+
+## Approach
+
+- Welcome Note group: what srepd is, token acquisition path, ctrl+c escape,
+  OB-1 "You're here because" reason, reconfiguration acknowledgement.
+- Step breadcrumbs: "Title · n/6" on six numbered milestones (token, teams,
+  silent policy, environment, options, summary). Keep-confirm variants share
+  their milestone number; conditional steps unnumbered.
+- Integration tests updated with an extra enter to dismiss the welcome step.
+
+## Files
+
+- `pkg/tui/tui.go` — welcomeDescription, stepTitle, welcome group, numbered titles
+- `pkg/tui/config_polish_test.go` — welcome/breadcrumb tests
+- `pkg/tui/config_policy_picker_repro_test.go` — extra enter for welcome step

--- a/pkg/tui/config_policy_picker_repro_test.go
+++ b/pkg/tui/config_policy_picker_repro_test.go
@@ -220,6 +220,9 @@ func TestConfigWizardPolicyPickerRendersFetchedPolicies(t *testing.T) {
 	p.send(tea.WindowSizeMsg{Width: 120, Height: 50})
 	p.send(newConfigWizardReadyMsg(pkgconfig.ExistingConfig{}, pkgconfig.KeepDefaults{}, true))
 
+	// Welcome step: advance past it.
+	p.send(keyEnter())
+
 	// Token step: type a token and advance. Validation hits the mock.
 	p.send(keyRunes("mock-token"))
 	p.send(keyEnter())
@@ -286,6 +289,9 @@ func TestConfigWizardAdvancedOptionsConfirmAdvancesInOneEnter(t *testing.T) {
 	p := &wizardPump{t: t, m: m}
 	p.send(tea.WindowSizeMsg{Width: 120, Height: 50})
 	p.send(newConfigWizardReadyMsg(pkgconfig.ExistingConfig{}, pkgconfig.KeepDefaults{}, true))
+
+	// Welcome step: advance past it.
+	p.send(keyEnter())
 
 	// Token and teams steps, as in the main walk.
 	p.send(keyRunes("mock-token"))

--- a/pkg/tui/config_polish_test.go
+++ b/pkg/tui/config_polish_test.go
@@ -1,0 +1,33 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWelcomeDescription_NewUser(t *testing.T) {
+	desc := welcomeDescription(true, "")
+
+	assert.Contains(t, desc, "PagerDuty")
+	assert.Contains(t, desc, "User Settings")
+	assert.Contains(t, desc, "ctrl+c")
+	assert.NotContains(t, desc, "You're here because")
+}
+
+func TestWelcomeDescription_WithReason(t *testing.T) {
+	desc := welcomeDescription(false, "the configured PagerDuty API token is a placeholder value")
+
+	assert.Contains(t, desc, "You're here because")
+	assert.Contains(t, desc, "placeholder value")
+}
+
+func TestWelcomeDescription_ExistingConfig(t *testing.T) {
+	desc := welcomeDescription(false, "")
+	assert.Contains(t, desc, "existing")
+}
+
+func TestStepTitle(t *testing.T) {
+	assert.Equal(t, "Select your PagerDuty teams · 2/6", stepTitle("Select your PagerDuty teams", 2))
+	assert.Equal(t, "PagerDuty API token · 1/6", stepTitle("PagerDuty API token", 1))
+}

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -2128,6 +2128,37 @@ func resolveSilentPolicyChoice(choice, manualInput string) string {
 	return choice
 }
 
+// wizardStepTotal is the number of numbered wizard milestones visible to the
+// user: token, teams, silent policy, environment, options, summary. Keep-
+// confirm variants share their milestone's number; the welcome and
+// conditional AI/advanced/manual steps are unnumbered.
+const wizardStepTotal = 6
+
+// stepTitle renders a wizard milestone title with its step breadcrumb.
+func stepTitle(title string, n int) string {
+	return fmt.Sprintf("%s · %d/%d", title, n, wizardStepTotal)
+}
+
+// welcomeDescription builds the wizard's opening text: what srepd is, where
+// to get a token, how to bail out — and, when the wizard auto-launched over
+// a broken config (OB-1), why.
+func welcomeDescription(isNewFile bool, reason string) string {
+	var sb strings.Builder
+	sb.WriteString("srepd is a PagerDuty TUI for SRE on-call work: incidents,\n")
+	sb.WriteString("acknowledgements, silencing, notes, and cluster login.\n\n")
+	if reason != "" {
+		fmt.Fprintf(&sb, "You're here because: %s.\n\n", reason)
+	} else if !isNewFile {
+		sb.WriteString("This updates your existing configuration — current values are\nkept unless you change them.\n\n")
+	}
+	sb.WriteString("You'll need a PagerDuty API User Token. Create one at:\n")
+	sb.WriteString("PagerDuty web → My Profile → User Settings → API Access →\n")
+	sb.WriteString("Create New API User Token.\n\n")
+	sb.WriteString("Everything else is discovered for you. Press enter to begin,\n")
+	sb.WriteString("or ctrl+c to quit.")
+	return sb.String()
+}
+
 // buildTerminalOptions builds the environment step's terminal choices: the
 // current setting first (annotated, with a warning when its binary is
 // missing), then the detected terminals, deduplicated.
@@ -2245,8 +2276,13 @@ func (m *model) buildConfigForm(msg configWizardReadyMsg, tokenDesc, keepTeamsDe
 
 	return huh.NewForm(
 		huh.NewGroup(
+			huh.NewNote().
+				Title("Welcome to SREPD").
+				Description(welcomeDescription(msg.isNewFile, msg.wizardReason)),
+		),
+		huh.NewGroup(
 			huh.NewInput().
-				Title("PagerDuty API token").
+				Title(stepTitle("PagerDuty API token", 1)).
 				Description(tokenDesc).
 				EchoMode(huh.EchoModePassword).
 				Value(&m.configState.TokenInput).
@@ -2256,13 +2292,13 @@ func (m *model) buildConfigForm(msg configWizardReadyMsg, tokenDesc, keepTeamsDe
 		),
 		huh.NewGroup(
 			huh.NewConfirm().
-				Title("Keep current teams?").
+				Title(stepTitle("Keep current teams?", 2)).
 				Description(keepTeamsDesc).
 				Value(&m.configState.KeepTeams),
 		).WithHideFunc(func() bool { return !msg.kd.HasValidTeams }),
 		huh.NewGroup(
 			huh.NewMultiSelect[string]().
-				Title("Select your PagerDuty teams").
+				Title(stepTitle("Select your PagerDuty teams", 2)).
 				DescriptionFunc(func() string {
 					return teamGreeting(m.configState.FetchedUserName, m.configState.FetchedTeamCount)
 				}, &m.configState.FetchedUserName).
@@ -2286,13 +2322,13 @@ func (m *model) buildConfigForm(msg configWizardReadyMsg, tokenDesc, keepTeamsDe
 		).WithHideFunc(func() bool { return m.configState.KeepTeams }),
 		huh.NewGroup(
 			huh.NewConfirm().
-				Title("Keep current silent escalation policy?").
+				Title(stepTitle("Keep current silent escalation policy?", 3)).
 				Description(keepSilentDesc).
 				Value(&m.configState.KeepSilent),
 		).WithHideFunc(func() bool { return !msg.kd.HasSilent }),
 		huh.NewGroup(
 			huh.NewSelect[string]().
-				Title("Default silent escalation policy").
+				Title(stepTitle("Default silent escalation policy", 3)).
 				Description(
 					"When you silence an incident, it gets reassigned to this policy —\n"+
 						"one that routes only to bot users, not on-call humans.\n"+
@@ -2330,7 +2366,7 @@ func (m *model) buildConfigForm(msg configWizardReadyMsg, tokenDesc, keepTeamsDe
 		}),
 		huh.NewGroup(
 			huh.NewSelect[string]().
-				Title("Terminal for cluster login").
+				Title(stepTitle("Terminal for cluster login", 4)).
 				Description(
 					"Opens cluster login sessions. Terminals detected on this\n"+
 						"system are listed; your current setting comes first.",
@@ -2353,7 +2389,7 @@ func (m *model) buildConfigForm(msg configWizardReadyMsg, tokenDesc, keepTeamsDe
 		).WithHideFunc(func() bool { return !m.configState.AgentOffered }),
 		huh.NewGroup(
 			huh.NewConfirm().
-				Title("Configure advanced options?").
+				Title(stepTitle("Configure advanced options?", 5)).
 				Description(
 					"Custom service-to-policy silence overrides — a team-policy\n"+
 						"setting most users don't need. Skip unless your team's\n"+
@@ -2386,7 +2422,7 @@ func (m *model) buildConfigForm(msg configWizardReadyMsg, tokenDesc, keepTeamsDe
 		}),
 		huh.NewGroup(
 			huh.NewNote().
-				Title("Configuration summary").
+				Title(stepTitle("Configuration summary", 6)).
 				DescriptionFunc(func() string {
 					tmpFinal, _ := pkgconfig.ResolveFinalValues(m.configExisting, pkgconfig.WizardInputs{
 						TokenInput:          m.configState.TokenInput,


### PR DESCRIPTION
## Changes

1. **Welcome step** — Note group with orientation, token acquisition path (before the field), ctrl+c escape, OB-1 "You're here because" reason, reconfiguration acknowledgement
2. **Step breadcrumbs** — "Title · n/6" on six milestones; conditional steps unnumbered
3. Integration tests updated for the extra welcome group

## Tests

`config_polish_test.go` + updated policy picker integration tests. Full suite green.

## Plan doc

`docs/plans/381-first-run-polish-v2.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)