### PR TITLE
Fix stuck OCM tab spinners for incidents viewed before OCM auth

### DIFF
--- a/docs/plans/390-fix-preauth-enrich-inflight-leak.md
+++ b/docs/plans/390-fix-preauth-enrich-inflight-leak.md
@@ -1,0 +1,70 @@
+# 390: Fix stuck OCM tab spinners for incidents viewed before OCM auth
+
+Branch: `srepd/fix-preauth-enrich-inflight-leak`
+
+## What
+
+When srepd starts unauthenticated to OCM ("OCM tokens not valid — will
+authenticate async") and the user opens an incident before auth completes,
+the Cluster / Service Logs / Limited Support History / Reports tabs spin
+forever — even after OCM auth succeeds and other incidents enrich normally.
+
+Observed live with incident Q14TKHUE995O2B: journal showed "OCM connected
+(async)" followed by enrichment for exactly the clusters of incidents *not*
+yet viewed; the viewed incident's cluster never got a single OCM call, with
+no error logged.
+
+## Root cause
+
+`gotIncidentAlertsMsg` marks each uncached cluster
+`clusterEnrichInFlight[id] = true` *before* dispatching enrichment, but
+`enrichClusters()` silently returns nil when the OCM client is nil. No
+command is dispatched, so no `clusterInfoMsg` (the only handler that clears
+the flag) ever arrives — the flag leaks permanently.
+
+Every subsequent enrichment opportunity — including the `OCMClientReadyMsg`
+post-auth sweep — deliberately skips in-flight clusters, so the leaked flag
+blocks recovery forever. The tab spinners render directly off
+`clusterEnrichInFlight`, and phase 2 (service logs, limited support,
+reports) only dispatches from the `clusterInfoMsg` handler, so all four
+tabs stay in the spinner state.
+
+## Approach
+
+Restore the invariant: **a cluster is marked in-flight only when an
+enrichment command was actually dispatched.** In `gotIncidentAlertsMsg`,
+skip the mark-in-flight loop entirely when `m.ocmClient == nil`. The
+cluster IDs still land in `incidentClusterMap`, so the existing
+`OCMClientReadyMsg` sweep picks them up naturally once auth completes —
+no new recovery path needed.
+
+Considered instead clearing/ignoring in-flight flags in the
+`OCMClientReadyMsg` handler (nothing can genuinely be in flight before a
+client exists). Rejected in favor of fixing the invariant at the source:
+never set the flag without a dispatched command, so no other current or
+future consumer of the flag can be poisoned.
+
+## Tests (TDD — written first, verified red, then green)
+
+- `TestGotIncidentAlertsMsg_NilOCMClient_NoInFlightLeak` — alerts arriving
+  with a nil client must not mark the cluster in-flight, but must still
+  record it in `incidentClusterMap` for the post-auth sweep.
+- `TestOCMClientReadyMsg_EnrichesClusterViewedPreAuth` — full regression
+  sequence: alerts pre-auth, then `OCMClientReadyMsg`; asserts the sweep
+  marks the cluster in-flight *and* actually dispatches a phase-1
+  `clusterInfoMsg` command (batch unwrapped via a `collectCmdMsgs` helper
+  with a timeout, since the batch also contains a 4s flash-notification
+  tick).
+
+## Files
+
+- `pkg/tui/tui.go` — guard the mark-in-flight loop in `gotIncidentAlertsMsg`
+  with `m.ocmClient != nil`
+- `pkg/tui/ocm_enrichment_test.go` — two regression tests plus
+  `alertsForCluster` / `collectCmdMsgs` helpers
+
+## Known follow-up (not in this PR)
+
+The phase-2 msg handlers (`ocmServiceLogsMsg` / `limitedSupportMsg` /
+`clusterReportsMsg`) don't trigger `renderIncidentMsg`, so an already-open
+tab's body only refreshes on tab switch. Cosmetic; separate change.

--- a/pkg/tui/ocm_enrichment_test.go
+++ b/pkg/tui/ocm_enrichment_test.go
@@ -3,8 +3,10 @@ package tui
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/PagerDuty/go-pagerduty"
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/clcollins/srepd/pkg/launcher"
 	"github.com/clcollins/srepd/pkg/ocm"
 	"github.com/clcollins/srepd/pkg/pd"
@@ -715,5 +717,117 @@ func TestCacheCleanup_RemovedFromList(t *testing.T) {
 		// INC002 preserved
 		assert.Contains(t, m.clusterCache, c2)
 		assert.Contains(t, m.incidentClusterMap, "INC002")
+	})
+}
+
+// alertsForCluster builds a single-alert slice carrying the given cluster ID,
+// matching the PagerDuty alert body shape getUniqueClusters parses.
+func alertsForCluster(clusterID string) []pagerduty.IncidentAlert {
+	return []pagerduty.IncidentAlert{
+		{
+			APIObject: pagerduty.APIObject{ID: "A1"},
+			Body: map[string]interface{}{
+				"details": map[string]interface{}{
+					"cluster_id": clusterID,
+				},
+			},
+		},
+	}
+}
+
+// collectCmdMsgs executes cmd, flattening nested tea.Batch commands, running
+// each leaf command concurrently and collecting the messages produced before
+// the timeout. Slow commands (e.g. 4s flash-notification tea.Tick timers)
+// simply don't make the cut and are ignored.
+func collectCmdMsgs(t *testing.T, cmd tea.Cmd, timeout time.Duration) []tea.Msg {
+	t.Helper()
+	if cmd == nil {
+		return nil
+	}
+	results := make(chan tea.Msg, 64)
+	var run func(c tea.Cmd)
+	run = func(c tea.Cmd) {
+		if c == nil {
+			return
+		}
+		msg := c()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, sub := range batch {
+				go run(sub)
+			}
+			return
+		}
+		results <- msg
+	}
+	go run(cmd)
+
+	var msgs []tea.Msg
+	deadline := time.After(timeout)
+	for {
+		select {
+		case msg := <-results:
+			msgs = append(msgs, msg)
+		case <-deadline:
+			return msgs
+		}
+	}
+}
+
+func TestGotIncidentAlertsMsg_NilOCMClient_NoInFlightLeak(t *testing.T) {
+	t.Run("pre-auth alerts do not mark clusters in-flight", func(t *testing.T) {
+		m := createTestModel()
+		m.ocmClient = nil
+		m.incidentClusterMap = make(map[string][]string)
+		m.clusterEnrichInFlight = make(map[string]bool)
+		m.selectedIncident = &pagerduty.Incident{APIObject: pagerduty.APIObject{ID: "INC001"}}
+
+		result, _ := m.Update(gotIncidentAlertsMsg{
+			incidentID: "INC001",
+			alerts:     alertsForCluster(testClusterID),
+		})
+		updated := result.(model)
+
+		assert.False(t, updated.clusterEnrichInFlight[testClusterID],
+			"no enrichment can be dispatched without an OCM client, so the cluster must not be marked in-flight")
+		assert.Equal(t, []string{testClusterID}, updated.incidentClusterMap["INC001"],
+			"cluster must still be mapped so the post-auth sweep can enrich it")
+	})
+}
+
+func TestOCMClientReadyMsg_EnrichesClusterViewedPreAuth(t *testing.T) {
+	t.Run("cluster from incident opened pre-auth is enriched once OCM connects", func(t *testing.T) {
+		m := createTestModel()
+		m.ocmClient = nil
+		m.ocmAuthPending = true
+		m.incidentClusterMap = make(map[string][]string)
+		m.clusterCache = make(map[string]*ocm.ClusterInfo)
+		m.clusterEnrichInFlight = make(map[string]bool)
+		m.clusterEnrichFailed = make(map[string]int)
+		m.selectedIncident = &pagerduty.Incident{APIObject: pagerduty.APIObject{ID: "INC001"}}
+
+		// Alerts arrive for the open incident while OCM is still authenticating.
+		result, _ := m.Update(gotIncidentAlertsMsg{
+			incidentID: "INC001",
+			alerts:     alertsForCluster(testClusterID),
+		})
+		m = result.(model)
+		assert.False(t, m.clusterEnrichInFlight[testClusterID],
+			"no OCM client yet — cluster must not be marked in-flight")
+
+		// OCM auth completes.
+		result, cmd := m.Update(OCMClientReadyMsg{Client: createMockOCMClient(), Err: nil})
+		updated := result.(model)
+
+		assert.True(t, updated.clusterEnrichInFlight[testClusterID],
+			"post-auth sweep must mark the pre-auth cluster in-flight when dispatching")
+
+		var enriched bool
+		for _, msg := range collectCmdMsgs(t, cmd, 500*time.Millisecond) {
+			if info, ok := msg.(clusterInfoMsg); ok && info.clusterID == testClusterID {
+				enriched = true
+			}
+		}
+		assert.True(t, enriched,
+			"OCMClientReadyMsg must dispatch phase-1 enrichment (clusterInfoMsg) for the cluster viewed pre-auth")
 	})
 }

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -860,19 +860,28 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				m.incidentClusterMap[msg.incidentID] = clusterIDs
 			}
