### PR TITLE
fix(tui): surface terminal login errors, remove tmux from separators

### DIFF
--- a/docs/plans/414-fix-login-error-surfacing.md
+++ b/docs/plans/414-fix-login-error-surfacing.md
@@ -1,0 +1,70 @@
+# Plan 414: Surface terminal login errors and remove tmux from separator profiles
+
+**Branch:** `srepd/fix-login-error-surfacing`
+
+## Problem
+
+When a terminal process launched by cluster login exits with an error,
+srepd silently swallows it. The `login()` function discards stderr
+(exec.Cmd.Stderr is nil) and reaps the child process in a fire-and-forget
+goroutine that only logs at Debug level. The user sees "login completed"
+with no indication anything went wrong.
+
+This was discovered when using `tmux -C` as the terminal — tmux failed
+with "error connecting to socket (No such file or directory)" but srepd
+showed no error. Additionally, tmux was incorrectly listed as a separator
+terminal despite being a multiplexer, not a terminal emulator.
+
+## Solution
+
+### 1. Capture stderr and surface exit errors
+
+- Add `bytes.Buffer` on `exec.Cmd.Stderr` to capture terminal process stderr
+- Add `loginProcessExitedMsg` type carrying `exitErr` and `stderr`
+- Add `waitCmd tea.Cmd` field to `loginFinishedMsg` — a blocking command
+  that waits on `c.Wait()` and returns `loginProcessExitedMsg`
+- Handle `loginProcessExitedMsg` in the Update loop: on error, route
+  through `errMsg` to the full-screen error modal (not the transient
+  status bar, which gets overwritten by polls within seconds)
+
+### 2. Remove tmux from separator terminals
+
+tmux is a terminal multiplexer, not a terminal emulator. It cannot open
+GUI windows on its own and should not be in `separatorTerminals`. Remove
+it so it falls through to `GenericProfile` (direct concatenation).
+
+## Key design decisions
+
+- **Error modal vs status bar:** Terminal exit errors go through `errMsg`
+  → `errMsgHandler` → full-screen error view. The status bar is too
+  transient — background polls overwrite it within seconds.
+- **waitCmd pattern:** Rather than blocking the entire `login()` command
+  on `c.Wait()` (which would freeze srepd until the terminal exits),
+  the wait is a separate `tea.Cmd` dispatched from `loginFinishedMsg`.
+  srepd stays responsive while the terminal runs.
+- **Stderr capture is best-effort:** For terminal emulators that open a
+  GUI window (gnome-terminal, ptyxis, etc.), stderr may be empty even on
+  failure. The exit code alone is still surfaced. For tools like tmux or
+  osascript, stderr contains the actual error message.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `pkg/tui/commands.go` | Add `loginProcessExitedMsg`, `waitCmd` field, stderr capture |
+| `pkg/tui/tui.go` | Handle `loginProcessExitedMsg`, dispatch `waitCmd` |
+| `pkg/launcher/profiles.go` | Remove tmux from `separatorTerminals` |
+| `pkg/tui/cluster_login_test.go` | Tests for new message types and dispatch |
+| `pkg/tui/commands_test.go` | Tests for waitCmd, exit error, stderr capture |
+| `pkg/launcher/launcher_test.go` | Update tmux profile expectation |
+| `pkg/launcher/profiles_test.go` | Update tmux profile detection test |
+
+## Related investigation
+
+A separate investigation into AppleScript terminal support (iTerm2,
+Terminal.app) identified three additional bugs not addressed in this PR:
+1. Environment variable passing is broken for AppleScript terminals
+2. No escaping of login command inside AppleScript strings
+3. macOS TCC permissions cause silent failures
+
+These findings are documented in the PR description for future work.

