### PR TITLE
Gate preset-supplied commands behind explicit safety confirmations

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ If no config file exists — or the config file is incomplete or still contains 
 
 **Team presets:** `srepd config --preset <file|https-url>` pre-seeds the wizard from a team-published YAML fragment carrying team policy decisions — teams, `default_silent_escalation_policy`, `custom_service_escalation_policies`, `cluster_login_command`, and optionally `terminal`/`editor`. Presets can never set `token` or `llm_api` credentials, only fill values you haven't configured, and every value is still confirmed in the wizard. URL fetches are HTTPS-only and size-capped. Teams can publish one preset link in their onboarding docs to eliminate the ID scavenger hunt for new members.
 
+Because `terminal`, `editor`, and `cluster_login_command` are commands srepd *executes*, a preset that seeds any of them triggers an extra safety gate after the final "Save changes?" confirmation: a bold red warning listing every preset-supplied command for review, followed by an explicit "Are you sure you trust the source?" confirmation showing the preset file or URL. Both default to No, and declining either discards all changes. Values you type yourself, and preset fields that are only PagerDuty IDs (teams, policies, mappings), never trigger the gate.
+
 ### Required
 
 | Key | Type | Description |
@@ -68,7 +70,7 @@ If no config file exists — or the config file is incomplete or still contains 
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `default_silent_escalation_policy` | `string` | (none) | Silent escalation policy ID for silencing incidents. The wizard fetches your team's policies and recommends ones with no on-call schedules; you can also skip or enter an ID manually. |
+| `default_silent_escalation_policy` | `string` | (none) | Silent escalation policy ID for silencing incidents. The wizard fetches policies from all your PagerDuty teams and marks ones with no on-call schedules as candidates ("does not page"); you can also skip or enter an ID manually. |
 | `custom_service_escalation_policies` | `map[string]string` | (none) | Per-service silent policy overrides (service ID to policy ID) |
 | `editor` | `string` | `vim` | Editor for incident notes (wizard prefills from `$EDITOR`/`$VISUAL`) |
 | `terminal` | `string` | `gnome-terminal` | Terminal emulator for cluster login (wizard detects installed terminals and warns when the configured one is missing) |

--- a/docs/plans/382-preset-command-safety-gate.md
+++ b/docs/plans/382-preset-command-safety-gate.md
@@ -1,0 +1,47 @@
+# 382: Preset command safety gate
+
+Branch: `srepd/preset-command-safety-gate`
+Related: plan 374 (supply-chain hardening), plan 370 (team presets)
+
+## Problem
+
+A `--preset` file or HTTPS URL is remote input, and three of its allowed
+keys — `terminal`, `editor`, `cluster_login_command` — are commands srepd
+executes. A malicious preset could plant arbitrary command execution
+behind an innocuous-looking team config, and the wizard's summary alone
+is easy to enter through.
+
+## Approach
+
+When a preset seeded any executable field
+(`PresetApplied.ExecutableAny()`: terminal, editor, or cluster login),
+the wizard requires two extra confirmations after the final
+"Save changes?":
+
+1. A **bold red** "⚠ SECURITY" confirm listing every preset-supplied
+   command with its final value ("They are safe" / "No — discard",
+   default No).
+2. "Are you sure you trust the source?" showing the preset file/URL
+   ("I trust this source" / "No — discard", default No).
+
+Declining either discards the save. The gate is enforced twice: by the
+group flow (the trust confirm hides unless the command review was
+affirmed) and re-checked at form completion in `switchConfigFocusMode`,
+so a future form-navigation bug cannot skip it. The red styling is
+deliberately theme-independent (bold, ANSI 196) so it reads as an alarm.
+
+Never gated: wizard-typed values, existing configs, and API-only preset
+fields (teams, silent policy, custom mappings) — those are IDs sent to
+the PagerDuty API, not executed.
+
+Presets cannot set the agent CLI or agentic prompts today (the allowlist
+rejects them); a tripwire comment on `presetAllowedKeys` requires any
+future executable or agentic-prompt key to join `ExecutableAny`.
+
+## Tests (TDD — written first)
+
+- `pkg/tui/config_preset_safety_test.go` drives the real wizard via the
+  message pump through save → red warning → trust confirm:
+  affirm-both path (config written), decline path (nothing written),
+  no-preset path (no gate), API-fields-only preset (no gate).
+- `TestPresetApplied_ExecutableAny` covers the gate predicate.

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -75,6 +75,15 @@ never accepted: presets carry team policy, not credentials.
 - **No credentials** — `token` and `llm_api` keys are always rejected
 - **No redirects to insecure hosts** — Go's `http.Client` follows redirects
   but the initial URL must be HTTPS
