### PR TITLE
Surface enrichment fetch errors inline in tab views

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,8 +1,1 @@
-{
-  "mcpServers": {
-    "tui-mcp": {
-      "command": "npx",
-      "args": ["tui-mcp"]
-    }
-  }
-}
+{}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "tui-mcp": {
+      "command": "npx",
+      "args": ["tui-mcp"]
+    }
+  }
+}

--- a/docs/plans/407-enrichment-error-display.md
+++ b/docs/plans/407-enrichment-error-display.md
@@ -1,0 +1,59 @@
+# 407: Surface enrichment fetch errors inline in tab views
+
+## Problem
+
+When backplane `ListReports` returns a 403 (or any error), the error is
+silently swallowed: the handler logs at Debug level and returns nil. The
+Reports tab stays stuck on "Loading cluster reports..." forever. The same
+silent-swallow pattern affects Service Logs and Limited Support tabs.
+
+Users have no indication that enrichment data failed to load.
+
+## Approach
+
+Store per-section errors in the model and display them as red (Warning
+color) text in the tab where data was expected, with a concise summary
+and "see logs for details" hint. Bypass glamour markdown rendering for
+error content so lipgloss styling is preserved.
+
+Also fix an existing bug: enrichment handlers did not dispatch
+`renderIncidentMsg` on success, so the viewport was not re-rendered until
+the user manually switched tabs.
+
+## Changes
+
+### Model (`model.go`)
+- Added `serviceLogErrors`, `limitedSupportErrors`, `clusterReportErrors`
+  maps (`map[string]error`) alongside existing data caches.
+
+### Theme (`theme.go`)
+- Added `InlineError` style: Warning color (#a4133c) foreground on
+  default background.
+
+### Handlers (`tui.go`)
+- `ocmServiceLogsMsg`, `limitedSupportMsg`, `clusterReportsMsg` handlers:
+  - Store errors in the new error maps on failure.
+  - Upgraded log level from Debug to Warn.
+  - Dispatch `renderIncidentMsg` on both success and error.
+
+### Render pipeline (`commands.go`, `views.go`)
+- `renderTabContent()` returns `(string, bool, error)` where the bool
+  indicates pre-rendered content that should skip glamour.
+- `renderIncident()` skips `renderIncidentMarkdown()` when preRendered.
+- New `renderEnrichmentError()` helper formats concise red error text.
+- Service Logs, Limited Support, and Reports tabs check error maps and
+  return styled error text instead of perpetual loading messages.
+
+### MCP config (`.mcp.json`)
+- Moved tui-mcp MCP server config from `.claude/settings.json` (wrong
+  location) to `.mcp.json` at project root (correct location for
+  project-scoped MCP servers).
+
+## Testing
+
+- Unit tests for error storage in all three handlers.
+- Unit tests for error display in all three tab render functions.
+- Unit tests for preRendered flag and glamour bypass.
+- Existing tests updated for new signatures.
+- Full CI suite: fmt-check, vet, lint, test, test-race all pass.
+- Visual verification via tui-mcp: no regressions in happy path.

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -512,9 +512,13 @@ func renderDocsContent(m *model) tea.Cmd {
 
 func renderIncident(m *model) tea.Cmd {
 	return func() tea.Msg {
-		t, err := m.renderTabContent()
+		t, preRendered, err := m.renderTabContent()
 		if err != nil {
 			return errMsg{err}
+		}
+
+		if preRendered {
+			return renderedIncidentMsg{t, nil}
 		}
 
 		content, err := renderIncidentMarkdown(m, t)

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -241,12 +241,15 @@ type model struct {
 	clusterCache          map[string]*ocm.ClusterInfo
 	serviceLogCache       map[string][]ocm.ServiceLog
 	limitedSupportCache   map[string][]ocm.LimitedSupportReason
+	serviceLogErrors      map[string]error
+	limitedSupportErrors  map[string]error
 
 	// Backplane enrichment state
-	backplaneClient    backplane.BackplaneClient
-	backplaneConfig    *backplane.Config
-	backplaneInitErr   error
-	clusterReportCache map[string][]backplane.Report
+	backplaneClient     backplane.BackplaneClient
+	backplaneConfig     *backplane.Config
+	backplaneInitErr    error
+	clusterReportCache  map[string][]backplane.Report
+	clusterReportErrors map[string]error
 
 	// Prior alerts state
 	priorAlertCache   map[string]*PriorAlertData

--- a/pkg/tui/model_test.go
+++ b/pkg/tui/model_test.go
@@ -507,7 +507,7 @@ func TestProgressiveRendering(t *testing.T) {
 				incidentCache:        make(map[string]*cachedIncidentData),
 			}
 
-			content, err := m.renderTabContent()
+			content, _, err := m.renderTabContent()
 			assert.NoError(t, err, "renderTabContent should render without error")
 
 			for _, expected := range tt.expectedContains {

--- a/pkg/tui/ocm_enrichment_test.go
+++ b/pkg/tui/ocm_enrichment_test.go
@@ -170,6 +170,22 @@ func TestServiceLogsMsg_UpdatesCache(t *testing.T) {
 
 		assert.Empty(t, updated.serviceLogCache)
 	})
+
+	t.Run("ocmServiceLogsMsg with error stores error in serviceLogErrors", func(t *testing.T) {
+		m := createTestModel()
+		m.serviceLogCache = make(map[string][]ocm.ServiceLog)
+
+		msg := ocmServiceLogsMsg{
+			clusterID: "1q2w3e4rfakeidtest9o0p1a2s3d4f5g",
+			err:       fmt.Errorf("fetch failed"),
+		}
+
+		result, _ := m.Update(msg)
+		updated := result.(model)
+
+		assert.Contains(t, updated.serviceLogErrors, "1q2w3e4rfakeidtest9o0p1a2s3d4f5g")
+		assert.EqualError(t, updated.serviceLogErrors["1q2w3e4rfakeidtest9o0p1a2s3d4f5g"], "fetch failed")
+	})
 }
 
 func TestLimitedSupportMsg_UpdatesCache(t *testing.T) {
@@ -202,6 +218,22 @@ func TestLimitedSupportMsg_UpdatesCache(t *testing.T) {
 		updated := result.(model)
 
 		assert.Empty(t, updated.limitedSupportCache)
+	})
+
+	t.Run("limitedSupportMsg with error stores error in limitedSupportErrors", func(t *testing.T) {
+		m := createTestModel()
+		m.limitedSupportCache = make(map[string][]ocm.LimitedSupportReason)
+
+		msg := limitedSupportMsg{
+			clusterID: "1q2w3e4rfakeidtest9o0p1a2s3d4f5g",
+			err:       fmt.Errorf("fetch failed"),
+		}
+
+		result, _ := m.Update(msg)
+		updated := result.(model)
+
+		assert.Contains(t, updated.limitedSupportErrors, "1q2w3e4rfakeidtest9o0p1a2s3d4f5g")
+		assert.EqualError(t, updated.limitedSupportErrors["1q2w3e4rfakeidtest9o0p1a2s3d4f5g"], "fetch failed")
 	})
 }
 
@@ -361,7 +393,7 @@ func TestRenderServiceLogsTab_WithData(t *testing.T) {
 			},
 		}
 
-		content, err := m.renderServiceLogsTab()
+		content, _, err := m.renderServiceLogsTab()
 		assert.NoError(t, err)
 		assert.Contains(t, content, "Cluster entered limited support due to unsupported configuration")
 		assert.Contains(t, content, "Warning")
@@ -382,7 +414,7 @@ func TestRenderLimitedSupportTab_WithData(t *testing.T) {
 			},
 		}
 
-		content, err := m.renderLimitedSupportTab()
+		content, _, err := m.renderLimitedSupportTab()
 		assert.NoError(t, err)
 		assert.Contains(t, content, "Customer modification")
 		assert.Contains(t, content, "manual")
@@ -395,7 +427,7 @@ func TestRenderServiceLogsTab_NoOCM(t *testing.T) {
 		m.serviceLogCache = make(map[string][]ocm.ServiceLog)
 		m.ocmClient = nil
 
-		content, err := m.renderServiceLogsTab()
+		content, _, err := m.renderServiceLogsTab()
 		assert.NoError(t, err)
 		assert.Contains(t, content, "OCM not connected")
 	})
