### PR TITLE
Add flashing OCM auth banner and block login during browser auth

### DIFF
--- a/docs/plans/408-auth-banner-login-block.md
+++ b/docs/plans/408-auth-banner-login-block.md
@@ -1,0 +1,78 @@
+# 408: Flashing OCM auth banner and login block
+
+## Problem
+
+When srepd starts with expired OCM tokens, it binds port 9998 via the OCM
+SDK's `auth.InitiateAuthCode()` for browser-based OAuth2 PKCE authentication.
+When the user presses `l` to login while this auth server is still running,
+srepd launches `ocm-container` which also calls `InitiateAuthCode()` on
+port 9998, causing a fatal `bind: address already in use` crash.
+
+Users also don't notice the browser auth prompt when it opens — there's no
+visible indication in srepd that they need to switch to their browser.
+
+Investigation confirmed:
+- Port 9998 is hardcoded in the upstream OCM SDK (`RedirectPort = "9998"`)
+- `ocm backplane login` does NOT trigger port 9998 (uses existing tokens)
+- Only `ocm-container` auto-triggers `InitiateAuthCode()` on every launch
+- Regular SDK token refresh does NOT bind port 9998 — only browser auth does
+- The existing `ocmAuthPending` field already tracks exactly this state
+
+## Approach
+
+Two coordinated features:
+
+1. **Color-cycling auth banner** in the bottom status bar — when
+   `ocmAuthPending` is true, show `>>> Please complete OCM browser auth <<<`
+   with a background color that cycles through 6 red/crimson shades every
+   500ms via a `tea.Tick` loop. Uses the same pattern as the typewriter
+   watcher animation.
+
+2. **Login block** at all 5 login entry points — prevents launching any
+   cluster login while auth is pending, with a flash notification explaining
+   why. Applies universally regardless of `cluster_login_command` since
+   srepd's own auth server is the source of the conflict.
+
+## Changes
+
+### Model (`model.go`)
+- Added `authBannerPhase int` field near `ocmAuthPending` — cycles 0-5 for
+  the color animation.
+
+### Commands (`commands.go`)
+- Added `authBannerTickMsg` type and `authBannerFlashInterval` (500ms) constant.
+- Added `startAuthBannerTick()` helper method.
+- Modified `ocmHandoffCmd()` to batch the tick start when setting
+  `ocmAuthPending = true`.
+
+### Update loop (`tui.go`)
+- Added `authBannerTickMsg` handler — cycles phase when auth is pending,
+  self-terminates when auth completes.
+- Added tick start in `Init()` when `ocmAuthPending` is true at startup.
+- Added `authBannerPhase = 0` reset in `OCMClientReadyMsg` handler.
+- Added auth guard in `loginMsg` and `rosaBoundaryLoginMsg` handlers.
+
+### Views (`views.go`)
+- Added `authBannerColors` slice (6 red/crimson shades).
+- Modified `renderBottomStatus()` — auth banner takes priority over the
+  update banner when `ocmAuthPending` is true.
+
+### Key handlers (`msgHandlers.go`)
+- Added auth guard in table-view and incident-view login key handlers.
+
+### Chords (`chords.go`)
+- Added auth guard in `chordRosaBoundaryLogin()`.
+
+### Tests (`auth_banner_test.go`)
+New test file with 10 test functions covering:
+- Tick phase cycling and wrapping
+- Tick self-termination when auth completes
+- `OCMClientReadyMsg` clearing banner phase
+- Banner rendering present/absent
+- Login blocked at all 5 entry points
+
+## Verification
+
+- `make test-all` passes (fmt, vet, lint, unit tests, race detection)
+- Golden snapshots unaffected (test models don't set `ocmAuthPending`)
+- Visual validation confirmed with test binary

--- a/pkg/tui/auth_banner_test.go
+++ b/pkg/tui/auth_banner_test.go
@@ -1,0 +1,197 @@
+package tui
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PagerDuty/go-pagerduty"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/clcollins/srepd/pkg/launcher"
+	"github.com/clcollins/srepd/pkg/ocm"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAuthBannerTickMsg_CyclesPhase(t *testing.T) {
+	tests := []struct {
+		name          string
+		startPhase    int
+		expectedPhase int
+	}{
+		{"0 to 1", 0, 1},
+		{"1 to 2", 1, 2},
+		{"4 to 5", 4, 5},
+		{"5 wraps to 0", 5, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := createTestModel()
+			m.ocmAuthPending = true
+			m.authBannerPhase = tt.startPhase
+
+			result, cmd := m.Update(authBannerTickMsg{})
+			updated := result.(model)
+
+			assert.Equal(t, tt.expectedPhase, updated.authBannerPhase)
+			assert.NotNil(t, cmd, "should schedule next tick")
+		})
+	}
+}
+
+func TestAuthBannerTickMsg_StopsWhenAuthDone(t *testing.T) {
+	t.Run("stops tick loop and resets phase when auth is complete", func(t *testing.T) {
+		m := createTestModel()
+		m.ocmAuthPending = false
+		m.authBannerPhase = 3
+
+		result, cmd := m.Update(authBannerTickMsg{})
+		updated := result.(model)
+
+		assert.Equal(t, 0, updated.authBannerPhase, "phase should reset to 0")
+		assert.Nil(t, cmd, "should not schedule next tick")
+	})
+}
+
+func TestOCMClientReadyMsg_ClearsBannerPhase(t *testing.T) {
+	t.Run("clears authBannerPhase on successful auth", func(t *testing.T) {
+		m := createTestModel()
+		m.ocmAuthPending = true
+		m.authBannerPhase = 4
+		m.incidentClusterMap = make(map[string][]string)
+		m.clusterEnrichInFlight = make(map[string]bool)
+		m.clusterEnrichFailed = make(map[string]int)
+		m.clusterCache = make(map[string]*ocm.ClusterInfo)
+		mock := createMockOCMClient()
+
+		result, _ := m.Update(OCMClientReadyMsg{Client: mock, Err: nil})
+		updated := result.(model)
+
+		assert.Equal(t, 0, updated.authBannerPhase)
+		assert.False(t, updated.ocmAuthPending)
+	})
+
+	t.Run("clears authBannerPhase on error", func(t *testing.T) {
+		m := createTestModel()
+		m.ocmAuthPending = true
+		m.authBannerPhase = 3
+
+		result, _ := m.Update(OCMClientReadyMsg{Err: fmt.Errorf("auth failed")})
+		updated := result.(model)
+
+		assert.Equal(t, 0, updated.authBannerPhase)
+		assert.False(t, updated.ocmAuthPending)
+	})
+}
+
+func TestRenderBottomStatus_AuthBanner(t *testing.T) {
+	t.Run("shows auth banner when ocmAuthPending is true", func(t *testing.T) {
+		m := sizedAuthTestModel(t)
+		m.ocmAuthPending = true
+		m.authBannerPhase = 0
+
+		output := m.renderBottomStatus()
+
+		assert.Contains(t, output, "Please complete OCM browser auth")
+	})
+}
+
+func TestRenderBottomStatus_NoAuthBanner(t *testing.T) {
+	t.Run("does not show auth banner when ocmAuthPending is false", func(t *testing.T) {
+		m := sizedAuthTestModel(t)
+		m.ocmAuthPending = false
+
+		output := m.renderBottomStatus()
+
+		assert.NotContains(t, output, "Please complete OCM browser auth")
+	})
+}
+
+func TestLoginMsg_BlockedDuringAuth(t *testing.T) {
+	t.Run("loginMsg blocked while OCM auth is pending", func(t *testing.T) {
+		m := createTestModel()
+		m.ocmAuthPending = true
+		m.selectedIncident = &pagerduty.Incident{
+			APIObject: pagerduty.APIObject{ID: "P123"},
+		}
+
+		result, cmd := m.Update(loginMsg("login"))
+		updated := result.(model)
+
+		assert.Contains(t, updated.status, "Login blocked")
+		assert.NotNil(t, cmd, "should return flash notification command")
+	})
+}
+
+func TestRosaBoundaryLoginMsg_BlockedDuringAuth(t *testing.T) {
+	t.Run("rosaBoundaryLoginMsg blocked while OCM auth is pending", func(t *testing.T) {
+		m := createTestModel()
+		m.ocmAuthPending = true
+		m.selectedIncident = &pagerduty.Incident{
+			APIObject: pagerduty.APIObject{ID: "P123"},
+		}
+
+		result, cmd := m.Update(rosaBoundaryLoginMsg("login"))
+		updated := result.(model)
+
+		assert.Contains(t, updated.status, "Login blocked")
+		assert.NotNil(t, cmd, "should return flash notification command")
+	})
+}
+
+func TestTableMode_LoginKeyBlockedDuringAuth(t *testing.T) {
+	t.Run("login key in table mode blocked while OCM auth is pending", func(t *testing.T) {
+		m := createTestModelWithSelectedIncident()
+		m.ocmAuthPending = true
+
+		result, cmd := m.Update(loginKeyMsg())
+		updated := result.(model)
+
+		assert.Contains(t, updated.status, "Login blocked")
+		assert.NotNil(t, cmd, "should return flash notification command")
+	})
+}
+
+func TestIncidentViewMode_LoginKeyBlockedDuringAuth(t *testing.T) {
+	t.Run("login key in incident view blocked while OCM auth is pending", func(t *testing.T) {
+		m := createTestModel()
+		m.ocmAuthPending = true
+		m.viewingIncident = true
+		m.selectedIncident = &pagerduty.Incident{
+			APIObject: pagerduty.APIObject{ID: "P123"},
+		}
+		m.incidentAlertsLoaded = true
+
+		result, cmd := m.Update(loginKeyMsg())
+		updated := result.(model)
+
+		assert.Contains(t, updated.status, "Login blocked")
+		assert.NotNil(t, cmd, "should return flash notification command")
+	})
+}
+
+func TestChordRosaBoundaryLogin_BlockedDuringAuth(t *testing.T) {
+	t.Run("rosa-boundary chord blocked while OCM auth is pending", func(t *testing.T) {
+		m := createTestModel()
+		m.ocmAuthPending = true
+		m.rosaBoundaryLauncher = launcher.ClusterLauncher{Enabled: true}
+		m.viewingIncident = true
+		m.selectedIncident = &pagerduty.Incident{
+			APIObject: pagerduty.APIObject{ID: "P123"},
+		}
+		m.incidentAlertsLoaded = true
+
+		result, cmd := chordRosaBoundaryLogin(m)
+		updated := result.(model)
+
+		assert.Contains(t, updated.status, "Login blocked")
+		assert.NotNil(t, cmd, "should return flash notification command")
+	})
+}
+
+func sizedAuthTestModel(t *testing.T) model {
+	t.Helper()
+	m := createTestModel()
+	result, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m, _ = result.(model)
+	return m
+}

