### PR TITLE
Document AWS Bedrock llm_api setup; default to inference-profile model

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,8 +198,15 @@ llm_api:
 | `llm_api.endpoint` | `string` | API endpoint URL (provider-specific default used if omitted) |
 | `llm_api.model` | `string` | Model identifier (provider-specific default used if omitted) |
 | `llm_api.api_key_env` | `string` | Name of env var containing API key (optional for all providers) |
-| `llm_api.region` | `string` | Cloud region for `anthropic-vertex` (auto-detected from `CLOUD_ML_REGION` or `VERTEXAI_LOCATION`) |
+| `llm_api.region` | `string` | Cloud region for `anthropic-vertex` (auto-detected from `CLOUD_ML_REGION` or `VERTEXAI_LOCATION`). Not used for `anthropic-bedrock` — its region comes from the AWS SDK environment |
 | `llm_api.project_id` | `string` | GCP project for `anthropic-vertex` (auto-detected from `ANTHROPIC_VERTEX_PROJECT_ID`, `VERTEXAI_PROJECT`, or `GOOGLE_CLOUD_PROJECT`) |
+
+> **AWS Bedrock:** export your AWS credentials and region in the environment
+> (`AWS_PROFILE` / `AWS_REGION`) — none go in the config. Enable Anthropic
+> models once in the [AWS Bedrock console](https://console.aws.amazon.com/bedrock/home#/model-catalog?providerName=anthropic),
+> and set `model` to an inference-profile ID such as `us.anthropic.claude-sonnet-4-6`
+> (bare foundation-model IDs are not on-demand invocable). See
+> [LLM Providers](docs/llm-providers.md#anthropic-bedrock) for full setup.
 
 ## Key Bindings
 

--- a/README.md
+++ b/README.md
@@ -202,8 +202,10 @@ llm_api:
 | `llm_api.project_id` | `string` | GCP project for `anthropic-vertex` (auto-detected from `ANTHROPIC_VERTEX_PROJECT_ID`, `VERTEXAI_PROJECT`, or `GOOGLE_CLOUD_PROJECT`) |
 
 > **AWS Bedrock:** export your AWS credentials and region in the environment
-> (`AWS_PROFILE` / `AWS_REGION`) — none go in the config. Enable Anthropic
-> models once in the [AWS Bedrock console](https://console.aws.amazon.com/bedrock/home#/model-catalog?providerName=anthropic),
+> (`AWS_PROFILE` / `AWS_REGION`) — none go in the config. Or authenticate with
+> a Bedrock API key by exporting `AWS_BEARER_TOKEN_BEDROCK` (plus `AWS_REGION`)
+> instead of IAM credentials. Enable Anthropic models once in the
+> [AWS Bedrock console](https://console.aws.amazon.com/bedrock/home#/model-catalog?providerName=anthropic),
 > and set `model` to an inference-profile ID such as `us.anthropic.claude-sonnet-4-6`
 > (bare foundation-model IDs are not on-demand invocable). See
 > [LLM Providers](docs/llm-providers.md#anthropic-bedrock) for full setup.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,8 +80,10 @@ See [AI Agents](ai-agents.md) for usage.
 
 For AWS Bedrock, credentials and region are supplied via the AWS SDK
 environment (e.g. `export AWS_PROFILE=... AWS_REGION=...`), not the SREPD
-config. See [LLM Providers](llm-providers.md#anthropic-bedrock) for the full
-setup, including one-time model enablement and inference-profile IDs.
+config. You can alternatively authenticate with a Bedrock API key by exporting
+`AWS_BEARER_TOKEN_BEDROCK` instead of IAM credentials. See
+[LLM Providers](llm-providers.md#anthropic-bedrock) for the full setup,
+including API keys, one-time model enablement, and inference-profile IDs.
 
 See [LLM Providers](llm-providers.md) for provider-specific setup.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,10 +71,17 @@ See [AI Agents](ai-agents.md) for usage.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `llm_api.provider` | `string` | (none) | LLM provider: `ollama`, `anthropic`, `openai`, `ramalama` |
+| `llm_api.provider` | `string` | (none) | LLM provider: `ollama`, `anthropic`, `anthropic-vertex`, `anthropic-bedrock`, `openai`, `ramalama` |
 | `llm_api.endpoint` | `string` | (provider default) | API endpoint URL |
-| `llm_api.model` | `string` | (provider default) | Model identifier |
-| `llm_api.api_key_env` | `string` | (none) | Name of env var containing API key (optional for all providers) |
+| `llm_api.model` | `string` | (provider default) | Model identifier. For `anthropic-bedrock`, use an inference-profile ID (e.g. `us.anthropic.claude-sonnet-4-6`), not a bare model ID |
+| `llm_api.api_key_env` | `string` | (none) | Name of env var containing API key (optional; ignored by `anthropic-vertex` / `anthropic-bedrock`) |
+| `llm_api.region` | `string` | (none) | Cloud region — `anthropic-vertex` only. Bedrock's region comes from the AWS SDK environment, not this field |
+| `llm_api.project_id` | `string` | (none) | Google Cloud project ID — `anthropic-vertex` only |
+
+For AWS Bedrock, credentials and region are supplied via the AWS SDK
+environment (e.g. `export AWS_PROFILE=... AWS_REGION=...`), not the SREPD
+config. See [LLM Providers](llm-providers.md#anthropic-bedrock) for the full
+setup, including one-time model enablement and inference-profile IDs.
 
 See [LLM Providers](llm-providers.md) for provider-specific setup.
 

--- a/docs/llm-providers.md
+++ b/docs/llm-providers.md
@@ -145,6 +145,53 @@ Verify your credentials and region work before configuring SREPD:
 aws bedrock list-foundation-models --query 'modelSummaries[0].modelId'
 ```
 
+**Alternative: Bedrock API key (bearer token).** Instead of AWS IAM
+credentials, you can authenticate with a **Bedrock API key** — a bearer token
+scoped to Bedrock that is sent as `Authorization: Bearer <key>` and replaces
+SigV4 signing. The AWS SDK (and therefore SREPD, with no extra config) picks
+it up automatically from the `AWS_BEARER_TOKEN_BEDROCK` environment variable:
+
+```bash
+export AWS_BEARER_TOKEN_BEDROCK=<your-bedrock-api-key>
+export AWS_REGION=us-east-2        # still required — see note below
+srepd
+```
+
+When `AWS_BEARER_TOKEN_BEDROCK` is set, it takes precedence over the IAM
+credential chain, so you do **not** need `AWS_PROFILE` or `~/.aws` credentials
+for Bedrock. The SREPD config is unchanged — just `provider: anthropic-bedrock`
+(plus an optional inference-profile `model`).
+
+**Region is still required and not embedded in the key.** Set `AWS_REGION`
+(or `AWS_DEFAULT_REGION`). For a **short-term** key this region *must match*
+the region the key was generated in, or calls fail.
+
+Two kinds of key:
+
+- **Short-term key** — valid for at most 12 hours (and no longer than the
+  generating session), inherits your current permissions, and is pinned to the
+  Region it was created in. AWS **recommends short-term keys** for anything
+  beyond initial exploration. Generate one from the Bedrock console
+  ("API keys" → short-term), or via the `aws-bedrock-token-generator` helper
+  (Python/JS/Java only — there is no Go helper).
+- **Long-term key** — a static IAM *service-specific credential* with an
+  expiration you choose at creation. Generate from the console (long-term
+  tab), or via the CLI:
+
+  ```bash
+  aws iam create-service-specific-credential \
+    --user-name your-bedrock-user \
+    --service-name bedrock.amazonaws.com \
+    --credential-age-days 30
+  ```
+
+  Because it is a long-lived static secret, treat a long-term key like any
+  other credential. AWS's own guidance: prefer short-term keys, and reserve
+  long-term keys for cases where short-term rotation isn't practical.
+
+Model enablement (below) and inference-profile model IDs apply the same way
+whether you authenticate with a key or IAM credentials.
+
 **One-time model enablement.** Before Anthropic models can be invoked in a
 given AWS account, you must enable them once. Sign in to the AWS Console,
 open the Bedrock model catalog for Anthropic —

--- a/docs/llm-providers.md
+++ b/docs/llm-providers.md
@@ -18,10 +18,12 @@ llm_api:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `provider` | `string` | Yes | Provider name. One of: `ollama`, `anthropic`, `openai`, `ramalama`. |
+| `provider` | `string` | Yes | Provider name. One of: `ollama`, `anthropic`, `anthropic-vertex`, `anthropic-bedrock`, `openai`, `ramalama`. |
 | `endpoint` | `string` | No | API endpoint URL. Each provider has a default (see below). |
 | `model` | `string` | No | Model identifier. Each provider has a default (see below). |
-| `api_key_env` | `string` | No | Name of the environment variable containing the API key. The key itself is never stored in config. Optional for all providers. |
+| `api_key_env` | `string` | No | Name of the environment variable containing the API key. The key itself is never stored in config. Optional for all providers. Ignored by `anthropic-vertex` and `anthropic-bedrock` (they authenticate via the cloud provider's SDK). |
+| `region` | `string` | No | Cloud region. Used by `anthropic-vertex` only. For `anthropic-bedrock`, the region comes from the AWS SDK environment (`AWS_REGION` / `~/.aws/config`), **not** from this field. |
+| `project_id` | `string` | No | Google Cloud project ID. Used by `anthropic-vertex` only. |
 
 When `api_key_env` is set, SREPD reads the API key from that environment variable at startup. When empty or unset, no authentication header is sent — suitable for local, unauthenticated servers.
 
@@ -91,6 +93,128 @@ llm_api:
   endpoint: https://custom-proxy.internal.example.com
   api_key_env: ANTHROPIC_API_KEY
 ```
+
+### anthropic-bedrock
+
+Anthropic Claude models via AWS Bedrock, using the official Go SDK's Bedrock
+transport.
+
+| Setting | Default |
+|---------|---------|
+| Endpoint | AWS SDK default (Bedrock runtime for the resolved region) |
+| Model | `us.anthropic.claude-sonnet-4-6` |
+| Credentials | AWS SDK default credential chain (see below) |
+| Region | AWS SDK default (`AWS_REGION` / `~/.aws/config`) |
+| Protocol | Anthropic SDK (Messages API) over Bedrock |
+
+```yaml
+llm_api:
+  provider: anthropic-bedrock
+  model: us.anthropic.claude-sonnet-4-6
+```
+
+Or, to accept the default model, just:
+
+```yaml
+llm_api:
+  provider: anthropic-bedrock
+```
+
+**Credentials.** SREPD puts **no** AWS credentials in its config. The Bedrock
+provider authenticates entirely through the **AWS SDK default credential
+chain** — the same sources every AWS tool uses, in order:
+
+1. Environment variables: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,
+   `AWS_SESSION_TOKEN` (for temporary/STS credentials), `AWS_PROFILE`
+2. Shared config/credentials files: `~/.aws/credentials`, `~/.aws/config`
+3. SSO, assumed roles, and EC2/ECS instance metadata (IMDS)
+
+You must also have a **region** set (`AWS_REGION` / `AWS_DEFAULT_REGION`, or a
+profile default in `~/.aws/config`) — `llm_api.region` is *not* read for
+Bedrock. In practice, export your AWS environment before launching SREPD:
+
+```bash
+export AWS_PROFILE=your-profile
+export AWS_REGION=us-east-2
+srepd
+```
+
+Verify your credentials and region work before configuring SREPD:
+
+```bash
+aws bedrock list-foundation-models --query 'modelSummaries[0].modelId'
+```
+
+**One-time model enablement.** Before Anthropic models can be invoked in a
+given AWS account, you must enable them once. Sign in to the AWS Console,
+open the Bedrock model catalog for Anthropic —
+`https://console.aws.amazon.com/bedrock/home#/model-catalog?providerName=anthropic`
+— and submit the one-time enablement/enrollment request for the Claude
+model(s) you intend to use. Until this is done, invocations fail with an
+access error even though credentials are valid.
+
+**Model IDs — use an inference profile, not a bare model ID.** Current
+Anthropic Claude models on Bedrock are *inference-profile-only*: they do not
+support on-demand throughput by their bare foundation-model ID (e.g.
+`anthropic.claude-sonnet-4-6-20250514-v1:0`). You must use a cross-region
+inference profile ID, which is region-prefixed — `us.` for US regions,
+`global.` for cross-region routing:
+
+```
+us.anthropic.claude-sonnet-4-6
+```
+
+SREPD's default is already an inference-profile ID
+(`us.anthropic.claude-sonnet-4-6`), so the minimal config above works
+out of the box in US regions. If you set `model:` yourself, use a profile ID.
+
+To list the inference profiles available in your account:
+
+```bash
+aws bedrock list-inference-profiles \
+  --query 'inferenceProfileSummaries[?contains(inferenceProfileId, `anthropic`)].inferenceProfileId' \
+  --output table
+```
+
+To check which models (if any) support **on-demand** invocation by their bare
+ID — i.e. those that do *not* require an inference profile:
+
+```bash
+aws bedrock list-foundation-models --by-inference-type ON_DEMAND \
+  --query 'modelSummaries[].modelId' --output table
+```
+
+Note: at the time of writing, no Anthropic Claude models appear in the
+`ON_DEMAND` list — they are all inference-profile-only — which is exactly why
+the default model is a `us.`-prefixed profile ID.
+
+### anthropic-vertex
+
+Anthropic Claude models via Google Vertex AI, using the official Go SDK's
+Vertex transport.
+
+| Setting | Default |
+|---------|---------|
+| Endpoint | Google SDK default (Vertex for the resolved region) |
+| Model | `claude-sonnet-4-6` |
+| Credentials | Google application default credentials (ADC) |
+| Region | `llm_api.region`, or `CLOUD_ML_REGION` / `VERTEXAI_LOCATION` |
+| Project | `llm_api.project_id`, or `ANTHROPIC_VERTEX_PROJECT_ID` / `VERTEXAI_PROJECT` / `GOOGLE_CLOUD_PROJECT` |
+| Protocol | Anthropic SDK (Messages API) over Vertex |
+
+```yaml
+llm_api:
+  provider: anthropic-vertex
+  region: us-east5
+  project_id: my-gcp-project
+```
+
+Unlike Bedrock, Vertex **does** read `region` and `project_id` from config
+(falling back to the environment variables listed above). Provider creation
+fails with a clear error if neither config nor environment supplies a region
+and project ID. Credentials come from Google application default credentials
+(e.g. `gcloud auth application-default login`, or a service-account key
+referenced by `GOOGLE_APPLICATION_CREDENTIALS`).
 
 ### openai
 

--- a/docs/plans/406-bedrock-docs-and-default-model.md
+++ b/docs/plans/406-bedrock-docs-and-default-model.md
@@ -59,6 +59,34 @@ different model set `model:` to their own profile ID.
 - `README.md`: add a short Bedrock callout under the config reference table
   linking to the detailed doc.
 
+### Bedrock API-key (bearer-token) auth — docs only
+
+A follow-up within this PR documents authenticating to Bedrock with a
+**Bedrock API key** (bearer token) as an alternative to exported AWS IAM
+credentials. **No code was needed:** the pinned `anthropic-sdk-go` v1.57.0
+bedrock package already honors the `AWS_BEARER_TOKEN_BEDROCK` environment
+variable — `bedrock.WithLoadDefaultConfig` (which the provider already calls)
+delegates to `bedrock.WithConfig`, which reads that env var at
+`bedrock/bedrock.go:221` and, when set, sends `Authorization: Bearer <key>`
+in place of SigV4. Verified against the installed SDK source.
+
+The docs (`docs/llm-providers.md`, README callout, `configuration.md` note)
+now cover: setting `AWS_BEARER_TOKEN_BEDROCK`; that it takes precedence over
+the IAM chain; that `AWS_REGION` is still required and (for short-term keys)
+must match the key's origin region; and the short-term (≤12h, region-pinned,
+AWS-recommended) vs long-term (static IAM service-specific credential) key
+distinction with generation commands.
+
+**Deferred (not in this PR):** letting the SREPD config *name* the token env
+var (e.g. via `api_key_env` or a dedicated `bedrock_api_key_env` key) by
+injecting `bedrock.NewStaticBearerTokenProvider` through `bedrock.WithConfig`.
+That would add a direct `aws-sdk-go-v2/config` dependency to `pkg/ai` and
+touch the client-construction path, for an ergonomic gain over simply
+exporting one environment variable — judged not worth it for now. Note for any
+future implementer: the correct wiring is the bedrock package's
+`BearerAuthTokenProvider`, **not** `option.WithAPIKey` (which sets the
+Anthropic `X-Api-Key` header that Bedrock rejects).
+
 ## Notes / lessons
 
 - **Vertex reads `region`/`project_id` from config; Bedrock does not.** This

--- a/docs/plans/406-bedrock-docs-and-default-model.md
+++ b/docs/plans/406-bedrock-docs-and-default-model.md
@@ -1,0 +1,71 @@
+# 406: Document AWS Bedrock llm_api setup; default to an inference-profile model
+
+## Problem
+
+Two gaps surfaced while helping a user configure the `anthropic-bedrock`
+provider live against a real AWS account:
+
+1. **The default Bedrock model can't be invoked.** The default was the bare
+   foundation-model ID `anthropic.claude-sonnet-4-6-20250514-v1:0`. On current
+   AWS accounts, Anthropic Claude models on Bedrock are **inference-profile
+   only** — they do not support on-demand throughput by their bare model ID.
+   Invoking the bare ID fails at query time. Confirmed live:
+   `aws bedrock list-foundation-models --by-inference-type ON_DEMAND` returns
+   **no** Anthropic models, while `aws bedrock list-inference-profiles` shows
+   `us.anthropic.claude-sonnet-4-6` (and siblings) as `ACTIVE`. A test invoke
+   of `us.anthropic.claude-sonnet-4-6` via `bedrock-runtime invoke-model`
+   succeeded and returned a real completion.
+
+2. **The docs don't mention Bedrock at all.** `docs/llm-providers.md` and
+   `docs/configuration.md` predated the vertex/bedrock providers (PR #397,
+   plan 394) and still listed only `ollama`/`anthropic`/`openai`/`ramalama`,
+   omitting `anthropic-vertex`, `anthropic-bedrock`, and the `region` /
+   `project_id` fields. A user following the docs had no way to learn the
+   Bedrock setup, the credential model, or the inference-profile requirement.
+
+## Approach
+
+### Code
+
+Change the Bedrock default model from the bare foundation-model ID to the US
+cross-region inference profile ID `us.anthropic.claude-sonnet-4-6`, so the
+minimal config (`provider: anthropic-bedrock` with no `model`) works out of
+the box in US regions. Updated in both places that hold the default
+(`pkg/ai/bedrock.go` const and `pkg/ai/factory.go` registry), with a comment
+explaining why it's a profile ID. TDD: the two test assertions that pin the
+default (`pkg/ai/bedrock_test.go`, `pkg/ai/factory_test.go`) were updated
+first.
+
+No behavior change beyond the default string — the provider already passes
+`llm_api.model` straight through, so users on non-US regions or wanting a
+different model set `model:` to their own profile ID.
+
+### Docs
+
+- `docs/llm-providers.md`: add full `anthropic-bedrock` and `anthropic-vertex`
+  sections; add `region` / `project_id` to the fields table; update the
+  provider list. The Bedrock section documents:
+  - Credentials come from the **AWS SDK default credential chain** (env vars,
+    `~/.aws`, SSO/roles/IMDS) — **nothing** in the SREPD config. Region comes
+    from `AWS_REGION` / `~/.aws/config`, not `llm_api.region`.
+  - The minimal config and the model-override config.
+  - One-time model enablement in the AWS console
+    (`.../bedrock/home#/model-catalog?providerName=anthropic`).
+  - Inference-profile requirement, with the `list-inference-profiles` and
+    `list-foundation-models --by-inference-type ON_DEMAND` commands to
+    discover valid IDs.
+- `docs/configuration.md`: add the two providers and the `region` /
+  `project_id` keys to the LLM API table; add a Bedrock pointer note.
+- `README.md`: add a short Bedrock callout under the config reference table
+  linking to the detailed doc.
+
+## Notes / lessons
+
+- **Vertex reads `region`/`project_id` from config; Bedrock does not.** This
+  asymmetry is real (`pkg/ai/vertex.go` vs `pkg/ai/bedrock.go`, which only
+  calls `bedrock.WithLoadDefaultConfig`) and is now documented explicitly so
+  users don't waste time setting `llm_api.region` for Bedrock expecting it to
+  take effect.
+- **Bedrock model IDs are not foundation-model IDs.** The inference-profile
+  requirement is the single biggest Bedrock footgun; both the default and the
+  docs now steer users to `us.`-prefixed profile IDs.

--- a/pkg/ai/bedrock.go
+++ b/pkg/ai/bedrock.go
@@ -10,7 +10,11 @@ import (
 	"github.com/charmbracelet/log"
 )
 
-const bedrockDefaultModel = "anthropic.claude-sonnet-4-6-20250514-v1:0"
+// bedrockDefaultModel is a US cross-region inference profile ID, not a bare
+// foundation-model ID. Current Anthropic Claude models on Bedrock are
+// inference-profile-only (no ON_DEMAND throughput), so the bare
+// foundation-model ID cannot be invoked directly. See docs/llm-providers.md.
+const bedrockDefaultModel = "us.anthropic.claude-sonnet-4-6"
 
 func newBedrockProvider(cfg Config) (p *anthropicProvider, err error) {
 	defer func() {

--- a/pkg/ai/bedrock_test.go
+++ b/pkg/ai/bedrock_test.go
@@ -17,5 +17,5 @@ func TestNewBedrockProvider_AuthPanicRecovery(t *testing.T) {
 }
 
 func TestNewBedrockProvider_DefaultModel(t *testing.T) {
-	assert.Equal(t, "anthropic.claude-sonnet-4-6-20250514-v1:0", bedrockDefaultModel)
+	assert.Equal(t, "us.anthropic.claude-sonnet-4-6", bedrockDefaultModel)
 }

--- a/pkg/ai/factory.go
+++ b/pkg/ai/factory.go
@@ -23,7 +23,7 @@ var providerRegistry = map[string]providerMeta{
 	},
 	"anthropic-bedrock": {
 		defaultEndpoint: "",
-		defaultModel:    "anthropic.claude-sonnet-4-6-20250514-v1:0",
+		defaultModel:    "us.anthropic.claude-sonnet-4-6",
 	},
 	"ollama": {
 		defaultEndpoint: "http://localhost:11434",

--- a/pkg/ai/factory_test.go
+++ b/pkg/ai/factory_test.go
@@ -275,7 +275,7 @@ func TestProviderRegistry_Defaults(t *testing.T) {
 			name:            "anthropic-bedrock defaults",
 			provider:        "anthropic-bedrock",
 			defaultEndpoint: "",
-			defaultModel:    "anthropic.claude-sonnet-4-6-20250514-v1:0",
+			defaultModel:    "us.anthropic.claude-sonnet-4-6",
 		},
 		{
 			name:            "ollama defaults",


### PR DESCRIPTION
## Problem

Two gaps surfaced while configuring the `anthropic-bedrock` provider live against a real AWS account:

1. **The default Bedrock model couldn't be invoked.** The default was the bare foundation-model ID `anthropic.claude-sonnet-4-6-20250514-v1:0`. Current Anthropic Claude models on Bedrock are **inference-profile only** — no on-demand throughput by bare model ID, so invoking it fails at query time. Verified live: `aws bedrock list-foundation-models --by-inference-type ON_DEMAND` returns **no** Anthropic models, while `us.anthropic.claude-sonnet-4-6` is an `ACTIVE` inference profile and invokes successfully.

2. **The docs didn't mention Bedrock at all.** `docs/llm-providers.md` and `docs/configuration.md` predated the vertex/bedrock providers (PR #397) and still listed only `ollama`/`anthropic`/`openai`/`ramalama`, omitting both cloud providers and the `region`/`project_id` fields.

## Changes

**Code (one-line default + tests):**
- Default Bedrock model → `us.anthropic.claude-sonnet-4-6` (US cross-region inference profile), in `pkg/ai/bedrock.go` and `pkg/ai/factory.go`, with a comment explaining why it's a profile ID. Test assertions updated (TDD).

**Docs:**
- `docs/llm-providers.md`: full `anthropic-bedrock` and `anthropic-vertex` sections; `region`/`project_id` added to the fields table. Bedrock section covers:
  - Credentials from the **AWS SDK default credential chain** — nothing in srepd config; region from `AWS_REGION`/`~/.aws`, not `llm_api.region`
  - **Bedrock API key (bearer token) as an alternative to IAM credentials** — export `AWS_BEARER_TOKEN_BEDROCK`; the pinned anthropic-sdk-go already honors it (no code change). Covers short-term (≤12h, region-pinned, AWS-recommended) vs long-term (static IAM service-specific credential) keys, generation commands, and the region-match caveat
  - One-time model enablement in the [AWS Bedrock console](https://console.aws.amazon.com/bedrock/home#/model-catalog?providerName=anthropic)
  - Inference-profile requirement + the `list-inference-profiles` / `list-foundation-models --by-inference-type ON_DEMAND` discovery commands
- `docs/configuration.md`: two providers + `region`/`project_id` added to the LLM API table, plus Bedrock credential-chain and API-key pointer notes
- `README.md`: short Bedrock callout (credential chain + API key) linking to the detail doc

## Why no code for API keys

The pinned `anthropic-sdk-go` v1.57.0 bedrock package already reads `AWS_BEARER_TOKEN_BEDROCK` natively (`bedrock.WithLoadDefaultConfig` → `WithConfig` → env var at `bedrock.go:221`, sending `Authorization: Bearer` in place of SigV4). So env-var API-key auth works today with zero code — this PR documents it. Letting the srepd *config* name the token env var was considered and deferred (it would add a direct `aws-sdk-go-v2/config` dependency to `pkg/ai` for marginal ergonomic gain); see the plan doc.

## Verification

Full local suite green: fmt-check, vet, lint (0 issues), test, test-race.

No new dependencies. No user-facing config/flag/keybinding changes (docs + a default string), so `readme-check` is not triggered — README updated regardless.

Plan doc: `docs/plans/406-bedrock-docs-and-default-model.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)