@@ -407,7 +439,7 @@ func TestRenderLimitedSupportTab_NoOCM(t *testing.T) {
 		m.limitedSupportCache = make(map[string][]ocm.LimitedSupportReason)
 		m.ocmClient = nil
 
-		content, err := m.renderLimitedSupportTab()
+		content, _, err := m.renderLimitedSupportTab()
 		assert.NoError(t, err)
 		assert.Contains(t, content, "OCM not connected")
 	})
@@ -425,13 +457,49 @@ func TestRenderClusterTab_Loading(t *testing.T) {
 	})
 }
 
+func TestRenderServiceLogsTab_FetchError(t *testing.T) {
+	t.Run("shows error message when fetch failed", func(t *testing.T) {
+		m := createTestModel()
+		setupModelWithCluster(&m)
+		m.serviceLogCache = make(map[string][]ocm.ServiceLog)
+		m.ocmClient = createMockOCMClient()
+		m.serviceLogErrors = map[string]error{
+			testClusterID: fmt.Errorf("unexpected status 403"),
+		}
+
+		content, preRendered, err := m.renderServiceLogsTab()
+		assert.NoError(t, err)
+		assert.True(t, preRendered, "error content should be pre-rendered")
+		assert.Contains(t, content, "Failed to load service logs")
+		assert.Contains(t, content, "see logs for details")
+	})
+}
+
+func TestRenderLimitedSupportTab_FetchError(t *testing.T) {
+	t.Run("shows error message when fetch failed", func(t *testing.T) {
+		m := createTestModel()
+		setupModelWithCluster(&m)
+		m.limitedSupportCache = make(map[string][]ocm.LimitedSupportReason)
+		m.ocmClient = createMockOCMClient()
+		m.limitedSupportErrors = map[string]error{
+			testClusterID: fmt.Errorf("unexpected status 403"),
+		}
+
+		content, preRendered, err := m.renderLimitedSupportTab()
+		assert.NoError(t, err)
+		assert.True(t, preRendered, "error content should be pre-rendered")
+		assert.Contains(t, content, "Failed to load limited support")
+		assert.Contains(t, content, "see logs for details")
+	})
+}
+
 func TestRenderServiceLogsTab_Loading(t *testing.T) {
 	t.Run("shows loading message when client connected but no data", func(t *testing.T) {
 		m := createTestModel()
 		m.serviceLogCache = make(map[string][]ocm.ServiceLog)
 		m.ocmClient = createMockOCMClient()
 
-		content, err := m.renderServiceLogsTab()
+		content, _, err := m.renderServiceLogsTab()
 		assert.NoError(t, err)
 		assert.Contains(t, content, "Loading service logs")
 	})
@@ -443,7 +511,7 @@ func TestRenderLimitedSupportTab_Empty(t *testing.T) {
 		m.limitedSupportCache = make(map[string][]ocm.LimitedSupportReason)
 		m.ocmClient = createMockOCMClient()
 
-		content, err := m.renderLimitedSupportTab()
+		content, _, err := m.renderLimitedSupportTab()
 		assert.NoError(t, err)
 		assert.Contains(t, content, "No limited support history")
 	})