+			// Only mark clusters in-flight when an OCM client exists to
+			// dispatch the enrichment: enrichClusters no-ops on a nil client,
+			// and an in-flight flag with no clusterInfoMsg coming is never
+			// cleared, so the OCMClientReadyMsg post-auth sweep would skip
+			// the cluster forever and the OCM tabs would spin indefinitely.
+			// Pre-auth clusters stay unmarked in incidentClusterMap and are
+			// picked up by that sweep once auth completes.
 			var uncachedClusters []string
-			for _, id := range clusterIDs {
-				if _, cached := m.clusterCache[id]; cached {
-					continue
+			if m.ocmClient != nil {
+				for _, id := range clusterIDs {
+					if _, cached := m.clusterCache[id]; cached {
+						continue
+					}
+					if m.clusterEnrichInFlight[id] {
+						continue
+					}
+					if m.clusterEnrichFailed[id] >= 3 {
+						continue
+					}
+					uncachedClusters = append(uncachedClusters, id)
+					m.clusterEnrichInFlight[id] = true
 				}
-				if m.clusterEnrichInFlight[id] {
-					continue
-				}
-				if m.clusterEnrichFailed[id] >= 3 {
-					continue
-				}
-				uncachedClusters = append(uncachedClusters, id)
-				m.clusterEnrichInFlight[id] = true
 			}
 			enrichCmds := enrichClusters(m.ocmClient, uncachedClusters, m.devMode)
 			if len(enrichCmds) > 0 {


### PR DESCRIPTION
## Problem

When srepd starts unauthenticated to OCM and an incident is opened before async auth completes, the Cluster / Service Logs / Limited Support History / Reports tabs spin forever — even after OCM auth succeeds and other incidents enrich normally. Observed live with incident Q14TKHUE995O2B: the journal showed `OCM connected (async)` followed by enrichment for exactly the clusters of incidents *not* yet viewed; the viewed incident's cluster never got a single OCM call, with no error logged.

## Root cause

`gotIncidentAlertsMsg` marks each uncached cluster `clusterEnrichInFlight = true` *before* dispatching enrichment, but `enrichClusters()` silently returns nil when the OCM client is nil. No command is dispatched, so no `clusterInfoMsg` (the only place the flag is cleared) ever arrives — the flag leaks permanently. The `OCMClientReadyMsg` post-auth sweep deliberately skips in-flight clusters, so the leaked flag blocks recovery forever. The tab spinners render directly off that flag, and phase 2 (service logs / limited support / reports) only dispatches from the `clusterInfoMsg` handler, so all four tabs stay stuck.

## Fix

Restore the invariant: a cluster is marked in-flight only when an enrichment command was actually dispatched. The mark-in-flight loop is now guarded by `m.ocmClient != nil`. Pre-auth clusters still land in `incidentClusterMap`, so the existing `OCMClientReadyMsg` sweep enriches them once auth completes — no new recovery path needed.

## Tests (TDD — written first, verified red, then green)

- `TestGotIncidentAlertsMsg_NilOCMClient_NoInFlightLeak` — pre-auth alerts must not mark the cluster in-flight, but must still record it in `incidentClusterMap`
- `TestOCMClientReadyMsg_EnrichesClusterViewedPreAuth` — full regression sequence, asserting the post-auth sweep actually dispatches a phase-1 `clusterInfoMsg` (batch unwrapped with a timeout helper, since flag assertions alone pass under the bug)

## Dependencies

No new dependencies added.

Plan doc: `docs/plans/390-fix-preauth-enrich-inflight-leak.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2NqMb8k1H9ZfCxh5kgxQi