+- **Executable values are gated.** `terminal`, `editor`, and
+  `cluster_login_command` are commands srepd *executes*. A preset that
+  seeds any of them triggers an extra safety gate after the final
+  "Save changes?" confirmation: a bold red warning listing every
+  preset-supplied command for review, then an explicit "Are you sure you
+  trust the source?" confirmation showing the preset file or URL. Both
+  default to No; declining either discards all changes. Preset fields
+  that are only PagerDuty IDs (teams, policies, mappings) never trigger
+  the gate.
 
 ## Publishing a preset for your team
 

--- a/pkg/config/preset.go
+++ b/pkg/config/preset.go
@@ -46,9 +46,24 @@ func (p PresetApplied) Any() bool {
 	return p.Teams || p.Silent || p.Custom || p.ClusterLogin || p.Terminal || p.Editor
 }
 
+// ExecutableAny reports whether the preset seeded any field that maps to a
+// command srepd executes (terminal, editor, cluster login). These get an
+// extra bold-red safety confirmation in the wizard: a preset fetched from a
+// URL is remote input, and a malicious one could otherwise plant arbitrary
+// commands. Team/policy IDs are only ever sent to the PagerDuty API, so
+// they are excluded.
+func (p PresetApplied) ExecutableAny() bool {
+	return p.ClusterLogin || p.Terminal || p.Editor
+}
+
 // presetAllowedKeys is the strict allowlist of keys a preset may set.
 // Everything else — above all token and llm_api credentials — is rejected
 // loudly rather than silently ignored.
+//
+// SECURITY: if a key that maps to an executed binary or an agentic prompt
+// (e.g. agent_cli_command, prompt templates) is ever added here, it MUST
+// also be covered by PresetApplied.ExecutableAny so the wizard's bold-red
+// preset safety confirmation includes it.
 var presetAllowedKeys = map[string]bool{
 	"teams":                              true,
 	"default_silent_escalation_policy":   true,

--- a/pkg/config/preset_test.go
+++ b/pkg/config/preset_test.go
@@ -167,3 +167,14 @@ func TestForcePresetChanges(t *testing.T) {
 	assert.True(t, forced.EditorChanged)
 	assert.False(t, forced.TokenChanged, "token is never preset-driven")
 }
+
+// ExecutableAny gates the wizard's bold-red preset safety confirmations:
+// only fields srepd executes count, not IDs sent to the PagerDuty API.
+func TestPresetApplied_ExecutableAny(t *testing.T) {
+	assert.False(t, PresetApplied{}.ExecutableAny())
+	assert.False(t, PresetApplied{Teams: true, Silent: true, Custom: true}.ExecutableAny(),
+		"API-only fields must not trigger the safety gate")
+	assert.True(t, PresetApplied{Terminal: true}.ExecutableAny())
+	assert.True(t, PresetApplied{Editor: true}.ExecutableAny())
+	assert.True(t, PresetApplied{ClusterLogin: true}.ExecutableAny())
+}

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -1429,6 +1429,12 @@ type configFormState struct {
 	// a successful fetch and drive the greeting DescriptionFunc.
 	FetchedUserName  string
 	FetchedTeamCount int
+	// PresetCommandsSafe/PresetSourceTrusted are the extra safety
+	// confirmations shown after "Save changes?" when a --preset seeded
+	// fields that srepd executes (terminal, editor, cluster login). Both
+	// default to false and both must be affirmed or the save is discarded.
+	PresetCommandsSafe  bool
+	PresetSourceTrusted bool
 }
 
 // configWizardReadyMsg is sent when the existing config has been resolved

--- a/pkg/tui/config_mode_test.go
+++ b/pkg/tui/config_mode_test.go
@@ -12,6 +12,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/huh"
 	pkgconfig "github.com/clcollins/srepd/pkg/config"
+	"github.com/clcollins/srepd/pkg/ocm"
 	"github.com/clcollins/srepd/pkg/pd"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -70,6 +71,11 @@ func createConfigTestModel() model {
 		return &pd.MockPagerDutyClient{}
 	}
 	m.configFS = &tuiMockFS{}
+	// Completing the wizard fires the OB-6 OCM handoff; without a stub the
+	// real ocm.Connect runs — attempting live auth and panicking on repeat
+	// /oauth/callback mux registrations when multiple tests complete forms
+	// in one process.
+	m.ocmConnect = func() (ocm.OCMClient, error) { return nil, nil }
 	windowSize = tea.WindowSizeMsg{Width: 120, Height: 50}
 	return m
 }