@@ -665,7 +733,7 @@ func TestRenderServiceLogsTab_AuthPending(t *testing.T) {
 		m.ocmClient = nil
 		m.ocmAuthPending = true
 
-		content, err := m.renderServiceLogsTab()
+		content, _, err := m.renderServiceLogsTab()
 		assert.NoError(t, err)
 		assert.Contains(t, content, "authenticating")
 		assert.NotContains(t, content, "OCM not connected")
@@ -679,7 +747,7 @@ func TestRenderLimitedSupportTab_AuthPending(t *testing.T) {
 		m.ocmClient = nil
 		m.ocmAuthPending = true
 
-		content, err := m.renderLimitedSupportTab()
+		content, _, err := m.renderLimitedSupportTab()
 		assert.NoError(t, err)
 		assert.Contains(t, content, "authenticating")
 		assert.NotContains(t, content, "OCM not connected")

--- a/pkg/tui/ocm_tab_handlers_test.go
+++ b/pkg/tui/ocm_tab_handlers_test.go
@@ -26,12 +26,12 @@ func TestOcmServiceLogsMsg_InitializesNilCache(t *testing.T) {
 
 		assert.NotNil(t, updated.serviceLogCache, "should initialize nil map")
 		assert.Len(t, updated.serviceLogCache["1q2w3e4rfakeidtest9o0p1a2s3d4f5g"], 1)
-		assert.Nil(t, cmd, "should return nil cmd")
+		assert.NotNil(t, cmd, "should return re-render cmd")
 	})
 }
 
-func TestOcmServiceLogsMsg_ErrorReturnsNilCmd(t *testing.T) {
-	t.Run("error returns model and nil cmd without modifying cache", func(t *testing.T) {
+func TestOcmServiceLogsMsg_ErrorStoresError(t *testing.T) {
+	t.Run("error stores in error map and returns re-render cmd", func(t *testing.T) {
 		m := createTestModel()
 		m.serviceLogCache = make(map[string][]ocm.ServiceLog)
 
@@ -44,7 +44,9 @@ func TestOcmServiceLogsMsg_ErrorReturnsNilCmd(t *testing.T) {
 		updated := result.(model)
 
 		assert.Empty(t, updated.serviceLogCache, "cache should remain empty on error")
-		assert.Nil(t, cmd, "should return nil cmd on error")
+		assert.Contains(t, updated.serviceLogErrors, "1q2w3e4rfakeidtest9o0p1a2s3d4f5g")
+		assert.EqualError(t, updated.serviceLogErrors["1q2w3e4rfakeidtest9o0p1a2s3d4f5g"], "service log fetch failed")
+		assert.NotNil(t, cmd, "should return re-render cmd on error")
 	})
 }
 
@@ -63,7 +65,7 @@ func TestOcmServiceLogsMsg_StoresEmptySlice(t *testing.T) {
 
 		assert.Contains(t, updated.serviceLogCache, "1q2w3e4rfakeidtest9o0p1a2s3d4f5g")
 		assert.Empty(t, updated.serviceLogCache["1q2w3e4rfakeidtest9o0p1a2s3d4f5g"])
-		assert.Nil(t, cmd, "should return nil cmd")
+		assert.NotNil(t, cmd, "should return re-render cmd")
 	})
 }
 
@@ -84,12 +86,12 @@ func TestLimitedSupportMsg_InitializesNilCache(t *testing.T) {
 
 		assert.NotNil(t, updated.limitedSupportCache, "should initialize nil map")
 		assert.Len(t, updated.limitedSupportCache["1q2w3e4rfakeidtest9o0p1a2s3d4f5g"], 1)
-		assert.Nil(t, cmd, "should return nil cmd")
+		assert.NotNil(t, cmd, "should return re-render cmd")
 	})
 }
 