--- a/pkg/tui/chords.go
+++ b/pkg/tui/chords.go
@@ -123,6 +123,9 @@ func chordHelpText(prefix string) string {
 }
 
 func chordRosaBoundaryLogin(m model) (tea.Model, tea.Cmd) {
+	if m.ocmAuthPending {
+		return m, m.flashNotification("Login blocked — complete OCM browser auth first")
+	}
 	if !m.rosaBoundaryLauncher.Enabled {
 		m.setStatus("rosa-boundary not configured")
 		return m, nil

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -357,6 +357,16 @@ type clearFlashMsg struct {
 	message string
 }
 
+type authBannerTickMsg struct{}
+
+const authBannerFlashInterval = 500 * time.Millisecond
+
+func (m *model) startAuthBannerTick() tea.Cmd {
+	return tea.Tick(authBannerFlashInterval, func(time.Time) tea.Msg {
+		return authBannerTickMsg{}
+	})
+}
+
 type PollIncidentsMsg struct{}
 
 type lazyEnrichMsg struct{}
@@ -1744,6 +1754,7 @@ func (m *model) ocmHandoffCmd(requirePDConfig bool) tea.Cmd {
 	cmd := m.connectOCMCmdIfNeeded()
 	if cmd != nil {
 		m.ocmAuthPending = true
+		return tea.Batch(cmd, m.startAuthBannerTick())
 	}
 	return cmd
 }

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -230,8 +230,9 @@ type model struct {
 	tourStep int
 
 	// OCM enrichment state
-	ocmClient      ocm.OCMClient
-	ocmAuthPending bool
+	ocmClient       ocm.OCMClient
+	ocmAuthPending  bool
+	authBannerPhase int
 	// ocmConnect overrides the post-wizard OCM connection for tests; nil
 	// means the real ocm.Connect (which may run browser auth).
 	ocmConnect            func() (ocm.OCMClient, error)

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -693,9 +693,9 @@ func switchTableFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 
 		case key.Matches(msg, defaultKeyMap.Login):
-			// Login uses doIfIncidentSelected() instead of the standard sync pattern
-			// because it needs to fetch full incident details + alerts from the API
-			// before proceeding (via getIncidentMsg + waitForSelectedIncidentThenDoMsg).
+			if m.ocmAuthPending {
+				return m, m.flashNotification("Login blocked — complete OCM browser auth first")
+			}
 			return m, doIfIncidentSelected(&m, func() tea.Msg {
 				return waitForSelectedIncidentThenDoMsg{action: func() tea.Msg { return loginMsg("login") }, msg: "wait"}
 			})
@@ -957,11 +957,13 @@ func switchIncidentFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, func() tea.Msg { return parseTemplateForNoteMsg("add note") }
 
 		case key.Matches(msg, defaultKeyMap.Login):
+			if m.ocmAuthPending {
+				return m, m.flashNotification("Login blocked — complete OCM browser auth first")
+			}
 			if m.selectedIncident == nil {
 				m.setStatus("no incident selected")
 				return m, nil
 			}
-			// Login requires alerts to extract cluster_id
 			if !m.incidentAlertsLoaded {
 				m.setStatus("Loading incident alerts, please wait...")
 				return m, nil

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -65,6 +65,10 @@ func (m model) Init() tea.Cmd {
 		initCmds = append(initCmds, fetchUserTeams(m.config.Client))
 	}
 
+	if m.ocmAuthPending {
+		initCmds = append(initCmds, m.startAuthBannerTick())
+	}
+
 	if m.configModeRequested {
 		initCmds = append(initCmds, prepareConfigWizardCmd(m))
 	}
@@ -392,6 +396,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case OCMClientReadyMsg:
 		m.ocmAuthPending = false
+		m.authBannerPhase = 0
 		if msg.Err != nil {
 			log.Warn("OCM authentication failed", "error", msg.Err)
 			return m, m.flashNotification("OCM auth failed — cluster enrichment disabled")
@@ -559,6 +564,14 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case TickMsg:
 		return m, tea.Batch(runScheduledJobs(&m)...)
+
+	case authBannerTickMsg:
+		if !m.ocmAuthPending {
+			m.authBannerPhase = 0
+			return m, nil
+		}
+		m.authBannerPhase = (m.authBannerPhase + 1) % 6
+		return m, m.startAuthBannerTick()
 
 	case typewriterTickMsg:
 		return m, m.advanceTypewriter()
@@ -1253,6 +1266,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmds = append(cmds, func() tea.Msg { return getIncidentMsg(m.selectedIncident.ID) })
 
 	case loginMsg:
+		if m.ocmAuthPending {
+			return m, m.flashNotification("Login blocked — complete OCM browser auth first")
+		}
 		if m.selectedIncident == nil {
 			m.setStatus("unable to login - no selected incident")
 			return m, nil
@@ -1327,6 +1343,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmds = append(cmds, login(vars, m.launcher, m.selectedIncident, m.selectedIncidentAlerts, m.selectedIncidentNotes))
 
 	case rosaBoundaryLoginMsg:
+		if m.ocmAuthPending {
+			return m, m.flashNotification("Login blocked — complete OCM browser auth first")
+		}
 		if m.selectedIncident == nil {
 			m.setStatus("unable to login via rosa-boundary - no selected incident")
 			return m, nil

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -279,6 +279,15 @@ func (m model) renderHeader() string {
 	return s.String()
 }
 
+var authBannerColors = []string{
+	"#a4133c",
+	"#800f2f",
+	"#590d22",
+	"#800f2f",
+	"#a4133c",
+	"#c9184a",
+}
+
 func (m model) renderBottomStatus() string {
 	var s strings.Builder
 	var selectedID string
@@ -287,7 +296,31 @@ func (m model) renderBottomStatus() string {
 		selectedID = m.selectedIncident.ID
 	}
 
-	if m.updateAvailable {
+	if m.ocmAuthPending {
+		authNotice := ">>> Please complete OCM browser auth <<<"
+		bgColor := authBannerColors[m.authBannerPhase%len(authBannerColors)]
+		authStyle := lipgloss.NewStyle().
+			Bold(true).
+			Foreground(m.theme.Highlight).
+			Background(lipgloss.Color(bgColor)).
+			Padding(0, 1).
+			Align(lipgloss.Center)
+
+		leftWidth := windowSize.Width / 6
+		rightWidth := windowSize.Width / 4
+		centerWidth := windowSize.Width - leftWidth - rightWidth
+
+		versionDisplay := versionString()
+
+		s.WriteString(
+			lipgloss.JoinHorizontal(
+				0.2,
+				m.styles.Muted.Width(leftWidth).Padding(0, 0, 0, 1).Render(selectedID),
+				authStyle.Width(centerWidth).Render(authNotice),
+				m.styles.Muted.Width(rightWidth).Padding(0, 1, 0, 0).Align(lipgloss.Right).Render(versionDisplay),
+			),
+		)
+	} else if m.updateAvailable {
 		versionDisplay := updateString(Version, m.updateVersion)
 
 		updateNotice := fmt.Sprintf("An update is available: %s", m.updateVersion)


### PR DESCRIPTION
## Summary

- Adds a color-cycling "Please complete OCM browser auth" banner in the bottom status bar when OCM tokens are expired and browser auth is in progress
- Blocks all 5 login entry points (`l` key in table/incident view, loginMsg, rosaBoundaryLoginMsg, rosa-boundary chord) while auth is pending, preventing the port 9998 bind collision with ocm-container
- Banner cycles through 6 red/crimson background colors every 500ms using a self-terminating `tea.Tick` loop
- Banner disappears and login unblocks automatically when auth completes or fails

## Context

When srepd starts with expired OCM tokens, it binds port 9998 via the OCM SDK's `auth.InitiateAuthCode()` for PKCE browser auth. `ocm-container` also calls this function on launch when tokens are expired, causing a fatal `ListenAndServe(): listen tcp :9998: bind: address already in use` crash. Investigation confirmed the port is hardcoded in the upstream SDK and not configurable. Regular token refresh does NOT trigger this — only the browser auth flow does.

## Test plan

- [x] `make test-all` passes (fmt, vet, lint, unit tests, race detection)
- [x] 10 new tests in `auth_banner_test.go` covering tick cycling, self-termination, banner rendering, and login blocking at all 5 entry points
- [x] Golden snapshots unaffected
- [x] Visual validation with test binary confirmed color-cycling banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)