--- a/pkg/tui/config_preset_safety_test.go
+++ b/pkg/tui/config_preset_safety_test.go
@@ -1,0 +1,144 @@
+package tui
+
+// Preset safety gate (supply-chain hardening): a --preset is remote input,
+// and terminal, editor, and cluster_login_command values are commands srepd
+// executes. When a preset seeded any of them, saving requires two extra
+// explicit confirmations after "Save changes?" — a bold-red review of the
+// commands, then vouching for the source. Declining either discards the
+// save. Wizard-typed or existing-config values never see the gate.
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	pkgconfig "github.com/clcollins/srepd/pkg/config"
+	"github.com/clcollins/srepd/pkg/pd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	fakePresetTerminal = "FAKE-terminal --run"
+	fakePresetLogin    = "FAKE-login %%CLUSTER_ID%%"
+	fakePresetSource   = "https://preset.example.test/FAKE-team.yaml"
+)
+
+func presetWizardReadyMsg(applied pkgconfig.PresetApplied) configWizardReadyMsg {
+	existing := pkgconfig.ExistingConfig{}
+	if applied.Terminal {
+		existing.Terminal = fakePresetTerminal
+	}
+	if applied.ClusterLogin {
+		existing.ClusterLoginCommand = fakePresetLogin
+	}
+	return configWizardReadyMsg{
+		existing:      existing,
+		kd:            pkgconfig.KeepDefaults{},
+		isNewFile:     true,
+		teamNames:     map[string]string{},
+		policyNames:   map[string]string{},
+		presetApplied: applied,
+	}
+}
+
+// walkToSaveConfirm drives the wizard from launch to the "Save changes?"
+// confirm using the pump.
+func walkToSaveConfirm(t *testing.T, p *wizardPump) {
+	t.Helper()
+	p.send(keyEnter()) // welcome step
+	p.send(keyRunes("mock-token"))
+	p.send(keyEnter())
+	p.releaseHeld() // teams fetch returns
+	p.send(keyRunes("x"))
+	p.send(keyEnter())
+	p.releaseHeld() // policy fetch returns
+	p.enterUntil(t, "Save changes?", 14)
+}
+
+func newPresetSafetyPump(t *testing.T, applied pkgconfig.PresetApplied) (*wizardPump, *tuiMockFS) {
+	t.Helper()
+	m := createConfigTestModel()
+	mfs := &tuiMockFS{}
+	m.configFS = mfs
+	mock := policyPickerMockClient()
+	m.pdClientFactory = func(_ string) pd.PagerDutyClient { return mock }
+
+	p := &wizardPump{t: t, m: m}
+	p.send(tea.WindowSizeMsg{Width: 120, Height: 50})
+	p.send(presetWizardReadyMsg(applied))
+	walkToSaveConfirm(t, p)
+	return p, mfs
+}
+
+func TestPresetSafety_GateShownAndSavesAfterBothConfirms(t *testing.T) {
+	applied := pkgconfig.PresetApplied{
+		Terminal:     true,
+		ClusterLogin: true,
+		Source:       fakePresetSource,
+	}
+	p, mfs := newPresetSafetyPump(t, applied)
+
+	// Save changes? defaults to Yes; enter must land on the red warning,
+	// not complete the form.
+	p.send(keyEnter())
+	view := p.view()
+	require.Contains(t, view, "SECURITY",
+		"preset-seeded executable fields must trigger the safety warning after Save")
+	assert.Contains(t, view, fakePresetTerminal, "the warning must list the terminal command")
+	assert.Contains(t, view, fakePresetLogin, "the warning must list the cluster login command")
+	assert.True(t, p.m.(model).configMode, "form must not complete before the gate")
+
+	// Affirm the commands are safe → the trust-the-source confirm.
+	p.send(keyRunes("y"))
+	view = p.view()
+	require.Contains(t, view, "trust the source",
+		"affirming the commands must lead to the source-trust confirm")
+	assert.Contains(t, view, fakePresetSource, "the trust confirm must show the preset source")
+
+	// Affirm trust → form completes and the config is written.
+	p.send(keyRunes("y"))
+	p.releaseHeld()
+	assert.False(t, p.m.(model).configMode, "form must complete after both confirmations")
+	assert.Contains(t, string(mfs.writeData), fakePresetTerminal,
+		"config must be written with the confirmed values")
+}
+
+func TestPresetSafety_DecliningCommandsDiscardsSave(t *testing.T) {
+	applied := pkgconfig.PresetApplied{Terminal: true, Source: fakePresetSource}
+	p, mfs := newPresetSafetyPump(t, applied)
+
+	p.send(keyEnter()) // Save changes? → warning
+	require.Contains(t, p.view(), "SECURITY")
+
+	p.send(keyRunes("n")) // not safe → no trust prompt, form completes, discarded
+	p.releaseHeld()
+	assert.False(t, p.m.(model).configMode, "form must complete after declining")
+	assert.Empty(t, mfs.writeData, "declining the command review must discard the save")
+	// The "preset commands not confirmed" status is set on completion but
+	// immediately superseded by the follow-up incident-list refresh in the
+	// synchronous pump, so it is not asserted here — the empty write is the
+	// behavior under test.
+}
+
+func TestPresetSafety_NoGateWithoutPreset(t *testing.T) {
+	p, mfs := newPresetSafetyPump(t, pkgconfig.PresetApplied{})
+
+	assert.NotContains(t, p.view(), "SECURITY",
+		"no preset means no safety warning anywhere in the flow")
+	p.send(keyEnter()) // Save changes? → completes directly
+	p.releaseHeld()
+	assert.False(t, p.m.(model).configMode, "form must complete without extra gates")
+	assert.NotEmpty(t, mfs.writeData, "config must be written")
+}
+
+func TestPresetSafety_NoGateForNonExecutableFields(t *testing.T) {
+	// Teams/policies are only sent to the PagerDuty API, never executed —
+	// they must not trigger the gate.
+	applied := pkgconfig.PresetApplied{Teams: true, Silent: true, Custom: true, Source: fakePresetSource}
+	p, mfs := newPresetSafetyPump(t, applied)
+
+	p.send(keyEnter())
+	p.releaseHeld()
+	assert.False(t, p.m.(model).configMode, "form must complete without extra gates")
+	assert.NotEmpty(t, mfs.writeData, "config must be written")
+}

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -323,6 +323,19 @@ func switchConfigFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Batch(cmds...)
 		}
 