-func TestLimitedSupportMsg_ErrorReturnsNilCmd(t *testing.T) {
-	t.Run("error returns model and nil cmd without modifying cache", func(t *testing.T) {
+func TestLimitedSupportMsg_ErrorStoresError(t *testing.T) {
+	t.Run("error stores in error map and returns re-render cmd", func(t *testing.T) {
 		m := createTestModel()
 		m.limitedSupportCache = make(map[string][]ocm.LimitedSupportReason)
 
@@ -102,7 +104,9 @@ func TestLimitedSupportMsg_ErrorReturnsNilCmd(t *testing.T) {
 		updated := result.(model)
 
 		assert.Empty(t, updated.limitedSupportCache, "cache should remain empty on error")
-		assert.Nil(t, cmd, "should return nil cmd on error")
+		assert.Contains(t, updated.limitedSupportErrors, "1q2w3e4rfakeidtest9o0p1a2s3d4f5g")
+		assert.EqualError(t, updated.limitedSupportErrors["1q2w3e4rfakeidtest9o0p1a2s3d4f5g"], "limited support fetch failed")
+		assert.NotNil(t, cmd, "should return re-render cmd on error")
 	})
 }
 
@@ -126,12 +130,12 @@ func TestClusterReportsMsg_StoresInCache(t *testing.T) {
 
 		assert.Contains(t, updated.clusterReportCache, "1q2w3e4rfakeidtest9o0p1a2s3d4f5g")
 		assert.Len(t, updated.clusterReportCache["1q2w3e4rfakeidtest9o0p1a2s3d4f5g"], 2)
-		assert.Nil(t, cmd, "should return nil cmd")
+		assert.NotNil(t, cmd, "should return re-render cmd")
 	})
 }
 
 func TestClusterReportsMsg_ErrorDoesNotPopulateCache(t *testing.T) {
-	t.Run("error does not populate cache", func(t *testing.T) {
+	t.Run("error does not populate cache but stores in error map", func(t *testing.T) {
 		m := createTestModel()
 		m.clusterReportCache = make(map[string][]backplane.Report)
 
@@ -144,7 +148,9 @@ func TestClusterReportsMsg_ErrorDoesNotPopulateCache(t *testing.T) {
 		updated := result.(model)
 
 		assert.Empty(t, updated.clusterReportCache, "cache should remain empty on error")
-		assert.Nil(t, cmd, "should return nil cmd on error")
+		assert.Contains(t, updated.clusterReportErrors, "1q2w3e4rfakeidtest9o0p1a2s3d4f5g")
+		assert.EqualError(t, updated.clusterReportErrors["1q2w3e4rfakeidtest9o0p1a2s3d4f5g"], "backplane reports fetch failed")
+		assert.NotNil(t, cmd, "should return re-render cmd on error")
 	})
 }
 
@@ -163,7 +169,7 @@ func TestClusterReportsMsg_InitializesNilCache(t *testing.T) {
 
 		assert.NotNil(t, updated.clusterReportCache, "should initialize nil map")
 		assert.Len(t, updated.clusterReportCache["1q2w3e4rfakeidtest9o0p1a2s3d4f5g"], 1)
-		assert.Nil(t, cmd, "should return nil cmd")
+		assert.NotNil(t, cmd, "should return re-render cmd")
 	})
 }
 
@@ -182,6 +188,6 @@ func TestClusterReportsMsg_StoresEmptySlice(t *testing.T) {
 
 		assert.Contains(t, updated.clusterReportCache, "1q2w3e4rfakeidtest9o0p1a2s3d4f5g")
 		assert.Empty(t, updated.clusterReportCache["1q2w3e4rfakeidtest9o0p1a2s3d4f5g"])
-		assert.Nil(t, cmd, "should return nil cmd")
+		assert.NotNil(t, cmd, "should return re-render cmd")
 	})
 }

--- a/pkg/tui/theme.go
+++ b/pkg/tui/theme.go
@@ -38,6 +38,7 @@ type Styles struct {
 	Padded           lipgloss.Style
 	Muted            lipgloss.Style
 	Warning          lipgloss.Style
+	InlineError      lipgloss.Style
 	TableContainer   lipgloss.Style
 	Table            table.Styles
 	ActiveTab        lipgloss.Style
@@ -156,6 +157,7 @@ func BuildStyles(theme Theme) Styles {
 		Padded:           padded,
 		Muted:            lipgloss.NewStyle().Foreground(theme.Muted),
 		Warning:          lipgloss.NewStyle().Foreground(theme.Highlight).Background(theme.Warning),
+		InlineError:      lipgloss.NewStyle().Foreground(theme.Warning),
 		TableContainer:   tableContainer,
 		WatcherContainer: watcherContainer,
 		FormContainer:    formContainer,

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -1922,39 +1922,51 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case ocmServiceLogsMsg:
 		if msg.err != nil {
-			log.Debug("ocm.GetServiceLogs failed", "cluster_id", msg.clusterID, "error", msg.err)
-			return m, nil
+			log.Warn("ocm.GetServiceLogs failed", "cluster_id", msg.clusterID, "error", msg.err)
+			if m.serviceLogErrors == nil {
+				m.serviceLogErrors = make(map[string]error)
+			}
+			m.serviceLogErrors[msg.clusterID] = msg.err
+			return m, func() tea.Msg { return renderIncidentMsg("service logs error") }
 		}
 		if m.serviceLogCache == nil {
 			m.serviceLogCache = make(map[string][]ocm.ServiceLog)
 		}
 		m.serviceLogCache[msg.clusterID] = msg.logs
 		log.Info("service logs fetched", "cluster_id", msg.clusterID, "count", len(msg.logs))
-		return m, nil
+		return m, func() tea.Msg { return renderIncidentMsg("service logs arrived") }
 
 	case limitedSupportMsg:
 		if msg.err != nil {
-			log.Debug("ocm.GetLimitedSupportHistory failed", "cluster_id", msg.clusterID, "error", msg.err)
-			return m, nil
+			log.Warn("ocm.GetLimitedSupportHistory failed", "cluster_id", msg.clusterID, "error", msg.err)
+			if m.limitedSupportErrors == nil {
+				m.limitedSupportErrors = make(map[string]error)
+			}
+			m.limitedSupportErrors[msg.clusterID] = msg.err
+			return m, func() tea.Msg { return renderIncidentMsg("limited support error") }
 		}
 		if m.limitedSupportCache == nil {
 			m.limitedSupportCache = make(map[string][]ocm.LimitedSupportReason)
 		}
 		m.limitedSupportCache[msg.clusterID] = msg.reasons
 		log.Info("limited support fetched", "cluster_id", msg.clusterID, "count", len(msg.reasons))
-		return m, nil
+		return m, func() tea.Msg { return renderIncidentMsg("limited support arrived") }
 
 	case clusterReportsMsg:
 		if msg.err != nil {
-			log.Debug("backplane.ListReports failed", "cluster_id", msg.clusterID, "error", msg.err)
-			return m, nil
+			log.Warn("backplane.ListReports failed", "cluster_id", msg.clusterID, "error", msg.err)
+			if m.clusterReportErrors == nil {
+				m.clusterReportErrors = make(map[string]error)
+			}
+			m.clusterReportErrors[msg.clusterID] = msg.err
+			return m, func() tea.Msg { return renderIncidentMsg("reports error") }
 		}
 		if m.clusterReportCache == nil {
 			m.clusterReportCache = make(map[string][]backplane.Report)
 		}
 		m.clusterReportCache[msg.clusterID] = msg.reports
 		log.Info("cluster reports fetched", "cluster_id", msg.clusterID, "count", len(msg.reports))
-		return m, nil
+		return m, func() tea.Msg { return renderIncidentMsg("reports arrived") }
 
 	case priorAlertsMsg:
 		if m.priorAlertPending[msg.clusterID] > 0 {

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -364,7 +364,7 @@ func refreshArea(autoRefresh bool, autoAck bool, showLowUrgency bool) string {
 	return fstring
 }
 
-func (m model) renderTabContent() (string, error) {
+func (m model) renderTabContent() (string, bool, error) {
 	var alerts []pagerduty.IncidentAlert
 	var notes []pagerduty.IncidentNote
 
@@ -379,15 +379,17 @@ func (m model) renderTabContent() (string, error) {
 	summary.AlertsLoading = !m.incidentAlertsLoaded
 	summary.NotesLoading = !m.incidentNotesLoaded
 
+	var content string
+	var err error
 	switch m.activeTab {
 	case tabDetails:
-		return m.renderDetailsTab(summary)
+		content, err = m.renderDetailsTab(summary)
 	case tabAlerts:
-		return m.renderAlertsTab(summary)
+		content, err = m.renderAlertsTab(summary)
 	case tabNotes:
-		return m.renderNotesTab(summary)
+		content, err = m.renderNotesTab(summary)
 	case tabCluster:
-		return m.renderClusterTab()
+		content, err = m.renderClusterTab()
 	case tabServiceLogs:
 		return m.renderServiceLogsTab()
 	case tabLimitedSupport:
@@ -395,9 +397,9 @@ func (m model) renderTabContent() (string, error) {
 	case tabReports:
 		return m.renderClusterReportsTab()
 	case tabPDHistory:
-		return m.renderPDHistoryTab()
+		content, err = m.renderPDHistoryTab()
 	}
-	return "", nil
+	return content, false, err
 }
 
 func (m model) renderDetailsTab(summary incidentSummary) (string, error) {
@@ -542,15 +544,31 @@ func (m model) renderClusterTab() (string, error) {
 	return content.String(), nil
 }
 
-func (m model) renderServiceLogsTab() (string, error) {
+func (m model) renderEnrichmentError(section string, errs map[string]error) string {
+	var msgs []string
+	for _, err := range errs {
+		msgs = append(msgs, err.Error())
+	}
+	summary := strings.Join(msgs, "; ")
+	if len(summary) > 120 {
+		summary = summary[:120] + "..."
+	}
+	text := fmt.Sprintf("\nFailed to load %s: %s — see logs for details\n", section, summary)
+	return m.styles.InlineError.Render(text)
+}
+
+func (m model) renderServiceLogsTab() (string, bool, error) {
 	if len(m.serviceLogCache) == 0 {
+		if len(m.serviceLogErrors) > 0 {
+			return m.renderEnrichmentError("service logs", m.serviceLogErrors), true, nil
+		}
 		if m.ocmClient == nil {
 			if m.ocmAuthPending {
-				return "\n_OCM authenticating — complete login in browser..._\n", nil
+				return "\n_OCM authenticating — complete login in browser..._\n", false, nil
 			}
-			return "\n_OCM not connected_\n", nil
+			return "\n_OCM not connected_\n", false, nil
 		}
-		return "\n_Loading service logs..._\n", nil
+		return "\n_Loading service logs..._\n", false, nil
 	}
 
 	var allLogs []ocm.ServiceLog
@@ -567,7 +585,7 @@ func (m model) renderServiceLogsTab() (string, error) {
 	})
 
 	if len(allLogs) == 0 {
-		return "\n_No service logs (info-severity filtered)_\n", nil
+		return "\n_No service logs (info-severity filtered)_\n", false, nil
 	}
 
 	total := len(allLogs)
@@ -585,18 +603,21 @@ func (m model) renderServiceLogsTab() (string, error) {
 			content.WriteString("\n---\n")
 		}
 	}
-	return content.String(), nil
+	return content.String(), false, nil
 }
 
-func (m model) renderLimitedSupportTab() (string, error) {
+func (m model) renderLimitedSupportTab() (string, bool, error) {
 	if len(m.limitedSupportCache) == 0 {
+		if len(m.limitedSupportErrors) > 0 {
+			return m.renderEnrichmentError("limited support", m.limitedSupportErrors), true, nil
+		}
 		if m.ocmClient == nil {
 			if m.ocmAuthPending {
-				return "\n_OCM authenticating — complete login in browser..._\n", nil
+				return "\n_OCM authenticating — complete login in browser..._\n", false, nil
 			}
-			return "\n_OCM not connected_\n", nil
+			return "\n_OCM not connected_\n", false, nil
 		}
-		return "\n_No limited support history_\n", nil
+		return "\n_No limited support history_\n", false, nil
 	}
 
 	var allReasons []ocm.LimitedSupportReason
@@ -605,7 +626,7 @@ func (m model) renderLimitedSupportTab() (string, error) {
 	}
 
 	if len(allReasons) == 0 {
-		return "\n_No limited support history_\n", nil
+		return "\n_No limited support history_\n", false, nil
 	}
 
 	slices.SortFunc(allReasons, func(a, b ocm.LimitedSupportReason) int {
@@ -626,34 +647,38 @@ func (m model) renderLimitedSupportTab() (string, error) {
 			content.WriteString("\n---\n")
 		}
 	}
-	return content.String(), nil
+	return content.String(), false, nil
 }
 
-func (m model) renderClusterReportsTab() (string, error) {
+func (m model) renderClusterReportsTab() (string, bool, error) {
 	if m.backplaneClient == nil {
 		if m.backplaneConfig == nil {
-			return "\n_Backplane not enabled; ensure your ~/.config/backplane/config.json exists and is readable..._\n", nil
+			return "\n_Backplane not enabled; ensure your ~/.config/backplane/config.json exists and is readable..._\n", false, nil
 		}
 		if m.ocmAuthPending {
-			return "\n_Backplane initializing — completing OCM authentication..._\n", nil
+			return "\n_Backplane initializing — completing OCM authentication..._\n", false, nil
 		}
 		if m.ocmClient == nil {
-			return "\n_Backplane initializing — waiting for OCM connection..._\n", nil
+			return "\n_Backplane initializing — waiting for OCM connection..._\n", false, nil
 		}
 		if m.backplaneInitErr != nil {
-			return fmt.Sprintf("\n_Backplane not available — %v_\n", m.backplaneInitErr), nil
+			return fmt.Sprintf("\n_Backplane not available — %v_\n", m.backplaneInitErr), false, nil
 		}
-		return "\n_Backplane not available — check logs for details_\n", nil
+		return "\n_Backplane not available — check logs for details_\n", false, nil
+	}
+
+	if len(m.clusterReportErrors) > 0 && len(m.clusterReportCache) == 0 {
+		return m.renderEnrichmentError("cluster reports", m.clusterReportErrors), true, nil
 	}
 
 	if len(m.clusterReportCache) == 0 {
 		if m.ocmClient == nil {
 			if m.ocmAuthPending {
-				return "\n_OCM authenticating — complete login in browser..._\n", nil
+				return "\n_OCM authenticating — complete login in browser..._\n", false, nil
 			}
-			return "\n_OCM not connected_\n", nil
+			return "\n_OCM not connected_\n", false, nil
 		}
-		return "\n_Loading cluster reports..._\n", nil
+		return "\n_Loading cluster reports..._\n", false, nil
 	}
 
 	var allReports []backplane.Report
@@ -662,7 +687,7 @@ func (m model) renderClusterReportsTab() (string, error) {
 	}
 
 	if len(allReports) == 0 {
-		return "\n_No cluster reports_\n", nil
+		return "\n_No cluster reports_\n", false, nil
 	}
 
 	slices.SortFunc(allReports, func(a, b backplane.Report) int {
@@ -688,7 +713,7 @@ func (m model) renderClusterReportsTab() (string, error) {
 			content.WriteString("\n---\n")
 		}
 	}
-	return content.String(), nil
+	return content.String(), false, nil
 }
 
 func (m model) renderPDHistoryTab() (string, error) {

--- a/pkg/tui/views_render_test.go
+++ b/pkg/tui/views_render_test.go
@@ -20,7 +20,7 @@ func TestRenderClusterReportsTab_BackplaneNoConfig(t *testing.T) {
 	m.backplaneClient = nil
 	m.backplaneConfig = nil
 
-	content, err := m.renderClusterReportsTab()
+	content, _, err := m.renderClusterReportsTab()
 
 	assert.NoError(t, err)
 	assert.Contains(t, content, "Backplane not enabled")
@@ -32,7 +32,7 @@ func TestRenderClusterReportsTab_BackplaneOCMAuthPending(t *testing.T) {
 	m.backplaneConfig = &backplane.Config{}
 	m.ocmAuthPending = true
 
-	content, err := m.renderClusterReportsTab()
+	content, _, err := m.renderClusterReportsTab()
 
 	assert.NoError(t, err)
 	assert.Contains(t, content, "Backplane initializing")
@@ -46,7 +46,7 @@ func TestRenderClusterReportsTab_BackplaneWaitingForOCM(t *testing.T) {
 	m.ocmClient = nil
 	m.ocmAuthPending = false
 
-	content, err := m.renderClusterReportsTab()
+	content, _, err := m.renderClusterReportsTab()
 
 	assert.NoError(t, err)
 	assert.Contains(t, content, "Backplane initializing")
@@ -60,7 +60,7 @@ func TestRenderClusterReportsTab_BackplaneInitError(t *testing.T) {
 	m.ocmClient = createMockOCMClient()
 	m.backplaneInitErr = fmt.Errorf("no backplane URL in config or from OCM")
 
-	content, err := m.renderClusterReportsTab()
+	content, _, err := m.renderClusterReportsTab()
 
 	assert.NoError(t, err)
 	assert.Contains(t, content, "Backplane not available")
@@ -74,7 +74,7 @@ func TestRenderClusterReportsTab_BackplaneInitNoStoredError(t *testing.T) {
 	m.ocmClient = createMockOCMClient()
 	m.backplaneInitErr = nil
 
-	content, err := m.renderClusterReportsTab()
+	content, _, err := m.renderClusterReportsTab()
 
 	assert.NoError(t, err)
 	assert.Contains(t, content, "Backplane not available")
@@ -88,7 +88,7 @@ func TestRenderClusterReportsTab_OCMNotConnected(t *testing.T) {
 	m.ocmClient = nil
 	m.ocmAuthPending = false
 
-	content, err := m.renderClusterReportsTab()
+	content, _, err := m.renderClusterReportsTab()
 
 	assert.NoError(t, err)
 	assert.Contains(t, content, "OCM not connected")
@@ -101,7 +101,7 @@ func TestRenderClusterReportsTab_OCMAuthPending(t *testing.T) {
 	m.ocmClient = nil
 	m.ocmAuthPending = true
 
-	content, err := m.renderClusterReportsTab()
+	content, _, err := m.renderClusterReportsTab()
 
 	assert.NoError(t, err)
 	assert.Contains(t, content, "OCM authenticating")
@@ -113,7 +113,7 @@ func TestRenderClusterReportsTab_Loading(t *testing.T) {
 	m.clusterReportCache = map[string][]backplane.Report{}
 	m.ocmClient = createMockOCMClient()
 
-	content, err := m.renderClusterReportsTab()
+	content, _, err := m.renderClusterReportsTab()
 
 	assert.NoError(t, err)
 	assert.Contains(t, content, "Loading cluster reports")
@@ -127,7 +127,7 @@ func TestRenderClusterReportsTab_EmptyReports(t *testing.T) {
 		"fake-cluster-123": {},
 	}
 
-	content, err := m.renderClusterReportsTab()
+	content, _, err := m.renderClusterReportsTab()
 
 	assert.NoError(t, err)
 	assert.Contains(t, content, "No cluster reports")
@@ -146,7 +146,7 @@ func TestRenderClusterReportsTab_WithData(t *testing.T) {
 		},
 	}
 
-	content, err := m.renderClusterReportsTab()
+	content, _, err := m.renderClusterReportsTab()
 
 	assert.NoError(t, err)
 	assert.Contains(t, content, "Report 1/2")
@@ -171,11 +171,49 @@ func TestRenderClusterReportsTab_InvalidBase64FallsBackToRaw(t *testing.T) {
 		},
 	}
 
-	content, err := m.renderClusterReportsTab()
+	content, _, err := m.renderClusterReportsTab()
 
 	assert.NoError(t, err)
 	// On decode failure the raw Data is written verbatim.
 	assert.Contains(t, content, "not-valid-base64!!!")
+}
+
+func TestRenderClusterReportsTab_FetchError(t *testing.T) {
+	m := createTestModel()
+	m.backplaneClient = backplane.NewMockClient()
+	m.ocmClient = createMockOCMClient()
+	setupModelWithCluster(&m)
+	m.clusterReportCache = map[string][]backplane.Report{}
+	m.clusterReportErrors = map[string]error{
+		testClusterID: fmt.Errorf("unexpected status 403: user not allowed"),
+	}
+
+	content, preRendered, err := m.renderClusterReportsTab()
+
+	assert.NoError(t, err)
+	assert.True(t, preRendered, "error content should be pre-rendered to bypass glamour")
+	assert.Contains(t, content, "Failed to load cluster reports")
+	assert.Contains(t, content, "see logs for details")
+}
+
+func TestRenderClusterReportsTab_FetchErrorWithData(t *testing.T) {
+	m := createTestModel()
+	m.backplaneClient = backplane.NewMockClient()
+	m.ocmClient = createMockOCMClient()
+	setupModelWithCluster(&m)
+	m.clusterCache = map[string]*ocm.ClusterInfo{testClusterID: {ID: testClusterID}}
+	m.clusterReportCache = map[string][]backplane.Report{
+		testClusterID: {{ReportID: "r1", Summary: "good report", CreatedAt: "2026-06-01T00:00:00Z"}},
+	}
+	m.clusterReportErrors = map[string]error{
+		"other-cluster-id-fake-9999999999": fmt.Errorf("access denied"),
+	}
+
+	content, preRendered, err := m.renderClusterReportsTab()
+
+	assert.NoError(t, err)
+	assert.False(t, preRendered, "data content should go through glamour")
+	assert.Contains(t, content, "good report")
 }
 
 // indexOf is a small helper returning the index of sub in s, or -1.

--- a/pkg/tui/views_test.go
+++ b/pkg/tui/views_test.go
@@ -1086,7 +1086,7 @@ func TestRenderTabContent_DetailsTab(t *testing.T) {
 			incidentCache:        make(map[string]*cachedIncidentData),
 		}
 
-		content, err := m.renderTabContent()
+		content, _, err := m.renderTabContent()
 		assert.NoError(t, err)
 		assert.Contains(t, content, "Q999")
 		assert.Contains(t, content, "Tab Test Incident")
@@ -1120,7 +1120,7 @@ func TestRenderTabContent_AlertsTab(t *testing.T) {
 			},
 		}
 
-		content, err := m.renderTabContent()
+		content, _, err := m.renderTabContent()
 		assert.NoError(t, err)
 		assert.Contains(t, content, "**A1**")
 		assert.Contains(t, content, "**A2**")


### PR DESCRIPTION
## Summary
- Enrichment fetch errors (backplane reports 403, OCM service logs, limited support) were silently swallowed, leaving tabs stuck on "Loading..." forever
- Store per-section errors in model and render as red (Warning color) text with concise summary + "see logs for details" hint
- Fix existing bug where enrichment handlers didn't dispatch re-renders on success — tabs now update immediately when data arrives
- Move tui-mcp MCP server config from `.claude/settings.json` to `.mcp.json` (correct project-level location)

## Test plan
- [x] Unit tests for error storage in all three enrichment handlers
- [x] Unit tests for error display in all three tab render functions
- [x] Unit tests for preRendered flag and glamour bypass
- [x] Existing tests updated for new `renderTabContent()` signature
- [x] Full CI suite: fmt-check, vet, lint, test, test-race all pass
- [x] Visual verification via tui-mcp: no regressions in happy path

🤖 Generated with [Claude Code](https://claude.com/claude-code)