### PR TITLE
Fix review-found bugs, tighten Update loop, add lazy-enricher staleness refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ A PagerDuty terminal user interface focused on common SRE tasks.
 * Open SOP/runbook links and incidents directly from alerts
 * Log into clusters via ocm-container or ocm backplane with multi-cluster selection
 * Add notes, auto-refresh with selection preservation, auto-acknowledge when on-call
+* Background data freshness: incident details, alerts, and notes are cached
+  and automatically re-fetched when older than five minutes
 * PagerDuty environment variables passed automatically to terminal sessions
 * [Flag conditions](docs/flag-conditions.md): mark incidents matching cluster ID or organization name patterns
 * [AI agents](docs/ai-agents.md): `:agent` CLI queries and `:watcher` LLM analysis with ambient incident pattern detection

--- a/docs/plans/386-bug-fixes-polish-lazy-refresh.md
+++ b/docs/plans/386-bug-fixes-polish-lazy-refresh.md
@@ -1,0 +1,98 @@
+# 386: Bug fixes, Update-loop polish, and lazy-enricher staleness refresh
+
+Branch: `srepd/bug-fixes-polish-lazy-refresh`
+
+## What
+
+A full-codebase review (carried over from an unpushed session, re-verified
+against current main) found six bugs, several Update-loop inefficiencies, and
+a data-freshness gap:
+
+**Bug fixes**
+
+- `UserIsOnCall` sent `time.Now().String()` as `Since`/`Until` — not the
+  ISO8601/RFC3339 the PagerDuty API accepts — so the on-call check that gates
+  auto-acknowledge queried with invalid time bounds. It also returned "not
+  on call" on the first malformed on-call entry, hiding valid shifts, and
+  called `time.Now()` four times per invocation.
+- `removeCommentsFromBytes` dropped newlines (multi-line notes collapsed to
+  one line when posted to PagerDuty) and wrote each kept line once per
+  non-matching prefix when given multiple prefixes.
+- `login()` and `openBrowserCmd()` ran `exec.Command(...).Start()` at
+  command-construction time — inside the Bubble Tea Update loop — instead of
+  inside the returned `tea.Cmd`. A slow terminal or browser launch froze the
+  UI. All four launch paths (regular, cluster-selected, and both
+  rosa-boundary variants) route through `login()` since PR #386, so one fix
+  covers them all. `openBrowserCmd` also gained a `go c.Wait()` reaper.
+- `loginMsg`, `rosaBoundaryLoginMsg`, and `waitForSelectedIncidentThenDoMsg`
+  re-queued themselves immediately while waiting for data, spinning the
+  Update loop at full speed. They now requeue via `requeueAfterDelay()`
+  (`tea.Tick`, 250ms).
+- `silenceIncidentsMsg` unconditionally appended the selected incident to
+  the list being silenced, double-silencing it when already present.
+- `initialScheduledJobs` was a package-level slice of pointers; the job
+  structs (whose `lastRun` mutates as jobs fire) were shared across model
+  instances. Replaced with a `defaultScheduledJobs()` factory.
+
+**Polish**
+
+- The per-message debug-log preamble in `Update()` ran `reflect.TypeOf`
+  comparisons on every message regardless of log level; it is now gated
+  behind `log.GetLevel()` and uses a type switch.
+- Cache invalidation on list refresh was O(n²); now a single pass over the
+  cache with an ID map.
+- The error-help widget was constructed on every `View()` render; now only
+  on the error path.
+- New `view_render_test.go` smoke-tests the top-level `View()` output per
+  focus mode (table, error, incident tabs, log, cluster select) and the
+  Enter/Esc/Down key flows.
+
+**Lazy-enricher staleness refresh**
+
+Since list-wide prefetch was removed (plan 055), the lazy enricher fetches
+each incident once and never refreshes it — notes and alerts added after the
+first fetch don't appear until a status change invalidates the cache. The
+enricher now re-fetches incidents whose cached data is older than five
+minutes, at the same pace (one incident per 3s `lazyEnrichMsg` tick,
+cursor-spiral priority).
+
+## Key design decisions
+
+- **Extend the existing enricher instead of adding a prefetch queue.** An
+  earlier draft added a parallel per-tick prefetch engine; it was rejected
+  because background alerts responses cascade into OCM/backplane/prior-alert
+  fetches via the `selectedIncident == nil` branch of `gotIncidentAlertsMsg`,
+  and 6 req/s of background traffic consumes most of the client rate
+  limiter's 10 req/s budget. Re-using the 1-per-3s enricher keeps the
+  cascade and pacing semantics exactly as they are today — stale incidents
+  simply become eligible again.
+- **`lastFetched` now means "time of last data write".** It was only set by
+  the details handler, so alerts/notes-only entries looked infinitely stale.
+  All three `gotIncident*Msg` handlers now stamp it, which also makes a
+  stale re-fetch self-limiting: the first response to land resets the TTL.
+- **A dispatch-cooldown map is required, not optional.** Failed notes/alerts
+  fetches never write the cache, so an incident with a persistently failing
+  fetch stays "incomplete" forever; without `enrichDispatchedAt` (30s
+  cooldown per incident) it would be re-dispatched every 3 seconds. A
+  single-slot guard is insufficient — two failing incidents would
+  round-robin around it.
+
+## Files
+
+- `pkg/tui/commands.go` — `UserIsOnCall`, `removeCommentsFromBytes`,
+  `login`, `openBrowserCmd`, `requeueAfterDelay`, `needsEnrichment`,
+  `pickNextEnrichment`, TTL/cooldown constants
+- `pkg/tui/tui.go` — requeue sites, silence guard, debug preamble, cache
+  invalidation single pass + dispatch-record pruning, `lastFetched` stamps
+  in notes/alerts handlers
+- `pkg/tui/model.go` — `defaultScheduledJobs()` factory,
+  `enrichDispatchedAt` field + constructor init
+- `pkg/tui/views.go` — error-help construction moved to error branch
+- `pkg/tui/view_render_test.go` — new focus-mode render smoke tests
+- `pkg/tui/lazy_enrich_test.go`, `pkg/tui/commands_test.go`,
+  `pkg/tui/update_test.go` — new and updated tests
+- `README.md` — background data freshness feature bullet
+
+## Post-mortem / Lessons Learned
+
+(To be filled after merge)

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -32,7 +32,18 @@ import (
 const (
 	watcherQueryTimeout     = 60 * time.Second
 	watcherSynthesisTimeout = 30 * time.Second
+
+	// requeueDelay is how long to wait before re-queuing a message that is
+	// waiting on data to arrive (e.g. login waiting for alerts). Without a
+	// delay the requeue becomes a hot loop that saturates the Update cycle
+	requeueDelay = 250 * time.Millisecond
 )
+
+// requeueAfterDelay re-sends msg after requeueDelay, yielding the Update
+// loop instead of spinning on an immediate requeue
+func requeueAfterDelay(msg tea.Msg) tea.Cmd {
+	return tea.Tick(requeueDelay, func(time.Time) tea.Msg { return msg })
+}
 
 // This file contains the commands that are used in the Bubble Tea update function.
 // These commands are functions that return a tea.Cmd, which performs I/O with
@@ -329,6 +340,31 @@ type PollIncidentsMsg struct{}
 
 type lazyEnrichMsg struct{}
 
+const (
+	// incidentCacheTTL is how long fully-loaded incident data stays fresh
+	// before the lazy enricher re-fetches it, so notes and alerts added
+	// since the last fetch appear without a manual refresh
+	incidentCacheTTL = 5 * time.Minute
+
+	// enrichDispatchCooldown bounds how often the lazy enricher may
+	// re-dispatch fetches for the same incident while responses are still
+	// in flight or persistently failing (failed fetches never write the
+	// cache, so the entry would otherwise be re-picked every cycle)
+	enrichDispatchCooldown = 30 * time.Second
+)
+
+// needsEnrichment reports whether an incident's cached data is missing,
+// incomplete, or older than incidentCacheTTL.
+func needsEnrichment(c *cachedIncidentData, now time.Time) bool {
+	if c == nil {
+		return true
+	}
+	if !c.dataLoaded || !c.notesLoaded || !c.alertsLoaded {
+		return true
+	}
+	return now.Sub(c.lastFetched) > incidentCacheTTL
+}
+
 func pickNextEnrichment(m *model) tea.Cmd {
 	if m.config == nil {
 		return nil
@@ -341,6 +377,7 @@ func pickNextEnrichment(m *model) tea.Cmd {
 
 	cursor := m.table.Cursor()
 	n := len(rows)
+	now := time.Now()
 
 	for offset := 0; offset < n; offset++ {
 		var indices []int
@@ -366,9 +403,16 @@ func pickNextEnrichment(m *model) tea.Cmd {
 				continue
 			}
 			incidentID := row[1]
-			if _, exists := m.incidentCache[incidentID]; exists {
+			if !needsEnrichment(m.incidentCache[incidentID], now) {
 				continue
 			}
+			if dispatched, ok := m.enrichDispatchedAt[incidentID]; ok && now.Sub(dispatched) < enrichDispatchCooldown {
+				continue
+			}
+			if m.enrichDispatchedAt == nil {
+				m.enrichDispatchedAt = make(map[string]time.Time)
+			}
+			m.enrichDispatchedAt[incidentID] = now
 			return func() tea.Msg { return getIncidentMsg(incidentID) }
 		}
 	}
@@ -519,11 +563,12 @@ func AcknowledgedByUser(i pagerduty.Incident, id string) bool {
 
 // UserIsOnCall returns true if the current time is between any of the current user's pagerduty.OnCalls in the next six hours
 func UserIsOnCall(p *pd.Config, id string) bool {
-	var timeLayout = "2006-01-02T15:04:05Z"
+	// The PagerDuty API requires ISO8601/RFC3339 timestamps for Since/Until
+	now := time.Now()
 	opts := pagerduty.ListOnCallOptions{
 		UserIDs: []string{id},
-		Since:   time.Now().String(),
-		Until:   time.Now().Add(time.Hour * 6).String(),
+		Since:   now.Format(time.RFC3339),
+		Until:   now.Add(time.Hour * 6).Format(time.RFC3339),
 	}
 
 	onCalls, err := pd.GetUserOnCalls(p.Client, id, opts)
@@ -535,18 +580,19 @@ func UserIsOnCall(p *pd.Config, id string) bool {
 	for _, o := range onCalls {
 		log.Debug("tui.UserIsOnCall()", "on-call", o)
 
-		start, err := time.Parse(timeLayout, o.Start)
+		// A malformed entry must not hide valid on-call shifts; skip it
+		start, err := time.Parse(time.RFC3339, o.Start)
 		if err != nil {
 			log.Debug("tui.UserIsOnCall()", "msg", "error parsing on-call start time", "error", err)
-			return false
+			continue
 		}
-		end, err := time.Parse(timeLayout, o.End)
+		end, err := time.Parse(time.RFC3339, o.End)
 		if err != nil {
 			log.Debug("tui.UserIsOnCall()", "msg", "error parsing on-call end time", "error", err)
-			return false
+			continue
 		}
 
-		if start.Before(time.Now()) && end.After(time.Now()) {
+		if start.Before(now) && end.After(now) {
 			return true
 		}
 	}
@@ -604,27 +650,31 @@ type openBrowserMsg string
 type openSOPMsg string
 
 func openBrowserCmd(browser []string, url string) tea.Cmd {
-	log.Debug("tui.openBrowserCmd()", "msg", "opening browser", "browser", browser, "url", url)
+	// All process work happens inside the returned command so the Update
+	// loop is never blocked by exec setup or a slow Start()
+	return func() tea.Msg {
+		log.Debug("tui.openBrowserCmd()", "msg", "opening browser", "browser", browser, "url", url)
 
-	var args []string
-	args = append(args, browser[1:]...)
-	args = append(args, url)
+		var args []string
+		args = append(args, browser[1:]...)
+		args = append(args, url)
 
-	c := exec.Command(browser[0], args...)
-	log.Debug("tui.openBrowserCmd()", "command", c.String())
+		c := exec.Command(browser[0], args...)
+		log.Debug("tui.openBrowserCmd()", "command", c.String())
 
-	err := c.Start()
-	if err != nil {
-		log.Debug("tui.openBrowserCmd()", "error", err)
-		return func() tea.Msg {
+		err := c.Start()
+		if err != nil {
+			log.Debug("tui.openBrowserCmd()", "error", err)
 			return browserFinishedMsg{err}
 		}
-	}
 
-	// Browser opened successfully - don't wait for it or check stderr
-	// Browsers write warnings/info to stderr that aren't actual errors
+		// Browser opened successfully - don't wait for it or check stderr
+		// Browsers write warnings/info to stderr that aren't actual errors
+		// Reap the child in the background to avoid zombies
+		go func() {
+			_ = c.Wait()
+		}()
 
-	return func() tea.Msg {
 		return browserFinishedMsg{}
 	}
 }
@@ -842,69 +892,71 @@ func extractEnvVarPairs(envFlags []string) []string {
 }
 
 func login(vars map[string]string, l launcher.ClusterLauncher, incident *pagerduty.Incident, alerts []pagerduty.IncidentAlert, notes []pagerduty.IncidentNote) tea.Cmd {
-	// The first element of Terminal is the command to be executed, followed by args, in order
-	// This handles if folks use, eg: flatpak run <some package> as a terminal.
-	command := l.BuildLoginCommand(vars)
+	// All process work happens inside the returned command so the Update
+	// loop is never blocked by command construction or a slow Start().
+	// The arguments are snapshots (map, launcher value, pointer, slices),
+	// so deferring execution is safe.
+	return func() tea.Msg {
+		// The first element of Terminal is the command to be executed, followed by args, in order
+		// This handles if folks use, eg: flatpak run <some package> as a terminal.
+		command := l.BuildLoginCommand(vars)
 
-	// Build individual PAGERDUTY_* environment variables filtered to the selected cluster
-	clusterID := vars["%%CLUSTER_ID%%"]
-	envFlags := buildPagerDutyEnvVars(incident, alerts, notes, clusterID)
+		// Build individual PAGERDUTY_* environment variables filtered to the selected cluster
+		clusterID := vars["%%CLUSTER_ID%%"]
+		envFlags := buildPagerDutyEnvVars(incident, alerts, notes, clusterID)
 
-	// Determine the correct env var passing mechanism based on the command flow:
-	// 1. ocm-container flow: use -e flags (they become podman -e flags)
-	// 2. Non-ocm-container in toolbox: use --env= flags on flatpak-spawn
-	// 3. Non-ocm-container, not in toolbox: set on exec.Cmd.Env
+		// Determine the correct env var passing mechanism based on the command flow:
+		// 1. ocm-container flow: use -e flags (they become podman -e flags)
+		// 2. Non-ocm-container in toolbox: use --env= flags on flatpak-spawn
+		// 3. Non-ocm-container, not in toolbox: set on exec.Cmd.Env
 
-	var finalCommand []string
-	var processEnvVars []string // Only used for the exec.Cmd.Env case
+		var finalCommand []string
+		var processEnvVars []string // Only used for the exec.Cmd.Env case
 
-	if commandContainsOCMContainer(command) {
-		// ocm-container flow: insert -e flags into the command for ocm-container
-		finalCommand = insertOCMContainerEnvFlags(command, envFlags)
-		log.Debug("tui.login(): ocm-container flow", "finalCommand", finalCommand)
-	} else if l.IsToolbox() {
-		// Non-ocm-container in toolbox: use --env= flags on flatpak-spawn
-		// so that the host process launched via flatpak-spawn inherits them
-		toolboxFlags := l.ToolboxEnvFlags(envFlags)
-		finalCommand = launcher.InsertToolboxEnvFlags(command, toolboxFlags)
-		log.Debug("tui.login(): toolbox non-ocm-container flow", "toolboxFlags", toolboxFlags, "finalCommand", finalCommand)
-	} else {
-		// Non-ocm-container, not in toolbox: set env vars on the process directly
-		finalCommand = command
-		processEnvVars = extractEnvVarPairs(envFlags)
-		log.Debug("tui.login(): direct process env flow", "processEnvVars", processEnvVars, "finalCommand", finalCommand)
-	}
+		if commandContainsOCMContainer(command) {
+			// ocm-container flow: insert -e flags into the command for ocm-container
+			finalCommand = insertOCMContainerEnvFlags(command, envFlags)
+			log.Debug("tui.login(): ocm-container flow", "finalCommand", finalCommand)
+		} else if l.IsToolbox() {
+			// Non-ocm-container in toolbox: use --env= flags on flatpak-spawn
+			// so that the host process launched via flatpak-spawn inherits them
+			toolboxFlags := l.ToolboxEnvFlags(envFlags)
+			finalCommand = launcher.InsertToolboxEnvFlags(command, toolboxFlags)
+			log.Debug("tui.login(): toolbox non-ocm-container flow", "toolboxFlags", toolboxFlags, "finalCommand", finalCommand)
+		} else {
+			// Non-ocm-container, not in toolbox: set env vars on the process directly
+			finalCommand = command
+			processEnvVars = extractEnvVarPairs(envFlags)
+			log.Debug("tui.login(): direct process env flow", "processEnvVars", processEnvVars, "finalCommand", finalCommand)
+		}
 
-	c := exec.Command(finalCommand[0], finalCommand[1:]...)
+		c := exec.Command(finalCommand[0], finalCommand[1:]...)
 
-	// For the non-ocm-container, non-toolbox case, set env vars on the process
-	if len(processEnvVars) > 0 {
-		c.Env = append(os.Environ(), processEnvVars...)
-	}
+		// For the non-ocm-container, non-toolbox case, set env vars on the process
+		if len(processEnvVars) > 0 {
+			c.Env = append(os.Environ(), processEnvVars...)
+		}
 
-	log.Debug("tui.login(): original command", "command", command)
-	log.Debug("tui.login(): env flags", "envFlags", envFlags)
-	log.Debug("tui.login(): final command", "finalCommand", finalCommand)
-	log.Debug("tui.login()", "command", c.String())
+		log.Debug("tui.login(): original command", "command", command)
+		log.Debug("tui.login(): env flags", "envFlags", envFlags)
+		log.Debug("tui.login(): final command", "finalCommand", finalCommand)
+		log.Debug("tui.login()", "command", c.String())
 
-	startCmdErr := c.Start()
-	if startCmdErr != nil {
-		log.Error("tui.login()", "error", startCmdErr)
-		return func() tea.Msg {
+		startCmdErr := c.Start()
+		if startCmdErr != nil {
+			log.Error("tui.login()", "error", startCmdErr)
 			return loginFinishedMsg{startCmdErr}
 		}
-	}
 
-	// Reap the child process in background to avoid zombies.
-	// Don't block — return immediately so srepd stays responsive.
-	go func() {
-		err := c.Wait()
-		if err != nil {
-			log.Debug("tui.login(): terminal process exited", "error", err)
-		}
-	}()
+		// Reap the child process in background to avoid zombies.
+		// Don't block — return immediately so srepd stays responsive.
+		go func() {
+			err := c.Wait()
+			if err != nil {
+				log.Debug("tui.login(): terminal process exited", "error", err)
+			}
+		}()
 
-	return func() tea.Msg {
 		return loginFinishedMsg{}
 	}
 }
@@ -1060,21 +1112,25 @@ func addNoteToIncident(p *pd.Config, incident *pagerduty.Incident, file *os.File
 	}
 }
 
-// removeCommentsFromBytes removes any lines beginning with any of the provided prefixes []byte and returns a string.
+// removeCommentsFromBytes removes any lines beginning with any of the provided
+// prefixes and returns the remaining lines joined with newlines.
 func removeCommentsFromBytes(b []byte, prefixes ...string) string {
-	var content strings.Builder
+	var kept []string
 
-	lines := strings.Split(string(b[:]), "\n")
-
-	for _, c := range lines {
-		for _, a := range prefixes {
-			if !strings.HasPrefix(c, a) {
-				content.WriteString(c)
+	for _, line := range strings.Split(string(b), "\n") {
+		isComment := false
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(line, prefix) {
+				isComment = true
+				break
 			}
+		}
+		if !isComment {
+			kept = append(kept, line)
 		}
 	}
 
-	return content.String()
+	return strings.TrimSpace(strings.Join(kept, "\n"))
 }
 
 // getDetailFieldFromAlert safely extracts a string field from alert body details.

--- a/pkg/tui/commands_test.go
+++ b/pkg/tui/commands_test.go
@@ -14,9 +14,11 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 	"github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/clcollins/srepd/pkg/launcher"
 	"github.com/clcollins/srepd/pkg/pd"
 	"github.com/clcollins/srepd/pkg/rand"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExecErr_Error(t *testing.T) {
@@ -631,6 +633,105 @@ func TestOpenBrowserCmd(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestOpenBrowserCmd_DoesNotStartUntilInvoked(t *testing.T) {
+	// Process work must happen inside the returned tea.Cmd, not at
+	// command-construction time (which runs inside the Update loop)
+	target := filepath.Join(t.TempDir(), "started")
+
+	cmd := openBrowserCmd([]string{"touch"}, target)
+
+	// Start() is asynchronous, so a single immediate stat would race the
+	// child process; the file must never appear until the command runs
+	require.Never(t, func() bool {
+		_, err := os.Stat(target)
+		return err == nil
+	}, 500*time.Millisecond, 25*time.Millisecond, "process must not start before the command is invoked")
+
+	msg, ok := cmd().(browserFinishedMsg)
+	require.True(t, ok)
+	require.NoError(t, msg.err)
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(target)
+		return err == nil
+	}, 2*time.Second, 10*time.Millisecond, "process should run once the command is invoked")
+}
+
+func TestLogin_DoesNotStartUntilInvoked(t *testing.T) {
+	// Same contract as openBrowserCmd: the terminal process must launch
+	// when the tea.Cmd runs, not when login() constructs it inside Update
+	target := filepath.Join(t.TempDir(), "started")
+
+	l, err := launcher.NewClusterLauncherWithToolbox("touch", "%%CLUSTER_ID%%", "false", func() bool { return false })
+	require.NoError(t, err)
+
+	vars := map[string]string{"%%CLUSTER_ID%%": target}
+	cmd := login(vars, l, nil, nil, nil)
+
+	// Start() is asynchronous, so a single immediate stat would race the
+	// child process; the file must never appear until the command runs
+	require.Never(t, func() bool {
+		_, err := os.Stat(target)
+		return err == nil
+	}, 500*time.Millisecond, 25*time.Millisecond, "process must not start before the command is invoked")
+
+	msg, ok := cmd().(loginFinishedMsg)
+	require.True(t, ok)
+	require.NoError(t, msg.err)
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(target)
+		return err == nil
+	}, 2*time.Second, 10*time.Millisecond, "process should run once the command is invoked")
+}
+
+func TestRequeueAfterDelay_ReturnsOriginalMessage(t *testing.T) {
+	// The helper paces requeues via tea.Tick; the actual delay is in
+	// (0, requeueDelay] because tea.Tick aligns to interval boundaries,
+	// so only the returned message is asserted, never elapsed time
+	cmd := requeueAfterDelay(loginMsg("x"))
+	require.NotNil(t, cmd)
+	assert.Equal(t, loginMsg("x"), cmd())
+}
+
+func TestLoginMsg_RequeuesWhenNoAlerts(t *testing.T) {
+	m := createTestModel()
+	m.selectedIncident = &pagerduty.Incident{APIObject: pagerduty.APIObject{ID: "Q1"}}
+	m.selectedIncidentAlerts = nil
+
+	_, cmd := m.Update(loginMsg("login"))
+
+	require.NotNil(t, cmd)
+	assert.Equal(t, loginMsg("sender: loginMsg; requeue"), cmd())
+}
+
+func TestRosaBoundaryLoginMsg_RequeuesWhenNoAlerts(t *testing.T) {
+	m := createTestModel()
+	m.selectedIncident = &pagerduty.Incident{APIObject: pagerduty.APIObject{ID: "Q1"}}
+	m.selectedIncidentAlerts = nil
+
+	_, cmd := m.Update(rosaBoundaryLoginMsg("login"))
+
+	require.NotNil(t, cmd)
+	assert.Equal(t, rosaBoundaryLoginMsg("requeue"), cmd())
+}
+
+func TestWaitForSelectedIncidentThenDoMsg_RequeuesWhileWaiting(t *testing.T) {
+	m := createTestModel()
+	m.selectedIncident = nil
+	// Keep the incident view open so the no-incident abort branch is not taken
+	m.viewingIncident = true
+
+	msg := waitForSelectedIncidentThenDoMsg{
+		action: func() tea.Msg { return nil },
+		msg:    "test-action",
+	}
+	_, cmd := m.Update(msg)
+
+	require.NotNil(t, cmd)
+	requeued, ok := cmd().(waitForSelectedIncidentThenDoMsg)
+	require.True(t, ok, "the same message type should be requeued")
+	assert.Equal(t, msg.msg, requeued.msg)
 }
 
 // envVarMap converts a buildPagerDutyEnvVars result slice into a map of
@@ -1641,6 +1742,54 @@ func TestUserIsOnCall_MultipleOnCalls(t *testing.T) {
 	assert.True(t, result, "user should be on-call when at least one on-call window covers current time")
 }
 
+func TestUserIsOnCall_SinceUntilAreRFC3339(t *testing.T) {
+	// The PagerDuty API requires ISO8601/RFC3339 for Since/Until. Go's
+	// time.Time.String() format is not accepted and produces queries with
+	// invalid time ranges.
+	mockClient := &pd.MockPagerDutyClient{}
+	config := &pd.Config{Client: mockClient}
+
+	UserIsOnCall(config, "USER1")
+
+	require.Len(t, mockClient.RecordedListOnCallOpts, 1)
+	opts := mockClient.RecordedListOnCallOpts[0]
+
+	since, err := time.Parse(time.RFC3339, opts.Since)
+	require.NoError(t, err, "Since must be RFC3339, got %q", opts.Since)
+	until, err := time.Parse(time.RFC3339, opts.Until)
+	require.NoError(t, err, "Until must be RFC3339, got %q", opts.Until)
+	assert.Equal(t, 6*time.Hour, until.Sub(since), "on-call window should span six hours")
+	assert.Equal(t, []string{"USER1"}, opts.UserIDs)
+}
+
+func TestUserIsOnCall_SkipsMalformedEntry(t *testing.T) {
+	// A malformed on-call entry must not hide a valid, currently-active
+	// shift that follows it.
+	now := time.Now().UTC()
+	mockClient := &pd.MockPagerDutyClient{
+		ListOnCallsResponses: []pagerduty.ListOnCallsResponse{
+			{
+				OnCalls: []pagerduty.OnCall{
+					{
+						User:  pagerduty.User{APIObject: pagerduty.APIObject{ID: "USER1"}},
+						Start: "not-a-timestamp",
+						End:   "also-not-a-timestamp",
+					},
+					{
+						User:  pagerduty.User{APIObject: pagerduty.APIObject{ID: "USER1"}},
+						Start: now.Add(-1 * time.Hour).Format(time.RFC3339),
+						End:   now.Add(5 * time.Hour).Format(time.RFC3339),
+					},
+				},
+			},
+		},
+	}
+	config := &pd.Config{Client: mockClient}
+
+	result := UserIsOnCall(config, "USER1")
+	assert.True(t, result, "valid active shift after a malformed entry should still count")
+}
+
 func TestRemoveCommentsFromBytes_Basic(t *testing.T) {
 	input := []byte("line 1\n# comment\nline 2\n")
 	result := removeCommentsFromBytes(input, "#")
@@ -1671,17 +1820,19 @@ func TestRemoveCommentsFromBytes_EmptyInput(t *testing.T) {
 }
 
 func TestRemoveCommentsFromBytes_MultiplePrefixes(t *testing.T) {
-	// Note: with multiple prefixes, lines matching one prefix are still
-	// written by the inner loop iteration of the non-matching prefix.
-	// A line starting with "#" will NOT be written for the "#" prefix,
-	// but WILL be written for the "//" prefix. This is the actual behavior.
-	// Test with a single prefix to avoid this edge case, which is consistent
-	// with how the function is used in practice (always a single "#" prefix).
-	input := []byte("line 1\n# hash comment\nline 2\n")
+	// Lines matching ANY prefix are removed, and kept lines appear exactly
+	// once regardless of how many prefixes are provided
+	input := []byte("line 1\n# hash comment\n// slash comment\nline 2\n")
+	result := removeCommentsFromBytes(input, "#", "//")
+	assert.Equal(t, "line 1\nline 2", result)
+}
+
+func TestRemoveCommentsFromBytes_PreservesNewlines(t *testing.T) {
+	// Multi-line notes must keep their line breaks; a previous
+	// implementation concatenated all kept lines into one
+	input := []byte("first paragraph\n\nsecond paragraph\n# trailing comment")
 	result := removeCommentsFromBytes(input, "#")
-	assert.Contains(t, result, "line 1")
-	assert.Contains(t, result, "line 2")
-	assert.NotContains(t, result, "# hash")
+	assert.Equal(t, "first paragraph\n\nsecond paragraph", result)
 }
 
 func TestRemoveCommentsFromBytes_CommentInMiddle(t *testing.T) {
@@ -1690,6 +1841,31 @@ func TestRemoveCommentsFromBytes_CommentInMiddle(t *testing.T) {
 	result := removeCommentsFromBytes(input, "#")
 	assert.Contains(t, result, "line with # in middle")
 	assert.NotContains(t, result, "# actual comment")
+}
+
+func TestDefaultScheduledJobs_NotShared(t *testing.T) {
+	// Each model must get its own job structs: lastRun is mutated as jobs
+	// fire, and shared pointers would leak scheduling state across models
+	jobsA := defaultScheduledJobs()
+	jobsB := defaultScheduledJobs()
+
+	require.Equal(t, len(jobsA), len(jobsB))
+	for i := range jobsA {
+		assert.NotSame(t, jobsA[i], jobsB[i], "job %d must not be a shared pointer", i)
+	}
+
+	jobsA[1].lastRun = time.Now()
+	assert.True(t, jobsB[1].lastRun.IsZero(),
+		"updating one model's job lastRun must not affect another model's jobs")
+}
+
+func TestDefaultScheduledJobs_Frequencies(t *testing.T) {
+	jobs := defaultScheduledJobs()
+
+	require.Len(t, jobs, 3)
+	assert.Equal(t, 15*time.Second, jobs[0].frequency, "incident poll")
+	assert.Equal(t, 3*time.Second, jobs[1].frequency, "lazy enrichment")
+	assert.Equal(t, time.Hour, jobs[2].frequency, "update check")
 }
 
 func TestRunScheduledJobs_NoJobsDue(t *testing.T) {

--- a/pkg/tui/lazy_enrich_test.go
+++ b/pkg/tui/lazy_enrich_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"testing"
+	"time"
 
 	"github.com/charmbracelet/bubbles/table"
 	"github.com/clcollins/srepd/pkg/pd"
@@ -25,18 +26,120 @@ func makeTableWithRows(incidentIDs []string) table.Model {
 	return t
 }
 
-func TestPickNextEnrichment_AllCached(t *testing.T) {
+// completeEntry returns a fully-loaded cache entry fetched at the given time.
+func completeEntry(lastFetched time.Time) *cachedIncidentData {
+	return &cachedIncidentData{
+		dataLoaded:   true,
+		notesLoaded:  true,
+		alertsLoaded: true,
+		lastFetched:  lastFetched,
+	}
+}
+
+func TestNeedsEnrichment(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name     string
+		entry    *cachedIncidentData
+		expected bool
+	}{
+		{"nil entry needs enrichment", nil, true},
+		{"missing details needs enrichment", &cachedIncidentData{notesLoaded: true, alertsLoaded: true, lastFetched: now}, true},
+		{"missing notes needs enrichment", &cachedIncidentData{dataLoaded: true, alertsLoaded: true, lastFetched: now}, true},
+		{"missing alerts needs enrichment", &cachedIncidentData{dataLoaded: true, notesLoaded: true, lastFetched: now}, true},
+		{"complete and fresh does not need enrichment", completeEntry(now), false},
+		{"complete but stale needs enrichment", completeEntry(now.Add(-incidentCacheTTL - time.Minute)), true},
+		{"complete with zero lastFetched needs enrichment", completeEntry(time.Time{}), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, needsEnrichment(tt.entry, now))
+		})
+	}
+}
+
+func TestPickNextEnrichment_AllCachedAndFresh(t *testing.T) {
+	now := time.Now()
 	m := model{
-		table: makeTableWithRows([]string{"INC1", "INC2", "INC3"}),
+		table:  makeTableWithRows([]string{"INC1", "INC2", "INC3"}),
+		config: &pd.Config{Client: &pd.MockPagerDutyClient{}},
 		incidentCache: map[string]*cachedIncidentData{
-			"INC1": {dataLoaded: true, notesLoaded: true, alertsLoaded: true},
-			"INC2": {dataLoaded: true, notesLoaded: true, alertsLoaded: true},
-			"INC3": {dataLoaded: true, notesLoaded: true, alertsLoaded: true},
+			"INC1": completeEntry(now),
+			"INC2": completeEntry(now),
+			"INC3": completeEntry(now),
 		},
 	}
 
 	cmd := pickNextEnrichment(&m)
-	assert.Nil(t, cmd, "should return nil when all incidents are cached")
+	assert.Nil(t, cmd, "should return nil when all incidents are cached and fresh")
+}
+
+func TestPickNextEnrichment_PicksStaleIncident(t *testing.T) {
+	m := model{
+		table:  makeTableWithRows([]string{"INC1"}),
+		config: &pd.Config{Client: &pd.MockPagerDutyClient{}},
+		incidentCache: map[string]*cachedIncidentData{
+			"INC1": completeEntry(time.Now().Add(-incidentCacheTTL - time.Minute)),
+		},
+	}
+
+	cmd := pickNextEnrichment(&m)
+	require.NotNil(t, cmd, "a stale incident should be re-enriched")
+	assert.Equal(t, "INC1", string(cmd().(getIncidentMsg)))
+}
+
+func TestPickNextEnrichment_RespectsDispatchCooldown(t *testing.T) {
+	stale := completeEntry(time.Now().Add(-incidentCacheTTL - time.Minute))
+
+	t.Run("recently dispatched incident is skipped", func(t *testing.T) {
+		m := model{
+			table:         makeTableWithRows([]string{"INC1", "INC2"}),
+			config:        &pd.Config{Client: &pd.MockPagerDutyClient{}},
+			incidentCache: map[string]*cachedIncidentData{"INC1": stale},
+			enrichDispatchedAt: map[string]time.Time{
+				"INC1": time.Now(),
+			},
+		}
+
+		cmd := pickNextEnrichment(&m)
+		require.NotNil(t, cmd)
+		assert.Equal(t, "INC2", string(cmd().(getIncidentMsg)),
+			"a stale incident dispatched within the cooldown must not be re-dispatched")
+	})
+
+	t.Run("incident past the cooldown is eligible again", func(t *testing.T) {
+		m := model{
+			table:         makeTableWithRows([]string{"INC1"}),
+			config:        &pd.Config{Client: &pd.MockPagerDutyClient{}},
+			incidentCache: map[string]*cachedIncidentData{"INC1": stale},
+			enrichDispatchedAt: map[string]time.Time{
+				"INC1": time.Now().Add(-enrichDispatchCooldown - time.Second),
+			},
+		}
+
+		cmd := pickNextEnrichment(&m)
+		require.NotNil(t, cmd)
+		assert.Equal(t, "INC1", string(cmd().(getIncidentMsg)))
+	})
+}
+
+func TestPickNextEnrichment_RecordsDispatch(t *testing.T) {
+	m := model{
+		table:         makeTableWithRows([]string{"INC1"}),
+		config:        &pd.Config{Client: &pd.MockPagerDutyClient{}},
+		incidentCache: make(map[string]*cachedIncidentData),
+	}
+
+	cmd := pickNextEnrichment(&m)
+	require.NotNil(t, cmd)
+	assert.WithinDuration(t, time.Now(), m.enrichDispatchedAt["INC1"], time.Second,
+		"a dispatch must be recorded for the picked incident")
+
+	// A permanently failing fetch never writes the cache; the recorded
+	// dispatch must prevent an immediate re-pick storm
+	assert.Nil(t, pickNextEnrichment(&m), "the same incident must not be re-picked within the cooldown")
 }
 
 func TestPickNextEnrichment_HighlightedFirst(t *testing.T) {
@@ -63,7 +166,7 @@ func TestPickNextEnrichment_SpiralOrder(t *testing.T) {
 	tbl.SetCursor(2)
 
 	cache := map[string]*cachedIncidentData{
-		"INC2": {dataLoaded: true, notesLoaded: true, alertsLoaded: true},
+		"INC2": completeEntry(time.Now()),
 	}
 
 	m := model{
@@ -78,7 +181,7 @@ func TestPickNextEnrichment_SpiralOrder(t *testing.T) {
 	enrichMsg := msg.(getIncidentMsg)
 	assert.Equal(t, "INC3", string(enrichMsg), "should enrich highlight+1 after highlight is cached")
 
-	cache["INC3"] = &cachedIncidentData{dataLoaded: true, notesLoaded: true, alertsLoaded: true}
+	cache["INC3"] = completeEntry(time.Now())
 	cmd = pickNextEnrichment(&m)
 	require.NotNil(t, cmd)
 	msg = cmd()
@@ -86,7 +189,10 @@ func TestPickNextEnrichment_SpiralOrder(t *testing.T) {
 	assert.Equal(t, "INC1", string(enrichMsg), "should enrich highlight-1 next")
 }
 
-func TestPickNextEnrichment_SkipsPartialCache(t *testing.T) {
+func TestPickNextEnrichment_PicksIncompleteCache(t *testing.T) {
+	// A partial entry used to mean "fetch already in progress" and was
+	// skipped forever if the missing fetches failed; incomplete entries are
+	// now eligible, with the dispatch cooldown preventing re-pick storms
 	tbl := makeTableWithRows([]string{"INC1", "INC2"})
 	tbl.SetCursor(0)
 
@@ -102,7 +208,7 @@ func TestPickNextEnrichment_SkipsPartialCache(t *testing.T) {
 	require.NotNil(t, cmd)
 	msg := cmd()
 	enrichMsg := msg.(getIncidentMsg)
-	assert.Equal(t, "INC2", string(enrichMsg), "should skip partially cached incident (fetch already in progress)")
+	assert.Equal(t, "INC1", string(enrichMsg), "an incomplete cache entry should be re-enriched")
 }
 
 func TestPickNextEnrichment_EmptyTable(t *testing.T) {

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -47,19 +47,24 @@ type confirmActionState struct {
 	action tea.Cmd // Command to execute on 'y'
 }
 
-var initialScheduledJobs = []*scheduledJob{
-	{
-		jobMsg:    func() tea.Msg { return PollIncidentsMsg{} },
-		frequency: time.Second * 15,
-	},
-	{
-		jobMsg:    func() tea.Msg { return lazyEnrichMsg{} },
-		frequency: 3 * time.Second,
-	},
-	{
-		jobMsg:    checkForUpdate(false, ""),
-		frequency: time.Hour,
-	},
+// defaultScheduledJobs returns a fresh set of scheduled jobs. Each model gets
+// its own copies: the job structs are mutated (lastRun) as they fire, so
+// sharing pointers across models would leak state between instances.
+func defaultScheduledJobs() []*scheduledJob {
+	return []*scheduledJob{
+		{
+			jobMsg:    func() tea.Msg { return PollIncidentsMsg{} },
+			frequency: time.Second * 15,
+		},
+		{
+			jobMsg:    func() tea.Msg { return lazyEnrichMsg{} },
+			frequency: 3 * time.Second,
+		},
+		{
+			jobMsg:    checkForUpdate(false, ""),
+			frequency: time.Hour,
+		},
+	}
 }
 
 type model struct {
@@ -100,6 +105,11 @@ type model struct {
 
 	// Incident data cache - stores fetched data for reuse and pre-fetching
 	incidentCache map[string]*cachedIncidentData
+
+	// enrichDispatchedAt records when the lazy enricher last dispatched a
+	// fetch for each incident, preventing re-dispatch storms for slow or
+	// persistently failing fetches (whose responses never write the cache)
+	enrichDispatchedAt map[string]time.Time
 
 	scheduledJobs []*scheduledJob
 
@@ -343,7 +353,8 @@ func InitialModel(
 		apiInProgress:         false,
 		status:                "",
 		incidentCache:         make(map[string]*cachedIncidentData),
-		scheduledJobs:         append([]*scheduledJob{}, initialScheduledJobs...),
+		enrichDispatchedAt:    make(map[string]time.Time),
+		scheduledJobs:         defaultScheduledJobs(),
 		autoRefresh:           true,
 		showLowUrgency:        true,
 		ocmClient:             ocmClient,
@@ -464,7 +475,8 @@ func InitialModelWithConfig(
 		apiInProgress:         false,
 		status:                "",
 		incidentCache:         make(map[string]*cachedIncidentData),
-		scheduledJobs:         append([]*scheduledJob{}, initialScheduledJobs...),
+		enrichDispatchedAt:    make(map[string]time.Time),
+		scheduledJobs:         defaultScheduledJobs(),
 		autoRefresh:           true,
 		showLowUrgency:        true,
 		devMode:               true,

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -145,32 +145,33 @@ func filterMsgContent(msg tea.Msg) tea.Msg {
 // eg, bad:
 // return m, func() tea.Msg { getIncident(m.config, msg.incident.ID) }
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	msgType := reflect.TypeOf(msg)
-	// Reduce logging for high-frequency messages to prevent I/O overhead
-	shouldLog := true
+	// Reduce logging for high-frequency messages to prevent I/O overhead.
+	// Skip the reflection and message-formatting work entirely when debug
+	// logging is disabled — this runs on every message through the loop
+	if log.GetLevel() <= log.DebugLevel {
+		shouldLog := true
 
-	// Skip logging for very frequent messages
-	switch msgType {
-	case reflect.TypeOf(TickMsg{}),
-		reflect.TypeOf(spinner.TickMsg{}),
-		reflect.TypeOf(tea.MouseMsg{}),
-		reflect.TypeOf(ocmServiceLogsMsg{}),
-		reflect.TypeOf(limitedSupportMsg{}),
-		reflect.TypeOf(clusterReportsMsg{}),
-		reflect.TypeOf(priorAlertsMsg{}),
-		reflect.TypeOf(lazyEnrichMsg{}):
-		shouldLog = false
-	}
-
-	if keyMsg, ok := msg.(tea.KeyMsg); ok && shouldLog {
-		// Skip logging for arrow keys and other navigation used in scrolling
-		if keyMsg.Type == tea.KeyUp || keyMsg.Type == tea.KeyDown {
+		// Skip logging for very frequent messages
+		switch v := msg.(type) {
+		case TickMsg,
+			spinner.TickMsg,
+			tea.MouseMsg,
+			ocmServiceLogsMsg,
+			limitedSupportMsg,
+			clusterReportsMsg,
+			priorAlertsMsg,
+			lazyEnrichMsg:
 			shouldLog = false
+		case tea.KeyMsg:
+			// Skip logging for arrow keys and other navigation used in scrolling
+			if v.Type == tea.KeyUp || v.Type == tea.KeyDown {
+				shouldLog = false
+			}
 		}
-	}
 
-	if shouldLog {
-		log.Debug("Update", msgType, filterMsgContent(msg))
+		if shouldLog {
+			log.Debug("Update", reflect.TypeOf(msg), filterMsgContent(msg))
+		}
 	}
 
 	// PRIORITY HANDLING: Process user input keys immediately, before any queued messages
@@ -778,11 +779,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			log.Debug("Update", "gotIncidentNotesMsg", "refreshing cached notes", "incident", msg.incidentID, "count", len(msg.notes))
 			cached.notes = msg.notes
 			cached.notesLoaded = true
+			cached.lastFetched = time.Now()
 		} else {
 			log.Debug("Update", "gotIncidentNotesMsg", "caching new notes", "incident", msg.incidentID, "count", len(msg.notes))
 			m.incidentCache[msg.incidentID] = &cachedIncidentData{
 				notes:       msg.notes,
 				notesLoaded: true,
+				lastFetched: time.Now(),
 			}
 		}
 
@@ -821,11 +824,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			log.Debug("Update", "gotIncidentAlertsMsg", "refreshing cached alerts", "incident", msg.incidentID, "count", len(msg.alerts))
 			cached.alerts = msg.alerts
 			cached.alertsLoaded = true
+			cached.lastFetched = time.Now()
 		} else {
 			log.Debug("Update", "gotIncidentAlertsMsg", "caching new alerts", "incident", msg.incidentID, "count", len(msg.alerts))
 			m.incidentCache[msg.incidentID] = &cachedIncidentData{
 				alerts:       msg.alerts,
 				alertsLoaded: true,
+				lastFetched:  time.Now(),
 			}
 		}
 
@@ -1026,33 +1031,34 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// Clean up cache - remove entries for incidents no longer in the list
-		incidentIDs := make(map[string]bool)
-		for _, i := range m.incidentList {
-			incidentIDs[i.ID] = true
+		// and invalidate entries whose incident changed since it was cached
+		incidentsByID := make(map[string]*pagerduty.Incident, len(m.incidentList))
+		for i := range m.incidentList {
+			incidentsByID[m.incidentList[i].ID] = &m.incidentList[i]
 		}
-		for id := range m.incidentCache {
-			if incidentIDs[id] {
-				// Incident still exists - mark cache as potentially stale
-				// Find incident in new list and check if LastStatusChangeAt differs
-				for _, newIncident := range m.incidentList {
-					if newIncident.ID == id {
-						if cached, exists := m.incidentCache[id]; exists {
-							// Compare timestamps to detect changes
-							if cached.incident != nil &&
-								cached.incident.LastStatusChangeAt != newIncident.LastStatusChangeAt {
-								// Incident changed - invalidate cached details
-								log.Debug("Update", "updatedIncidentListMsg", "invalidating cache for updated incident", "id", id)
-								delete(m.incidentCache, id)
-							}
-						}
-						break
-					}
-				}
-			} else {
+		for id, cached := range m.incidentCache {
+			newIncident, exists := incidentsByID[id]
+			if !exists {
 				// Incident no longer in list - remove from cache and OCM data
 				delete(m.incidentCache, id)
 				m.clearOCMCacheForIncident(id)
 				log.Debug("Update", "updatedIncidentListMsg", "removing cached data for incident no longer in list", "incident", id)
+				continue
+			}
+			if cached.incident != nil &&
+				cached.incident.LastStatusChangeAt != newIncident.LastStatusChangeAt {
+				// Incident changed - invalidate cached details
+				log.Debug("Update", "updatedIncidentListMsg", "invalidating cache for updated incident", "id", id)
+				delete(m.incidentCache, id)
+			}
+		}
+
+		// Drop lazy-enrichment dispatch records for departed incidents.
+		// Swept separately from the cache: a persistently failing fetch has
+		// a dispatch record but never gets a cache entry
+		for id := range m.enrichDispatchedAt {
+			if _, exists := incidentsByID[id]; !exists {
+				delete(m.enrichDispatchedAt, id)
 			}
 		}
 
@@ -1219,7 +1225,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		if len(m.selectedIncidentAlerts) == 0 {
 			log.Debug("tui.Update()", "msg_type", reflect.TypeOf(msg), "msg", "no alerts found for incident - requeuing", "incident", m.selectedIncident.ID)
-			return m, func() tea.Msg { return loginMsg("sender: loginMsg; requeue") }
+			return m, requeueAfterDelay(loginMsg("sender: loginMsg; requeue"))
 		}
 
 		clusters := getUniqueClusters(m.selectedIncidentAlerts)
@@ -1293,7 +1299,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		if len(m.selectedIncidentAlerts) == 0 {
 			log.Debug("tui.Update()", "msg_type", reflect.TypeOf(msg), "msg", "no alerts found for incident - requeuing")
-			return m, func() tea.Msg { return rosaBoundaryLoginMsg("requeue") }
+			return m, requeueAfterDelay(rosaBoundaryLoginMsg("requeue"))
 		}
 
 		clusters := getUniqueClusters(m.selectedIncidentAlerts)
@@ -1442,10 +1448,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
-		// Re-queue the message if the selected incident is not yet available
+		// Re-queue the message if the selected incident is not yet available.
+		// The delay yields the Update loop instead of spinning on a hot requeue
 		if m.selectedIncident == nil {
 			m.setStatus("waiting for incident info...")
-			return m, func() tea.Msg { return msg }
+			return m, requeueAfterDelay(msg)
 		}
 
 		// Perform the action once the selected incident is available
@@ -1718,8 +1725,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		incidents := msg.incidents
-		if m.selectedIncident != nil {
-			incidents = append(msg.incidents, *m.selectedIncident)
+		// Only add the selected incident if it isn't already in the list,
+		// otherwise it would be silenced twice
+		if m.selectedIncident != nil && !slices.ContainsFunc(incidents, func(i pagerduty.Incident) bool {
+			return i.ID == m.selectedIncident.ID
+		}) {
+			incidents = append(incidents, *m.selectedIncident)
 		}
 
 		var cmds []tea.Cmd

--- a/pkg/tui/update_test.go
+++ b/pkg/tui/update_test.go
@@ -9,13 +9,205 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/PagerDuty/go-pagerduty"
+	"github.com/charmbracelet/log"
 	"github.com/clcollins/srepd/pkg/launcher"
 	"github.com/clcollins/srepd/pkg/pd"
 	"github.com/stretchr/testify/assert"
 )
+
+// captureLog redirects the global logger to a buffer for the duration of the
+// test and restores the previous output and level afterwards. Tests using it
+// must not run in parallel — the logger is a shared global.
+func captureLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	origLevel := log.GetLevel()
+	log.SetOutput(&buf)
+	t.Cleanup(func() {
+		log.SetOutput(os.Stderr)
+		log.SetLevel(origLevel)
+	})
+	return &buf
+}
+
+func TestUpdatedIncidentListCacheInvalidation(t *testing.T) {
+	newListModel := func() model {
+		m := createTestModel()
+		m.config = &pd.Config{
+			CurrentUser: &pagerduty.User{APIObject: pagerduty.APIObject{ID: "U123"}},
+		}
+		return m
+	}
+
+	t.Run("removes cache entries for incidents no longer in the list", func(t *testing.T) {
+		m := newListModel()
+		m.incidentCache["GONE"] = &cachedIncidentData{
+			incident: &pagerduty.Incident{APIObject: pagerduty.APIObject{ID: "GONE"}},
+		}
+
+		result, _ := m.Update(updatedIncidentListMsg{
+			incidents: []pagerduty.Incident{{APIObject: pagerduty.APIObject{ID: "Q123"}}},
+		})
+		m = result.(model)
+
+		assert.NotContains(t, m.incidentCache, "GONE")
+	})
+
+	t.Run("invalidates cache entries whose incident changed", func(t *testing.T) {
+		m := newListModel()
+		m.incidentCache["Q123"] = &cachedIncidentData{
+			incident: &pagerduty.Incident{
+				APIObject:          pagerduty.APIObject{ID: "Q123"},
+				LastStatusChangeAt: "2024-01-01T00:00:00Z",
+			},
+		}
+
+		result, _ := m.Update(updatedIncidentListMsg{
+			incidents: []pagerduty.Incident{{
+				APIObject:          pagerduty.APIObject{ID: "Q123"},
+				LastStatusChangeAt: "2024-06-01T00:00:00Z",
+			}},
+		})
+		m = result.(model)
+
+		assert.NotContains(t, m.incidentCache, "Q123",
+			"a changed LastStatusChangeAt must invalidate the cached entry")
+	})
+
+	t.Run("keeps cache entries for unchanged incidents", func(t *testing.T) {
+		m := newListModel()
+		m.incidentCache["Q123"] = &cachedIncidentData{
+			incident: &pagerduty.Incident{
+				APIObject:          pagerduty.APIObject{ID: "Q123"},
+				LastStatusChangeAt: "2024-01-01T00:00:00Z",
+			},
+		}
+
+		result, _ := m.Update(updatedIncidentListMsg{
+			incidents: []pagerduty.Incident{{
+				APIObject:          pagerduty.APIObject{ID: "Q123"},
+				LastStatusChangeAt: "2024-01-01T00:00:00Z",
+			}},
+		})
+		m = result.(model)
+
+		assert.Contains(t, m.incidentCache, "Q123")
+	})
+
+	t.Run("keeps partial cache entries without incident details", func(t *testing.T) {
+		m := newListModel()
+		// An alerts/notes-only entry has no incident and cannot be compared
+		m.incidentCache["Q123"] = &cachedIncidentData{notesLoaded: true}
+
+		result, _ := m.Update(updatedIncidentListMsg{
+			incidents: []pagerduty.Incident{{APIObject: pagerduty.APIObject{ID: "Q123"}}},
+		})
+		m = result.(model)
+
+		assert.Contains(t, m.incidentCache, "Q123")
+	})
+
+	t.Run("prunes enrichment dispatch records for departed incidents", func(t *testing.T) {
+		m := newListModel()
+		m.enrichDispatchedAt = map[string]time.Time{
+			"GONE": time.Now(),
+			"Q123": time.Now(),
+		}
+
+		result, _ := m.Update(updatedIncidentListMsg{
+			incidents: []pagerduty.Incident{{APIObject: pagerduty.APIObject{ID: "Q123"}}},
+		})
+		m = result.(model)
+
+		assert.NotContains(t, m.enrichDispatchedAt, "GONE")
+		assert.Contains(t, m.enrichDispatchedAt, "Q123")
+	})
+}
+
+func TestGotIncidentNotesMsg_SetsLastFetched(t *testing.T) {
+	t.Run("new cache entry records fetch time", func(t *testing.T) {
+		m := createTestModel()
+
+		result, _ := m.Update(gotIncidentNotesMsg{incidentID: "Q123", notes: []pagerduty.IncidentNote{}})
+		m = result.(model)
+
+		assert.False(t, m.incidentCache["Q123"].lastFetched.IsZero(),
+			"a notes-first cache entry must record when its data was fetched")
+	})
+
+	t.Run("existing cache entry fetch time advances", func(t *testing.T) {
+		m := createTestModel()
+		stale := time.Now().Add(-time.Hour)
+		m.incidentCache["Q123"] = &cachedIncidentData{lastFetched: stale}
+
+		result, _ := m.Update(gotIncidentNotesMsg{incidentID: "Q123", notes: []pagerduty.IncidentNote{}})
+		m = result.(model)
+
+		assert.True(t, m.incidentCache["Q123"].lastFetched.After(stale),
+			"refreshing notes must advance the entry's fetch time")
+	})
+}
+
+func TestGotIncidentAlertsMsg_SetsLastFetched(t *testing.T) {
+	t.Run("new cache entry records fetch time", func(t *testing.T) {
+		m := createTestModel()
+		m.config = &pd.Config{CurrentUser: &pagerduty.User{APIObject: pagerduty.APIObject{ID: "U1"}}}
+
+		result, _ := m.Update(gotIncidentAlertsMsg{incidentID: "Q123", alerts: []pagerduty.IncidentAlert{}})
+		m = result.(model)
+
+		assert.False(t, m.incidentCache["Q123"].lastFetched.IsZero(),
+			"an alerts-first cache entry must record when its data was fetched")
+	})
+
+	t.Run("existing cache entry fetch time advances", func(t *testing.T) {
+		m := createTestModel()
+		m.config = &pd.Config{CurrentUser: &pagerduty.User{APIObject: pagerduty.APIObject{ID: "U1"}}}
+		stale := time.Now().Add(-time.Hour)
+		m.incidentCache["Q123"] = &cachedIncidentData{lastFetched: stale}
+
+		result, _ := m.Update(gotIncidentAlertsMsg{incidentID: "Q123", alerts: []pagerduty.IncidentAlert{}})
+		m = result.(model)
+
+		assert.True(t, m.incidentCache["Q123"].lastFetched.After(stale),
+			"refreshing alerts must advance the entry's fetch time")
+	})
+}
+
+func TestUpdateDebugPreamble_LogsAtDebugLevel(t *testing.T) {
+	buf := captureLog(t)
+	log.SetLevel(log.DebugLevel)
+
+	m := createTestModel()
+	m.Update(updateIncidentListMsg("test"))
+
+	assert.Contains(t, buf.String(), "Update", "message flow should be logged at debug level")
+}
+
+func TestUpdateDebugPreamble_SilentAtInfoLevel(t *testing.T) {
+	buf := captureLog(t)
+	log.SetLevel(log.InfoLevel)
+
+	m := createTestModel()
+	m.Update(updateIncidentListMsg("test"))
+
+	assert.NotContains(t, buf.String(), "Update", "no per-message debug output above debug level")
+}
+
+func TestUpdateDebugPreamble_SkipsFrequentMessages(t *testing.T) {
+	buf := captureLog(t)
+	log.SetLevel(log.DebugLevel)
+
+	m := createTestModel()
+	m.Update(TickMsg{})
+
+	assert.NotContains(t, buf.String(), "Update", "high-frequency messages must not be logged")
+}
 
 func createTestTarGz(t *testing.T, filename string, content []byte) []byte {
 	t.Helper()
@@ -449,5 +641,53 @@ func TestSilenceIncidentsMsg_PerServicePolicy(t *testing.T) {
 		updated := result.(model)
 
 		assert.Contains(t, updated.status, "failed silencing")
+	})
+
+	t.Run("silenceIncidentsMsg does not silence the selected incident twice", func(t *testing.T) {
+		m := createTestModel()
+		m.config = &pd.Config{
+			Client:      &pd.MockPagerDutyClient{},
+			CurrentUser: &pagerduty.User{APIObject: pagerduty.APIObject{ID: "U1"}},
+			EscalationPolicies: map[string]*pagerduty.EscalationPolicy{
+				"SILENT_DEFAULT": {APIObject: pagerduty.APIObject{ID: "POL_DEFAULT"}, Name: "Default Silent"},
+			},
+		}
+
+		incidents := []pagerduty.Incident{
+			{APIObject: pagerduty.APIObject{ID: "Q123"}, Service: pagerduty.APIObject{ID: "SVC1"}},
+		}
+		m.selectedIncident = &incidents[0]
+
+		result, _ := m.Update(silenceIncidentsMsg{incidents: incidents})
+		updated := result.(model)
+
+		assert.Equal(t, 1, strings.Count(updated.status, "Q123"),
+			"an incident already in the message must be silenced only once")
+	})
+
+	t.Run("silenceIncidentsMsg still includes selected incident when absent", func(t *testing.T) {
+		m := createTestModel()
+		m.config = &pd.Config{
+			Client:      &pd.MockPagerDutyClient{},
+			CurrentUser: &pagerduty.User{APIObject: pagerduty.APIObject{ID: "U1"}},
+			EscalationPolicies: map[string]*pagerduty.EscalationPolicy{
+				"SILENT_DEFAULT": {APIObject: pagerduty.APIObject{ID: "POL_DEFAULT"}, Name: "Default Silent"},
+			},
+		}
+
+		incidents := []pagerduty.Incident{
+			{APIObject: pagerduty.APIObject{ID: "Q123"}, Service: pagerduty.APIObject{ID: "SVC1"}},
+		}
+		m.selectedIncident = &pagerduty.Incident{
+			APIObject: pagerduty.APIObject{ID: "Q456"},
+			Service:   pagerduty.APIObject{ID: "SVC1"},
+		}
+
+		result, _ := m.Update(silenceIncidentsMsg{incidents: incidents})
+		updated := result.(model)
+
+		assert.Contains(t, updated.status, "Q123")
+		assert.Contains(t, updated.status, "Q456",
+			"a selected incident not in the message should still be silenced")
 	})
 }

--- a/pkg/tui/view_render_test.go
+++ b/pkg/tui/view_render_test.go
@@ -1,0 +1,145 @@
+package tui
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/PagerDuty/go-pagerduty"
+	"github.com/charmbracelet/bubbles/table"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/clcollins/srepd/pkg/pd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests exercise the top-level View() rendering for each focus mode so
+// the UI a user actually sees is verifiable in unit tests: the full render
+// path runs against an in-memory model with a mocked PD client — no terminal,
+// API, or filesystem required.
+
+// sizedTestModel returns a model with a selected incident and a realistic
+// window size applied, so View() lays out like a real terminal session.
+func sizedTestModel(t *testing.T) model {
+	t.Helper()
+	m := createTestModelWithSelectedIncident()
+
+	result, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m, ok := result.(model)
+	require.True(t, ok)
+
+	// The window-size handler resets table columns; restore the incident row
+	m.table.SetRows([]table.Row{
+		{dot, "P1234567", "Test Alert Firing", "test-service"},
+	})
+	return m
+}
+
+func TestView_TableModeRendersIncidents(t *testing.T) {
+	m := sizedTestModel(t)
+
+	view := m.View()
+
+	assert.Contains(t, view, "P1234567", "incident ID should be visible in the table")
+	assert.Contains(t, view, "Test Alert Firing", "incident title should be visible in the table")
+	assert.Contains(t, view, "test-service", "service name should be visible in the table")
+}
+
+func TestView_ErrorModeRendersError(t *testing.T) {
+	m := sizedTestModel(t)
+	m.err = errors.New("something went sideways")
+
+	view := m.View()
+
+	assert.Contains(t, view, "ERROR", "error mode should show the error banner")
+	assert.Contains(t, view, "something went sideways", "error text should be rendered")
+}
+
+func TestView_IncidentModeRendersTabBar(t *testing.T) {
+	m := sizedTestModel(t)
+	m.viewingIncident = true
+	m.incidentViewer.SetContent("incident body content")
+
+	view := m.View()
+
+	assert.Contains(t, view, "Details", "tab bar should show the Details tab")
+	assert.Contains(t, view, "Notes", "tab bar should show the Notes tab")
+	assert.Contains(t, view, "incident body content", "viewer content should be rendered")
+}
+
+func TestView_LogModeRendersLogContent(t *testing.T) {
+	m := sizedTestModel(t)
+	m.viewingLog = true
+	m.logViewer.SetContent("log line alpha")
+
+	view := m.View()
+
+	assert.Contains(t, view, "log line alpha", "log viewer content should be rendered")
+}
+
+func TestView_ClusterSelectModeRendersPrompt(t *testing.T) {
+	m := sizedTestModel(t)
+	m.clusterSelectMode = true
+	m.clusterSelectPrompt = "Select cluster to log into (Enter=select, Esc=cancel):"
+	m.clusterSelectTable = table.New(
+		table.WithColumns([]table.Column{
+			{Title: "Cluster ID", Width: 40},
+			{Title: "Service", Width: 30},
+		}),
+		table.WithRows([]table.Row{{"cluster-abc", "svc-1"}, {"cluster-def", "svc-2"}}),
+	)
+
+	view := m.View()
+
+	assert.Contains(t, view, "Select cluster to log into")
+	assert.Contains(t, view, "cluster-abc")
+	assert.Contains(t, view, "cluster-def")
+}
+
+func TestView_EnterOpensIncidentView(t *testing.T) {
+	m := sizedTestModel(t)
+	m.config.Client = &pd.MockPagerDutyClient{}
+
+	result, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m, ok := result.(model)
+	require.True(t, ok)
+
+	assert.True(t, m.viewingIncident, "Enter on a highlighted row should open the incident view")
+	assert.NotNil(t, cmd, "opening an incident should trigger render + fetch commands")
+}
+
+func TestView_EscapeReturnsToTable(t *testing.T) {
+	m := sizedTestModel(t)
+	m.config.Client = &pd.MockPagerDutyClient{}
+	m.viewingIncident = true
+	m.selectedIncident = &m.incidentList[0]
+
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m, ok := result.(model)
+	require.True(t, ok)
+
+	assert.False(t, m.viewingIncident, "Escape should close the incident view")
+	view := m.View()
+	assert.Contains(t, view, "P1234567", "table should be visible again after Escape")
+}
+
+func TestView_DownNavigationFollowsCursor(t *testing.T) {
+	m := sizedTestModel(t)
+	m.config.Client = &pd.MockPagerDutyClient{}
+	m.incidentList = append(m.incidentList, pagerduty.Incident{
+		APIObject: pagerduty.APIObject{ID: "P7654321"},
+		Title:     "Second Incident",
+		Service:   pagerduty.APIObject{ID: "SVC2", Summary: "svc-2"},
+	})
+	m.table.SetRows([]table.Row{
+		{dot, "P1234567", "Test Alert Firing", "test-service"},
+		{dot, "P7654321", "Second Incident", "svc-2"},
+	})
+
+	result, cmd := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m, ok := result.(model)
+	require.True(t, ok)
+
+	require.NotNil(t, m.selectedIncident)
+	assert.Equal(t, "P7654321", m.selectedIncident.ID, "selection should follow the cursor")
+	assert.NotNil(t, cmd, "navigating to an uncached incident should trigger a fetch command")
+}

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -36,9 +36,6 @@ var (
 func (m model) View() string {
 	var s strings.Builder
 
-	// errHelpView := helpStyle.Render(help.New().View(errorViewKeyMap))
-	errHelpView := help.New().View(errorViewKeyMap)
-
 	s.WriteString(m.renderHeader())
 
 	switch {
@@ -51,7 +48,9 @@ func (m model) View() string {
 		s.WriteString("\n\n")
 		s.WriteString(m.err.Error())
 		s.WriteString("\n")
-		s.WriteString(errHelpView)
+		// Only built on the error path — constructing a help model on every
+		// render is wasted work for the common case
+		s.WriteString(help.New().View(errorViewKeyMap))
 
 		return m.styles.Error.Render(s.String())
 


### PR DESCRIPTION
Six bug fixes from a full-codebase review: RFC3339 on-call queries (gates
auto-acknowledge), multi-line note preservation, process launches deferred
out of the Update loop, 250ms-paced requeues, a double-silence guard, and
per-model scheduled jobs. Update-loop polish: log-level-gated debug
preamble, O(n) cache invalidation, error-help built only on the error
path, and View() render smoke tests. The lazy enricher now re-fetches
incident data older than five minutes with a per-incident dispatch
cooldown, replacing a rejected background-prefetch engine design.

Created with assistance from Claude 🤖 <claude@anthropic.com>

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>
