### PR TITLE
Route OCM auth messages to structured log

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -310,14 +310,14 @@ func launchTUI() {
 
 	if ocmAuthPending {
 		go func() {
-			fmt.Fprintln(os.Stderr, "OCM tokens expired — opening browser for authentication...")
+			log.Info("OCM tokens expired — opening browser for authentication")
 			token, authErr := ocm.AuthenticateAsync(cfg)
 			if authErr != nil {
 				log.Debug("OCM browser auth failed", "error", authErr)
 				p.Send(tui.OCMClientReadyMsg{Err: authErr})
 				return
 			}
-			fmt.Fprintln(os.Stderr, "OCM authentication successful.")
+			log.Info("OCM authentication successful")
 			ocm.ApplyAuthToken(cfg, token)
 			client, connErr := ocm.NewClientFromConfig(cfg, tui.Version)
 			if connErr != nil {

--- a/docs/plans/391-ocm-auth-log-cleanup.md
+++ b/docs/plans/391-ocm-auth-log-cleanup.md
@@ -1,0 +1,22 @@
+# 391: Route OCM auth messages to structured log
+
+Branch: `srepd/ocm-auth-log-cleanup`
+
+## What
+
+The async OCM authentication goroutine in `cmd/root.go` used
+`fmt.Fprintln(os.Stderr, ...)` for two status messages ("tokens expired"
+and "authentication successful"). These fire after the TUI alt-screen is
+active, so they're either invisible or flash briefly — providing no value
+to the user while cluttering stderr.
+
+## Approach
+
+Replace the two `fmt.Fprintln(os.Stderr, ...)` calls with `log.Info()`
+so they route to the systemd journal (or log file on macOS) alongside all
+other OCM lifecycle messages. The TUI already surfaces OCM auth status
+via `OCMClientReadyMsg`.
+
+## Files
+
+- `cmd/root.go` — two lines changed in the `ocmAuthPending` goroutine


### PR DESCRIPTION
## Summary

- Replace `fmt.Fprintln(os.Stderr, ...)` with `log.Info()` in the async OCM auth goroutine in `cmd/root.go`
- These messages fire after the TUI alt-screen is active, so they were invisible on stderr — now they reach the systemd journal alongside other OCM lifecycle messages

## Test plan

- [x] `make fmt-check` — passes
- [x] `make vet` — passes
- [x] `make lint` — passes
- [x] `make test` — passes
- [x] Plan doc included (`docs/plans/391-ocm-auth-log-cleanup.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)