### PR TITLE
Fix misleading backplane error on Reports tab

### DIFF
--- a/docs/plans/385-backplane-reports-tab-error.md
+++ b/docs/plans/385-backplane-reports-tab-error.md
@@ -1,0 +1,24 @@
+# 385: Fix misleading backplane error on Reports tab
+
+Branch: `srepd/fix-backplane-reports-tab-error`
+
+## What
+
+The Reports tab shows "Backplane not enabled; ensure your config.json exists..."
+whenever `backplaneClient` is nil, regardless of the actual cause. This is
+misleading when the config loaded fine but the client hasn't been created yet
+(OCM auth pending, URL resolution failed, etc.).
+
+Replace the single nil check with a cascade that shows the real state:
+no config, auth pending, waiting for OCM, init error with details, or
+a fallback pointing to logs.
+
+Also store `backplaneInitErr` on the model so the deferred-init failure
+in `OCMClientReadyMsg` surfaces the actual error to the user.
+
+## Files
+
+- `pkg/tui/model.go` — add `backplaneInitErr` field
+- `pkg/tui/tui.go` — set/clear `backplaneInitErr` in OCMClientReadyMsg handler
+- `pkg/tui/views.go` — replace single nil check with cascading status messages
+- `pkg/tui/views_render_test.go` — six tests covering all branches

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -229,6 +229,7 @@ type model struct {
 	// Backplane enrichment state
 	backplaneClient    backplane.BackplaneClient
 	backplaneConfig    *backplane.Config
+	backplaneInitErr   error
 	clusterReportCache map[string][]backplane.Report
 
 	// Prior alerts state

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -405,6 +405,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				resolvedURL, urlErr := msg.Client.GetBackplaneURL()
 				if urlErr != nil {
 					log.Warn("Backplane URL resolution from OCM failed (deferred)", "error", urlErr)
+					m.backplaneInitErr = fmt.Errorf("URL resolution from OCM failed: %w", urlErr)
 				} else {
 					m.backplaneConfig.URL = resolvedURL
 					log.Info("Backplane URL resolved from OCM (deferred)", "url", resolvedURL)
@@ -412,8 +413,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			if m.backplaneConfig.URL != "" {
 				m.backplaneClient = backplane.NewClient(m.backplaneConfig, msg.Client.GetAccessToken)
+				m.backplaneInitErr = nil
 				log.Info("Backplane client initialized (deferred)")
-			} else {
+			} else if m.backplaneInitErr == nil {
+				m.backplaneInitErr = fmt.Errorf("no backplane URL in config or from OCM")
 				log.Warn("Backplane client not created (deferred): no URL available")
 			}
 		}

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -557,7 +557,19 @@ func (m model) renderLimitedSupportTab() (string, error) {
 
 func (m model) renderClusterReportsTab() (string, error) {
 	if m.backplaneClient == nil {
-		return "\n_Backplane not enabled; ensure your ~/.config/backplane/config.json exists and is readable..._\n", nil
+		if m.backplaneConfig == nil {
+			return "\n_Backplane not enabled; ensure your ~/.config/backplane/config.json exists and is readable..._\n", nil
+		}
+		if m.ocmAuthPending {
+			return "\n_Backplane initializing — completing OCM authentication..._\n", nil
+		}
+		if m.ocmClient == nil {
+			return "\n_Backplane initializing — waiting for OCM connection..._\n", nil
+		}
+		if m.backplaneInitErr != nil {
+			return fmt.Sprintf("\n_Backplane not available — %v_\n", m.backplaneInitErr), nil
+		}
+		return "\n_Backplane not available — check logs for details_\n", nil
 	}
 
 	if len(m.clusterReportCache) == 0 {

--- a/pkg/tui/views_render_test.go
+++ b/pkg/tui/views_render_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"encoding/base64"
+	"fmt"
 	"testing"
 
 	"github.com/clcollins/srepd/pkg/backplane"
@@ -14,14 +15,70 @@ import (
 // only — no PagerDuty/OCM/backplane API calls, no host tools, no filesystem. They
 // raise coverage of a previously-untested (0%) render path and lock in its output.
 
-func TestRenderClusterReportsTab_BackplaneDisabled(t *testing.T) {
+func TestRenderClusterReportsTab_BackplaneNoConfig(t *testing.T) {
 	m := createTestModel()
 	m.backplaneClient = nil
+	m.backplaneConfig = nil
 
 	content, err := m.renderClusterReportsTab()
 
 	assert.NoError(t, err)
 	assert.Contains(t, content, "Backplane not enabled")
+}
+
+func TestRenderClusterReportsTab_BackplaneOCMAuthPending(t *testing.T) {
+	m := createTestModel()
+	m.backplaneClient = nil
+	m.backplaneConfig = &backplane.Config{}
+	m.ocmAuthPending = true
+
+	content, err := m.renderClusterReportsTab()
+
+	assert.NoError(t, err)
+	assert.Contains(t, content, "Backplane initializing")
+	assert.Contains(t, content, "OCM authentication")
+}
+
+func TestRenderClusterReportsTab_BackplaneWaitingForOCM(t *testing.T) {
+	m := createTestModel()
+	m.backplaneClient = nil
+	m.backplaneConfig = &backplane.Config{}
+	m.ocmClient = nil
+	m.ocmAuthPending = false
+
+	content, err := m.renderClusterReportsTab()
+
+	assert.NoError(t, err)
+	assert.Contains(t, content, "Backplane initializing")
+	assert.Contains(t, content, "OCM connection")
+}
+
+func TestRenderClusterReportsTab_BackplaneInitError(t *testing.T) {
+	m := createTestModel()
+	m.backplaneClient = nil
+	m.backplaneConfig = &backplane.Config{}
+	m.ocmClient = createMockOCMClient()
+	m.backplaneInitErr = fmt.Errorf("no backplane URL in config or from OCM")
+
+	content, err := m.renderClusterReportsTab()
+
+	assert.NoError(t, err)
+	assert.Contains(t, content, "Backplane not available")
+	assert.Contains(t, content, "no backplane URL in config or from OCM")
+}
+
+func TestRenderClusterReportsTab_BackplaneInitNoStoredError(t *testing.T) {
+	m := createTestModel()
+	m.backplaneClient = nil
+	m.backplaneConfig = &backplane.Config{}
+	m.ocmClient = createMockOCMClient()
+	m.backplaneInitErr = nil
+
+	content, err := m.renderClusterReportsTab()
+
+	assert.NoError(t, err)
+	assert.Contains(t, content, "Backplane not available")
+	assert.Contains(t, content, "check logs")
 }
 
 func TestRenderClusterReportsTab_OCMNotConnected(t *testing.T) {


### PR DESCRIPTION
## Summary

- Reports tab showed "Backplane not enabled; ensure your config.json exists..." whenever `backplaneClient` was nil — even when the config loaded fine but the client hadn't been created yet (OCM auth pending, URL resolution failed, etc.)
- Replace the single nil check with a cascading status that surfaces the real state: no config, auth pending, waiting for OCM, init error with details, or fallback pointing to logs
- Store `backplaneInitErr` on the model so deferred-init failures in `OCMClientReadyMsg` surface the actual error to the user

## Test plan

- [ ] Unit tests cover all 6 branches of the new cascade (no config, auth pending, waiting for OCM, init error, no stored error, existing tests unchanged)
- [ ] `make test-all` passes locally (fmt-check, vet, lint, test, test-race, test-fixtures)
- [ ] Manual: start srepd with expired OCM tokens, navigate to Reports tab before completing browser auth → should see "Backplane initializing — completing OCM authentication..." instead of the config error

🤖 Generated with [Claude Code](https://claude.com/claude-code)