--- a/pkg/launcher/launcher_test.go
+++ b/pkg/launcher/launcher_test.go
@@ -282,10 +282,10 @@ func TestProfile_ReturnsDetectedProfile(t *testing.T) {
 			expectedProfile: "separator (gnome-terminal)",
 		},
 		{
-			name:            "tmux detected as SeparatorProfile",
+			name:            "tmux detected as GenericProfile",
 			terminal:        "tmux new-window -n %%CLUSTER_ID%%",
 			loginCommand:    "ocm-container -C %%CLUSTER_ID%%",
-			expectedProfile: "separator (tmux)",
+			expectedProfile: "generic",
 		},
 		{
 			name:            "konsole detected as FlagProfile",

--- a/pkg/launcher/profiles.go
+++ b/pkg/launcher/profiles.go
@@ -22,7 +22,7 @@ type TerminalProfile interface {
 
 // SeparatorProfile is used by terminals that expect a "--" separator
 // between their own flags and the executed command (gnome-terminal,
-// ptyxis, wezterm, BlackBox, tmux).
+// ptyxis, wezterm, BlackBox).
 type SeparatorProfile struct {
 	terminalName string
 }
@@ -166,7 +166,6 @@ var separatorTerminals = map[string]bool{
 	"ptyxis":         true,
 	"wezterm":        true,
 	"blackbox":       true,
-	"tmux":           true,
 }
 
 // flagTerminals maps executable names to the flag they use.

--- a/pkg/launcher/profiles_test.go
+++ b/pkg/launcher/profiles_test.go
@@ -29,8 +29,8 @@ func TestDetectProfile_Wezterm(t *testing.T) {
 
 func TestDetectProfile_Tmux(t *testing.T) {
 	profile := DetectTerminalProfile("tmux new-window -n test")
-	assert.IsType(t, &SeparatorProfile{}, profile)
-	assert.Contains(t, profile.Name(), "tmux")
+	assert.IsType(t, &GenericProfile{}, profile)
+	assert.Equal(t, "generic", profile.Name())
 }
 
 func TestDetectProfile_Konsole(t *testing.T) {

--- a/pkg/tui/cluster_login_test.go
+++ b/pkg/tui/cluster_login_test.go
@@ -212,8 +212,7 @@ func TestLoginProcessExitedMsg_WithError(t *testing.T) {
 		m := createTestModel()
 
 		exitErr := errors.New("exit status 1")
-		result, cmd := m.Update(loginProcessExitedMsg{exitErr: exitErr})
-		m = result.(model)
+		_, cmd := m.Update(loginProcessExitedMsg{exitErr: exitErr})
 
 		assert.NotNil(t, cmd, "should return a command wrapping errMsg")
 		msg := cmd()
@@ -230,8 +229,7 @@ func TestLoginProcessExitedMsg_WithErrorAndStderr(t *testing.T) {
 
 		exitErr := errors.New("exit status 1")
 		stderr := "error connecting to /tmp/tmux-106593/default (No such file or directory)"
-		result, cmd := m.Update(loginProcessExitedMsg{exitErr: exitErr, stderr: stderr})
-		m = result.(model)
+		_, cmd := m.Update(loginProcessExitedMsg{exitErr: exitErr, stderr: stderr})
 
 		assert.NotNil(t, cmd, "should return a command wrapping errMsg")
 		msg := cmd()

--- a/pkg/tui/cluster_login_test.go
+++ b/pkg/tui/cluster_login_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/PagerDuty/go-pagerduty"
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/log"
 	"github.com/clcollins/srepd/pkg/pd"
 	"github.com/stretchr/testify/assert"
@@ -140,9 +141,8 @@ func TestLoginFinishedMsg_HappyWithSelectedIncident(t *testing.T) {
 		}
 
 		output := captureLogOutput(log.InfoLevel, func() {
-			result, cmd := m.Update(loginFinishedMsg{err: nil})
+			result, _ := m.Update(loginFinishedMsg{err: nil})
 			m = result.(model)
-			assert.Nil(t, cmd, "no command should be returned on successful login")
 		})
 
 		assert.Contains(t, output, "login completed",
@@ -158,13 +158,100 @@ func TestLoginFinishedMsg_HappyWithoutSelectedIncident(t *testing.T) {
 		m.selectedIncident = nil
 
 		output := captureLogOutput(log.InfoLevel, func() {
-			result, cmd := m.Update(loginFinishedMsg{err: nil})
+			result, _ := m.Update(loginFinishedMsg{err: nil})
 			m = result.(model)
-			assert.Nil(t, cmd, "no command should be returned on successful login")
 		})
 
 		assert.Contains(t, output, "login completed",
 			"should log login completed at INFO level")
+	})
+}
+
+func TestLoginFinishedMsg_DispatchesWaitCmd(t *testing.T) {
+	t.Run("dispatches waitCmd when present", func(t *testing.T) {
+		m := createTestModel()
+		m.selectedIncident = &pagerduty.Incident{
+			APIObject: pagerduty.APIObject{ID: "P999"},
+		}
+
+		waitCalled := false
+		waitCmd := func() tea.Msg {
+			waitCalled = true
+			return loginProcessExitedMsg{}
+		}
+
+		result, cmd := m.Update(loginFinishedMsg{err: nil, waitCmd: waitCmd})
+		m = result.(model)
+
+		assert.NotNil(t, cmd, "should return the waitCmd")
+		msg := cmd()
+		assert.True(t, waitCalled, "waitCmd should have been invoked")
+		_, ok := msg.(loginProcessExitedMsg)
+		assert.True(t, ok, "waitCmd should produce loginProcessExitedMsg")
+	})
+}
+
+func TestLoginFinishedMsg_NilWaitCmd(t *testing.T) {
+	t.Run("returns nil cmd when waitCmd is nil", func(t *testing.T) {
+		m := createTestModel()
+		m.selectedIncident = nil
+
+		result, cmd := m.Update(loginFinishedMsg{err: nil, waitCmd: nil})
+		m = result.(model)
+
+		assert.Nil(t, cmd, "should return nil when waitCmd is nil")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// loginProcessExitedMsg
+// ---------------------------------------------------------------------------
+
+func TestLoginProcessExitedMsg_WithError(t *testing.T) {
+	t.Run("returns errMsg command for error modal", func(t *testing.T) {
+		m := createTestModel()
+
+		exitErr := errors.New("exit status 1")
+		result, cmd := m.Update(loginProcessExitedMsg{exitErr: exitErr})
+		m = result.(model)
+
+		assert.NotNil(t, cmd, "should return a command wrapping errMsg")
+		msg := cmd()
+		em, ok := msg.(errMsg)
+		assert.True(t, ok, "returned command should produce errMsg")
+		assert.Contains(t, em.Error(), "terminal exited with error")
+		assert.Contains(t, em.Error(), "exit status 1")
+	})
+}
+
+func TestLoginProcessExitedMsg_WithErrorAndStderr(t *testing.T) {
+	t.Run("includes stderr in errMsg for error modal", func(t *testing.T) {
+		m := createTestModel()
+
+		exitErr := errors.New("exit status 1")
+		stderr := "error connecting to /tmp/tmux-106593/default (No such file or directory)"
+		result, cmd := m.Update(loginProcessExitedMsg{exitErr: exitErr, stderr: stderr})
+		m = result.(model)
+
+		assert.NotNil(t, cmd, "should return a command wrapping errMsg")
+		msg := cmd()
+		em, ok := msg.(errMsg)
+		assert.True(t, ok, "returned command should produce errMsg")
+		assert.Contains(t, em.Error(), "exit status 1")
+		assert.Contains(t, em.Error(), "No such file or directory")
+	})
+}
+
+func TestLoginProcessExitedMsg_Success(t *testing.T) {
+	t.Run("no-op when process exits cleanly", func(t *testing.T) {
+		m := createTestModel()
+		m.status = "previous status"
+
+		result, cmd := m.Update(loginProcessExitedMsg{exitErr: nil})
+		m = result.(model)
+
+		assert.Equal(t, "previous status", m.status, "status should be unchanged on clean exit")
+		assert.Nil(t, cmd, "should not return a command")
 	})
 }
 

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -782,7 +782,13 @@ type rosaBoundaryLoginMsg string
 type rosaBoundaryClusterSelectedMsg string
 
 type loginFinishedMsg struct {
-	err error
+	err     error
+	waitCmd tea.Cmd
+}
+
+type loginProcessExitedMsg struct {
+	exitErr error
+	stderr  string
 }
 
 // buildPagerDutyEnvVars constructs a slice of "-e", "KEY=VALUE" pairs for passing
@@ -967,6 +973,9 @@ func login(vars map[string]string, l launcher.ClusterLauncher, incident *pagerdu
 
 		c := exec.Command(finalCommand[0], finalCommand[1:]...)
 
+		var stderrBuf bytes.Buffer
+		c.Stderr = &stderrBuf
+
 		// For the non-ocm-container, non-toolbox case, set env vars on the process
 		if len(processEnvVars) > 0 {
 			c.Env = append(os.Environ(), processEnvVars...)
@@ -980,19 +989,19 @@ func login(vars map[string]string, l launcher.ClusterLauncher, incident *pagerdu
 		startCmdErr := c.Start()
 		if startCmdErr != nil {
 			log.Error("tui.login()", "error", startCmdErr)
-			return loginFinishedMsg{startCmdErr}
+			return loginFinishedMsg{err: startCmdErr}
 		}
 
-		// Reap the child process in background to avoid zombies.
-		// Don't block — return immediately so srepd stays responsive.
-		go func() {
+		waitCmd := func() tea.Msg {
 			err := c.Wait()
+			stderr := strings.TrimSpace(stderrBuf.String())
 			if err != nil {
-				log.Debug("tui.login(): terminal process exited", "error", err)
+				log.Debug("tui.login(): terminal process exited", "error", err, "stderr", stderr)
 			}
-		}()
+			return loginProcessExitedMsg{exitErr: err, stderr: stderr}
+		}
 
-		return loginFinishedMsg{}
+		return loginFinishedMsg{waitCmd: waitCmd}
 	}
 }
 

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -975,6 +975,7 @@ func login(vars map[string]string, l launcher.ClusterLauncher, incident *pagerdu
 
 		var stderrBuf bytes.Buffer
 		c.Stderr = &stderrBuf
+		c.WaitDelay = 5 * time.Second
 
 		// For the non-ocm-container, non-toolbox case, set env vars on the process
 		if len(processEnvVars) > 0 {

--- a/pkg/tui/commands_test.go
+++ b/pkg/tui/commands_test.go
@@ -679,10 +679,46 @@ func TestLogin_DoesNotStartUntilInvoked(t *testing.T) {
 	msg, ok := cmd().(loginFinishedMsg)
 	require.True(t, ok)
 	require.NoError(t, msg.err)
+	require.NotNil(t, msg.waitCmd, "should return a waitCmd for process reaping")
 	require.Eventually(t, func() bool {
 		_, err := os.Stat(target)
 		return err == nil
 	}, 2*time.Second, 10*time.Millisecond, "process should run once the command is invoked")
+}
+
+func TestLogin_WaitCmdReturnsExitError(t *testing.T) {
+	l, err := launcher.NewClusterLauncherWithToolbox("false", "%%CLUSTER_ID%%", "false", func() bool { return false })
+	require.NoError(t, err)
+
+	vars := map[string]string{"%%CLUSTER_ID%%": "unused"}
+	cmd := login(vars, l, nil, nil, nil)
+
+	msg, ok := cmd().(loginFinishedMsg)
+	require.True(t, ok)
+	require.NoError(t, msg.err, "Start() should succeed even when the process will fail")
+	require.NotNil(t, msg.waitCmd)
+
+	exitMsg, ok := msg.waitCmd().(loginProcessExitedMsg)
+	require.True(t, ok)
+	require.Error(t, exitMsg.exitErr, "false command should exit with error")
+}
+
+func TestLogin_WaitCmdCapturesStderr(t *testing.T) {
+	l, err := launcher.NewClusterLauncherWithToolbox("sh", "-c %%CLUSTER_ID%%", "false", func() bool { return false })
+	require.NoError(t, err)
+
+	vars := map[string]string{"%%CLUSTER_ID%%": "echo test-stderr-output >&2; exit 1"}
+	cmd := login(vars, l, nil, nil, nil)
+
+	msg, ok := cmd().(loginFinishedMsg)
+	require.True(t, ok)
+	require.NoError(t, msg.err)
+	require.NotNil(t, msg.waitCmd)
+
+	exitMsg, ok := msg.waitCmd().(loginProcessExitedMsg)
+	require.True(t, ok)
+	require.Error(t, exitMsg.exitErr)
+	assert.Contains(t, exitMsg.stderr, "test-stderr-output")
 }
 
 func TestRequeueAfterDelay_ReturnsOriginalMessage(t *testing.T) {

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -1466,6 +1466,20 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			log.Info("login completed")
 		}
+		if msg.waitCmd != nil {
+			return m, msg.waitCmd
+		}
+
+	case loginProcessExitedMsg:
+		if msg.exitErr != nil {
+			detail := msg.exitErr.Error()
+			if msg.stderr != "" {
+				detail = fmt.Sprintf("%s: %s", detail, msg.stderr)
+			}
+			loginErr := fmt.Errorf("terminal exited with error: %s", detail)
+			log.Error("tui.loginProcessExitedMsg()", "error", msg.exitErr, "stderr", msg.stderr)
+			return m, func() tea.Msg { return errMsg{loginErr} }
+		}
 
 	case openBrowserMsg:
 		if m.selectedIncident == nil {

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -1477,7 +1477,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				detail = fmt.Sprintf("%s: %s", detail, msg.stderr)
 			}
 			loginErr := fmt.Errorf("terminal exited with error: %s", detail)
-			log.Error("tui.loginProcessExitedMsg()", "error", msg.exitErr, "stderr", msg.stderr)
+			log.Debug("tui.loginProcessExitedMsg()", "error", msg.exitErr, "stderr", msg.stderr)
 			return m, func() tea.Msg { return errMsg{loginErr} }
 		}
 


### PR DESCRIPTION
## Summary

- **Surface terminal process errors:** Login errors were silently swallowed — stderr was discarded and `c.Wait()` errors were logged at Debug level in a fire-and-forget goroutine. Now stderr is captured via `bytes.Buffer`, a `loginProcessExitedMsg` carries exit errors back to the TUI, and errors route through `errMsg` to the full-screen error modal (not the transient status bar that polls overwrite).
- **Set `c.WaitDelay = 5s`** to bound `Wait()` when grandchildren inherit the stderr pipe (terminal emulators that fork/daemonize can hold it open indefinitely).
- **Remove tmux from `separatorTerminals`:** tmux is a terminal multiplexer, not a terminal emulator — it cannot open GUI windows and should not have `--` injected. Falls through to `GenericProfile` now.

## Behavior change note (tmux)

Users running srepd *inside* tmux with `terminal: tmux new-window` previously got `SeparatorProfile` which inserted `--` between terminal args and the login command. With `GenericProfile` the `--` is no longer inserted. tmux's option parser tolerates both forms, so this should be behavior-neutral — but it is technically a change for existing configs. tmux's man page does not document `--` as a supported separator.

## AppleScript terminal investigation (future work)

A parallel investigation into iTerm2 and Terminal.app support identified three additional bugs not fixed in this PR:

1. **Env var passing broken for AppleScript terminals:** `commandContainsOCMContainer()` matches "ocm-container" embedded in the AppleScript string, then `insertOCMContainerEnvFlags()` appends `-e KEY=VALUE` as extra `osascript` args (interpreted as AppleScript expressions, not env vars). The direct `exec.Cmd.Env` path also fails because env vars don't propagate across AppleEvents.
2. **No escaping in AppleScript strings:** Login command is interpolated raw into the AppleScript double-quoted string. `"` or `\` in any value would break the script.
3. **macOS TCC permissions:** First-run requires user approval for AppleEvent access. Denial causes silent error -1743 (now surfaced by this PR's error capture).

Full findings: `docs/plans/414-fix-login-error-surfacing.md`

## Test plan

- [x] All existing tests pass (`go test ./... -count=1`)
- [x] New tests for `loginProcessExitedMsg` (error, error+stderr, clean exit)
- [x] New tests for `loginFinishedMsg.waitCmd` dispatch
- [x] New tests for `login()` waitCmd (exit error, stderr capture)
- [x] Updated tmux profile detection tests (now GenericProfile)
- [x] `go vet`, `golangci-lint` clean
- [x] Manual test: `/tmp/srepd --dev` with broken terminal shows error modal
- [ ] Verify on macOS with iTerm2/Terminal.app (no macOS device available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)