+		// Preset safety gate: preset-seeded terminal/editor/cluster-login
+		// values are commands srepd executes, so both extra confirmations
+		// (commands reviewed, source trusted) must have been affirmed.
+		if m.configPresetApplied.ExecutableAny() &&
+			(!m.configState.PresetCommandsSafe || !m.configState.PresetSourceTrusted) {
+			m.setStatus("preset commands not confirmed — config changes discarded")
+			cmds := []tea.Cmd{func() tea.Msg { return updateIncidentListMsg("preset not confirmed") }}
+			if ocmCmd := m.ocmHandoffCmd(true); ocmCmd != nil {
+				cmds = append(cmds, ocmCmd)
+			}
+			return m, tea.Batch(cmds...)
+		}
+
 		final, err := pkgconfig.ResolveFinalValues(m.configExisting, pkgconfig.WizardInputs{
 			TokenInput:          m.configState.TokenInput,
 			SelectedTeams:       m.configState.SelectedTeams,

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -17,6 +17,7 @@ import (
 	"github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/huh"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/log"
 	"github.com/clcollins/srepd/pkg/ai"
 	"github.com/clcollins/srepd/pkg/alert"
@@ -2239,6 +2240,10 @@ func (m *model) buildConfigForm(msg configWizardReadyMsg, tokenDesc, keepTeamsDe
 
 	theme := SrepdHuhTheme(m.theme)
 
+	// Deliberately loud, theme-independent bold red for the preset command
+	// safety warnings — this must read as an alarm, not chrome.
+	presetWarnStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("196"))
+
 	km := huh.NewDefaultKeyMap()
 	km.Quit = key.NewBinding(key.WithKeys("ctrl+c", "ctrl+q"), key.WithHelp("ctrl+q/ctrl+c", "quit"))
 	km.Input.Prev = key.NewBinding(key.WithKeys("shift+tab"), key.WithHelp("shift+tab", "back"))
@@ -2461,5 +2466,54 @@ func (m *model) buildConfigForm(msg configWizardReadyMsg, tokenDesc, keepTeamsDe
 				Title("Save changes?").
 				Value(&m.configState.Confirm),
 		),
+		// Preset safety gate: a --preset is remote input, and terminal,
+		// editor, and cluster login values are commands srepd EXECUTES. When
+		// a preset seeded any of them, saving requires two extra explicit
+		// confirmations after "Save changes?" — reviewing the commands, then
+		// vouching for the source. Both default to No; declining either
+		// discards the save (enforced in switchConfigFocusMode). Hidden
+		// entirely for wizard-typed or existing-config values.
+		huh.NewGroup(
+			huh.NewConfirm().
+				Title(presetWarnStyle.Render("⚠ SECURITY: this preset supplies commands srepd will run")).
+				DescriptionFunc(func() string {
+					var b strings.Builder
+					b.WriteString(presetWarnStyle.Render("These values came from the --preset source and will be"))
+					b.WriteString("\n")
+					b.WriteString(presetWarnStyle.Render("EXECUTED as commands. Validate every one is safe:"))
+					b.WriteString("\n\n")
+					if m.configPresetApplied.Terminal {
+						fmt.Fprintf(&b, "  terminal: %s\n", m.configState.TerminalChoice)
+					}
+					if m.configPresetApplied.Editor {
+						fmt.Fprintf(&b, "  editor: %s\n", m.configState.EditorInput)
+					}
+					if m.configPresetApplied.ClusterLogin {
+						fmt.Fprintf(&b, "  cluster_login_command: %s\n", m.configExisting.ClusterLoginCommand)
+					}
+					b.WriteString("\nAnswering No discards all changes.")
+					return b.String()
+				}, &m.configState).
+				Affirmative("They are safe").
+				Negative("No — discard").
+				Value(&m.configState.PresetCommandsSafe),
+		).WithHideFunc(func() bool {
+			return !m.configPresetApplied.ExecutableAny() || !m.configState.Confirm
+		}),
+		huh.NewGroup(
+			huh.NewConfirm().
+				Title(presetWarnStyle.Render("Are you sure you trust the source?")).
+				Description(fmt.Sprintf(
+					"%s\n  %s\n\nOnly save if this file or URL is controlled by your team.",
+					presetWarnStyle.Render("These commands were supplied by:"),
+					m.configPresetApplied.Source,
+				)).
+				Affirmative("I trust this source").
+				Negative("No — discard").
+				Value(&m.configState.PresetSourceTrusted),
+		).WithHideFunc(func() bool {
+			return !m.configPresetApplied.ExecutableAny() || !m.configState.Confirm ||
+				!m.configState.PresetCommandsSafe
+		}),
 	).WithTheme(theme).WithKeyMap(km).WithWidth(m.layout.FormWidth).WithHeight(m.layout.FormHeight)
 }


### PR DESCRIPTION
## Problem

A `--preset` file or HTTPS URL is remote input, and three of its allowed keys — `terminal`, `editor`, `cluster_login_command` — are commands srepd **executes**. A malicious preset could plant arbitrary command execution behind an innocuous-looking team config, and the wizard summary alone is easy to enter through.

## Fix

When a preset seeded any executable field (`PresetApplied.ExecutableAny()`), saving requires two extra confirmations **after** the final "Save changes?":

1. A **bold red** "⚠ SECURITY: this preset supplies commands srepd will run" confirm listing every preset-supplied command with its final value ("They are safe" / "No — discard", default **No**).
2. "Are you sure you trust the source?" showing the preset file/URL ("I trust this source" / "No — discard", default **No**).

Declining either discards all changes. The gate is enforced twice — in the group flow and re-checked at form completion in `switchConfigFocusMode` — so a form-navigation bug cannot skip it.

Never gated: wizard-typed values, existing configs, and API-only preset fields (teams, silent policy, custom mappings). Presets cannot set the agent CLI or agentic prompts today (allowlist rejects them); a tripwire comment on `presetAllowedKeys` requires any future executable or agentic-prompt key to join the gated set.

## Tests

Message-pump tests drive the real wizard through save → red warning → trust confirm: affirm-both (config written), decline (nothing written), no-preset (no gate), API-fields-only preset (no gate); plus a unit test on the gate predicate. Plan doc: `docs/plans/382-preset-command-safety-gate.md`.

Related: #375 (supply-chain hardening) — this is the wizard-side counterpart, split into its own PR.

Created with assistance from Claude 🤖 <claude@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVGJhen8cGnEfbxJ9VYpAE