### PR TITLE
Reframe onboarding docs around the wizard (OB-2, OB-7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ make install        # install to $GOPATH/bin
 go install .        # standard go install
 ```
 
+## Getting Started
+
+1. **Create a PagerDuty API User Token**: PagerDuty web → My Profile → User Settings → API Access → Create New API User Token.
+2. **Run `srepd`** — the setup wizard does the rest: it validates your token, discovers your teams and escalation policies, detects your terminal and editor, and drops you straight into the live incident view when you save.
+
+That's it. Your team may also publish a preset with its policy decisions — if so, run `srepd config --preset <url>` from your team's onboarding docs instead. See [docs/presets.md](docs/presets.md) for details.
+
 ## Commands
 
 | Command | Description |
@@ -71,13 +78,12 @@ If no config file exists — or the config file is incomplete or still contains 
 | `default_silent_escalation_policy` | `string` | (none) | Silent escalation policy ID for silencing incidents. The wizard fetches your team's policies and recommends ones with no on-call schedules; you can also skip or enter an ID manually. |
 | `custom_service_escalation_policies` | `map[string]string` | (none) | Per-service silent policy overrides (service ID to policy ID) |
 | `editor` | `string` | `vim` | Editor for incident notes (wizard prefills from `$EDITOR`/`$VISUAL`) |
-| `terminal` | `string` | `gnome-terminal` | Terminal emulator for cluster login (wizard detects installed terminals and warns when the configured one is missing) |
+| `terminal` | `string` | `gnome-terminal --` | Terminal emulator for cluster login (wizard detects installed terminals and warns when the configured one is missing) |
 | `cluster_login_command` | `string` | `ocm backplane login %%CLUSTER_ID%%` | Cluster login command |
 | `rosa_boundary_command` | `string` | `rosa-boundary start-task --cluster-id %%CLUSTER_ID%% --connect` | rosa-boundary cluster login command |
 | `toolbox_mode` | `string` | `auto` | Toolbox detection: `auto`, `true`, or `false` |
 | `chord_prefix` | `string` | `ctrl+x` | Prefix key for chord commands |
-| `flag_marker` | `string` | `🚩 ` | Prefix marker for flagged incidents (alt: `\|►`) |
-| `agent_cli_command` | `string` | `claude --print` | CLI agent command for `:agent` queries |
+| `agent_cli_command` | `string` | `claude --print` | CLI agent command for `:agent` queries (set to `""` to disable AI features) |
 | `emoji` | `bool` | `true` | Use emoji markers or text fallbacks for flags/agent/watcher |
 | `reescalate_level` | `int` | `2` | Escalation level `ctrl+e` re-escalates to, skipping lower placeholder tiers (e.g. level 1 "Nobody") |
 | `stream_responses` | `bool` | `true` | Stream `:watcher`/LLM responses token-by-token when the provider supports it; set `false` for blocking responses |
@@ -103,15 +109,23 @@ colors:
   tab: "#7D56F4"        # Reserved for future use
 ```
 
-### Example
+### Advanced: manual configuration
+
+Prefer editing a file over the wizard? Generate a complete, annotated config with every supported key and its default:
+
+```bash
+srepd config generate --out ~/.config/srepd/srepd.yaml
+```
+
+Then fill in `token` and `teams`. **Do not copy placeholder values** like `<PagerDuty API token>` into the file — srepd treats them as unconfigured and routes you into the wizard. A minimal working config looks like:
 
 ```yaml
-token: <PagerDuty API token>
+token: u+yourRealTokenHere
 teams:
-  - <team ID>
+  - PABC123
 default_silent_escalation_policy: P654321
-terminal: gnome-terminal
-cluster_login_command: ocm-container --cluster-id %%CLUSTER_ID%%
+terminal: gnome-terminal --
+cluster_login_command: ocm backplane login %%CLUSTER_ID%%
 rosa_boundary_command: rosa-boundary start-task --cluster-id %%CLUSTER_ID%% --connect
 toolbox_mode: auto
 ```

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2025 NAME HERE <EMAIL ADDRESS>
+Copyright © 2023 Chris Collins 'collins.christopher@gmail.com'
 */
 package cmd
 
@@ -23,7 +23,12 @@ import (
 
 const description = `The config command is used to create or validate the SREPD config file.
 The config file is located at ~/.config/srepd/srepd.yaml and is used to store
-the configuration options for the SREPD application.`
+the configuration options for the SREPD application.
+
+You will need a PagerDuty API User Token: create one at PagerDuty web →
+My Profile → User Settings → API Access → Create New API User Token.
+Everything else — teams, escalation policies, terminal, editor — is
+discovered by the wizard, or pre-seeded from a team preset via --preset.`
 
 // safeToLogConfigKeys is the allowlist of config keys whose values are safe to log
 // verbatim under --debug. Any key not in this set is masked, so secret-bearing keys

--- a/docs/plans/383-onboarding-docs-v2.md
+++ b/docs/plans/383-onboarding-docs-v2.md
@@ -1,0 +1,13 @@
+# 383: Onboarding docs and headers (OB-2 + OB-7)
+
+Branch: `srepd/onboarding-docs-v2`
+
+## Changes
+
+- README: Getting Started section (two steps: create token, run srepd),
+  link to presets doc; YAML example demoted to "Advanced: manual
+  configuration" with config generate and placeholder warning; terminal
+  default corrected to `gnome-terminal --`; dead flag_marker row removed;
+  agent_cli_command documents `""` = disabled.
+- configCmd long description: token acquisition path + discovery summary.
+- Copyright headers fixed in cmd/config.go and pkg/config/config.go.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 NAME HERE <EMAIL ADDRESS>
+Copyright © 2023 Chris Collins 'collins.christopher@gmail.com'
 */
 package config
 


### PR DESCRIPTION
Closes OB-2 + OB-7 of #353.

- **Getting Started**: two steps — create token, run srepd. Links to presets doc.
- **Advanced: manual configuration**: YAML example demoted, led by `config generate`, placeholder warning
- Options table: terminal default corrected (`gnome-terminal --`), dead `flag_marker` removed (#322), `agent_cli_command` documents `""` = disabled
- `configCmd` long description: token path + discovery/preset summary
- Copyright headers fixed in `cmd/config.go` and `pkg/config/config.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)