### PR TITLE
fix(launcher): fix macOS AppleScript terminal env var passing and escaping

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -118,6 +118,11 @@ but rather a simple tool to make on-call tasks easier.`,
 		}
 	},
 	Run: func(cmd *cobra.Command, args []string) {
+		if dir, err := launcher.WrapperScriptDir(); err == nil {
+			if err := launcher.CleanupWrapperScripts(dir, 1*time.Hour); err != nil {
+				log.Warn("failed to clean up wrapper scripts", "error", err)
+			}
+		}
 
 		if viper.GetBool("dev") {
 			runDevMode()

--- a/docs/plans/415-fix-macos-applescript-terminal-integration.md
+++ b/docs/plans/415-fix-macos-applescript-terminal-integration.md
@@ -1,0 +1,96 @@
+# Plan 415: Fix macOS AppleScript terminal integration
+
+**Branch:** `srepd/fix-macos-terminal-integration`
+
+## Problem
+
+AppleScript terminal support (iTerm2, Terminal.app) has three bugs:
+
+1. **Env vars broken:** `commandContainsOCMContainer()` in `login()`
+   matched "ocm-container" inside the AppleScript string at `argv[2]`,
+   then `-e KEY=VAL` flags were appended as extra `osascript` arguments
+   rather than ocm-container arguments. Even if detection worked,
+   `strings.Join` flattening in `AppleScriptProfile.BuildCommand` would
+   re-tokenize env values containing spaces (incident titles, service
+   names) into extra arguments.
+2. **No escaping:** Login command interpolated raw into AppleScript
+   double-quoted string. `"` or `\` in values would break the script.
+3. **TCC permissions:** macOS TCC denial caused silent -1743 error.
+   Now surfaced by PR #420's error modal (already fixed).
+
+## Root cause
+
+The `login()` function operated on the post-profile-wrap command. For
+AppleScript profiles, the login command is buried inside an AppleScript
+string literal — there's no way to reliably splice `-e` flags or
+preserve argv boundaries at the exec.Cmd level.
+
+## Solution
+
+### 1. Wrapper script for ALL AppleScript terminals
+
+Route all AppleScript terminal launches through a wrapper script at
+`~/.cache/srepd/launch/login-<random>.sh`. The script:
+- Exports env vars with single-quote escaping (`'\''` idiom)
+- exec's the login command with each arg individually quoted
+- Preserves argv boundaries through the AppleScript → shell transition
+
+`NeedsWrapperScript()` on `ClusterLauncher` returns true whenever the
+profile is `*AppleScriptProfile` — both ocm-container and non-ocm flows.
+
+### 2. Pre-wrap ocm-container detection
+
+`LoginCommandContainsOCMContainer()` checks the raw
+`clusterLoginCommand` field (before profile wrapping), not the
+post-wrap command. When true and the profile is AppleScript, `-e`
+flags are inserted into the raw login command before writing the
+wrapper script — they land inside the properly-quoted exec line.
+
+### 3. AppleScript escaping (defense-in-depth)
+
+`appleScriptEscape()` escapes `\` → `\\` and `"` → `\"` in strings
+interpolated into AppleScript. Applied in `AppleScriptProfile.BuildCommand`.
+
+### 4. Startup cleanup
+
+`CleanupWrapperScripts()` prunes `.sh` files older than 1 hour from
+the launch directory at startup.
+
+## Key design decisions
+
+- **TerminalProfile interface unchanged:** No changes to `BuildCommand`
+  signature. The fix is entirely in the launcher and `login()` layers.
+- **All AppleScript through wrapper:** Even ocm-container with
+  AppleScript uses the wrapper. `strings.Join` flattening breaks env
+  values with spaces, which routinely appear in PagerDuty data.
+- **`BuildLoginCommandWithEnv` kept for non-AppleScript ocm profiles:**
+  SeparatorProfile, FlagProfile, DirectProfile all preserve argv
+  boundaries through exec.Command, so the simpler inject-then-wrap
+  path works correctly for them.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `pkg/launcher/launcher.go` | Add `LoginCommandContainsOCMContainer`, `NeedsWrapperScript`, `BuildLoginCommandWithEnv`, `BuildRawLoginCommand`, `BuildLoginCommandForScript`, export `InsertEnvFlagsAfterOCMContainer` |
+| `pkg/launcher/wrapper.go` | **New:** `WriteWrapperScript`, `CleanupWrapperScripts`, `WrapperScriptDir`, `shQuote` |
+| `pkg/launcher/profiles.go` | Add `appleScriptEscape`, apply in `AppleScriptProfile.BuildCommand` |
+| `pkg/tui/commands.go` | Refactor `login()` env var flow to use pre-wrap detection; remove `commandContainsOCMContainer` and `insertOCMContainerEnvFlags` (moved to launcher) |
+| `cmd/root.go` | Call `CleanupWrapperScripts()` at startup |
+| `pkg/launcher/launcher_test.go` | Tests for all new launcher methods |
+| `pkg/launcher/wrapper_test.go` | **New:** wrapper script tests including space-in-env regression |
+| `pkg/launcher/profiles_test.go` | Tests for `appleScriptEscape` and escaping in `BuildCommand` |
+| `pkg/tui/commands_test.go` | Remove tests for deleted functions |
+
+## macOS testing note
+
+No macOS device available for testing. The fix is validated by:
+- Unit tests for all new functions
+- Regression test for ocm-container + AppleScript with space-containing env values
+- All existing tests pass (no View() changes, no golden snapshot changes)
+- Build and `--dev` mode validation on Linux
+
+## Related
+
+- PR #420: Surface terminal login errors, remove tmux from separators
+- Plan 414: Login error surfacing investigation findings

--- a/pkg/launcher/launcher.go
+++ b/pkg/launcher/launcher.go
@@ -185,6 +185,143 @@ func (l *ClusterLauncher) Profile() TerminalProfile {
 	return l.profile
 }
 
+// LoginCommandContainsOCMContainer checks the raw clusterLoginCommand
+// (before profile wrapping) for the presence of "ocm-container". This
+// determines whether -e flags should be spliced into the login command
+// as ocm-container environment arguments.
+func (l *ClusterLauncher) LoginCommandContainsOCMContainer() bool {
+	for _, arg := range l.clusterLoginCommand {
+		if strings.Contains(arg, "ocm-container") {
+			return true
+		}
+	}
+	return false
+}
+
+// NeedsWrapperScript returns true when the terminal profile is an
+// AppleScriptProfile. AppleScript terminals need a wrapper script because:
+//  1. exec.Cmd.Env doesn't cross AppleEvents
+//  2. Even with ocm-container, strings.Join flattening in AppleScript
+//     re-tokenizes env values containing spaces (e.g., incident titles)
+//
+// The wrapper script's single-quoted exec line preserves argv boundaries.
+func (l *ClusterLauncher) NeedsWrapperScript() bool {
+	if l.profile == nil {
+		return false
+	}
+	_, isAppleScript := l.profile.(*AppleScriptProfile)
+	return isAppleScript
+}
+
+// BuildLoginCommandWithEnv builds the login command with -e env flags
+// inserted into the login command at the correct position for ocm-container
+// (after the ocm-container arg, before its other arguments), and then
+// applies the terminal profile wrapping. This ensures env flags ride
+// inside the login command string even for AppleScript profiles where
+// the login command gets interpolated into an AppleScript string.
+func (l *ClusterLauncher) BuildLoginCommandWithEnv(vars map[string]string, envFlags []string) []string {
+	profile := l.profile
+	if profile == nil {
+		profile = &GenericProfile{}
+	}
+
+	terminalArgs := []string{l.terminal[0]}
+	if len(l.terminal) > 1 {
+		terminalArgs = append(terminalArgs, replaceVars(l.terminal[1:], vars)...)
+	}
+
+	loginCmd := replaceVars(l.clusterLoginCommand, vars)
+
+	if len(envFlags) > 0 {
+		loginCmd = InsertEnvFlagsAfterOCMContainer(loginCmd, envFlags)
+	}
+
+	var command []string
+	if alreadyHasSeparator(profile, terminalArgs) {
+		command = append(terminalArgs, loginCmd...)
+	} else {
+		var err error
+		command, err = profile.BuildCommand(terminalArgs, loginCmd)
+		if err != nil {
+			log.Debug("launcher.BuildLoginCommandWithEnv(): profile.BuildCommand failed, falling back", "error", err)
+			command = append(terminalArgs, loginCmd...)
+		}
+	}
+
+	if l.runInToolbox {
+		command = append([]string{"flatpak-spawn", "--host"}, command...)
+	}
+
+	l.logCommand(command)
+	return command
+}
+
+// InsertEnvFlagsAfterOCMContainer inserts -e env flags into a login
+// command slice right after the ocm-container argument.
+func InsertEnvFlagsAfterOCMContainer(loginCmd []string, envFlags []string) []string {
+	ocmIdx := -1
+	for i, arg := range loginCmd {
+		if strings.Contains(arg, "ocm-container") {
+			ocmIdx = i
+			break
+		}
+	}
+
+	if ocmIdx < 0 {
+		return loginCmd
+	}
+
+	insertIdx := ocmIdx + 1
+	result := make([]string, 0, len(loginCmd)+len(envFlags))
+	result = append(result, loginCmd[:insertIdx]...)
+	result = append(result, envFlags...)
+	result = append(result, loginCmd[insertIdx:]...)
+	return result
+}
+
+// BuildRawLoginCommand returns the login command with variables replaced
+// but without any terminal profile wrapping. Used when the caller needs
+// the raw command (e.g., for writing a wrapper script).
+func (l *ClusterLauncher) BuildRawLoginCommand(vars map[string]string) []string {
+	return replaceVars(l.clusterLoginCommand, vars)
+}
+
+// BuildLoginCommandForScript builds a terminal command that executes a
+// wrapper script instead of the original login command. The script path
+// is passed as the login command to the terminal profile.
+func (l *ClusterLauncher) BuildLoginCommandForScript(vars map[string]string, scriptPath string) []string {
+	profile := l.profile
+	if profile == nil {
+		profile = &GenericProfile{}
+	}
+
+	terminalArgs := []string{l.terminal[0]}
+	if len(l.terminal) > 1 {
+		terminalArgs = append(terminalArgs, replaceVars(l.terminal[1:], vars)...)
+	}
+
+	loginCmd := []string{scriptPath}
+
+	var command []string
+	if alreadyHasSeparator(profile, terminalArgs) {
+		command = append(terminalArgs, loginCmd...)
+	} else {
+		var err error
+		command, err = profile.BuildCommand(terminalArgs, loginCmd)
+		if err != nil {
+			log.Debug("launcher.BuildLoginCommandForScript(): profile.BuildCommand failed, falling back", "error", err)
+			command = append(terminalArgs, loginCmd...)
+		}
+	}
+
+	if l.runInToolbox {
+		command = append([]string{"flatpak-spawn", "--host"}, command...)
+	}
+
+	l.logCommand(command)
+	return command
+}
+
 func (l *ClusterLauncher) BuildLoginCommand(vars map[string]string) []string {
 	// Ensure a profile is set; default to GenericProfile if nil (e.g.,
 	// when ClusterLauncher was constructed directly without NewClusterLauncher).

--- a/pkg/launcher/launcher_test.go
+++ b/pkg/launcher/launcher_test.go
@@ -453,6 +453,240 @@ func TestReplaceVars_PreservesArgBoundaries(t *testing.T) {
 	})
 }
 
+// ---------------------------------------------------------------------------
+// LoginCommandContainsOCMContainer
+// ---------------------------------------------------------------------------
+
+func TestLoginCommandContainsOCMContainer(t *testing.T) {
+	tests := []struct {
+		name     string
+		loginCmd []string
+		expected bool
+	}{
+		{
+			name:     "ocm-container as first arg",
+			loginCmd: []string{"ocm-container", "-C", "%%CLUSTER_ID%%"},
+			expected: true,
+		},
+		{
+			name:     "ocm-container with path prefix",
+			loginCmd: []string{"/usr/local/bin/ocm-container", "-C", "%%CLUSTER_ID%%"},
+			expected: true,
+		},
+		{
+			name:     "ocm backplane login (no ocm-container)",
+			loginCmd: []string{"ocm", "backplane", "login", "%%CLUSTER_ID%%"},
+			expected: false,
+		},
+		{
+			name:     "rosa-boundary (no ocm-container)",
+			loginCmd: []string{"rosa-boundary", "start-task", "--cluster-id", "%%CLUSTER_ID%%"},
+			expected: false,
+		},
+		{
+			name:     "empty login command",
+			loginCmd: []string{},
+			expected: false,
+		},
+		{
+			name:     "nil login command",
+			loginCmd: nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := ClusterLauncher{
+				clusterLoginCommand: tt.loginCmd,
+			}
+			assert.Equal(t, tt.expected, l.LoginCommandContainsOCMContainer())
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NeedsWrapperScript
+// ---------------------------------------------------------------------------
+
+func TestNeedsWrapperScript(t *testing.T) {
+	tests := []struct {
+		name     string
+		profile  TerminalProfile
+		loginCmd []string
+		expected bool
+	}{
+		{
+			name:     "AppleScript + non-ocm-container → needs wrapper",
+			profile:  &AppleScriptProfile{terminalName: "iterm2", appName: "iTerm2"},
+			loginCmd: []string{"ocm", "backplane", "login", "%%CLUSTER_ID%%"},
+			expected: true,
+		},
+		{
+			name:     "AppleScript + ocm-container → still needs wrapper (strings.Join breaks space-containing env values)",
+			profile:  &AppleScriptProfile{terminalName: "iterm2", appName: "iTerm2"},
+			loginCmd: []string{"ocm-container", "-C", "%%CLUSTER_ID%%"},
+			expected: true,
+		},
+		{
+			name:     "Separator profile + non-ocm → no wrapper",
+			profile:  &SeparatorProfile{terminalName: "gnome-terminal"},
+			loginCmd: []string{"ocm", "backplane", "login", "%%CLUSTER_ID%%"},
+			expected: false,
+		},
+		{
+			name:     "GenericProfile + non-ocm → no wrapper",
+			profile:  &GenericProfile{},
+			loginCmd: []string{"ocm", "backplane", "login", "%%CLUSTER_ID%%"},
+			expected: false,
+		},
+		{
+			name:     "nil profile → no wrapper",
+			profile:  nil,
+			loginCmd: []string{"ocm", "backplane", "login", "%%CLUSTER_ID%%"},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := ClusterLauncher{
+				profile:             tt.profile,
+				clusterLoginCommand: tt.loginCmd,
+			}
+			assert.Equal(t, tt.expected, l.NeedsWrapperScript())
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// BuildLoginCommandWithEnv
+// ---------------------------------------------------------------------------
+
+func TestBuildLoginCommandWithEnv_SeparatorProfile(t *testing.T) {
+	l := ClusterLauncher{
+		terminal:            []string{"gnome-terminal", "--"},
+		clusterLoginCommand: []string{"ocm-container", "-C", "%%CLUSTER_ID%%"},
+		profile:             &SeparatorProfile{terminalName: "gnome-terminal"},
+	}
+	vars := map[string]string{"%%CLUSTER_ID%%": "test-123"}
+	envFlags := []string{"-e", "KEY1=val1", "-e", "KEY2=val2"}
+
+	cmd := l.BuildLoginCommandWithEnv(vars, envFlags)
+
+	expected := []string{"gnome-terminal", "--", "ocm-container", "-e", "KEY1=val1", "-e", "KEY2=val2", "-C", "test-123"}
+	assert.Equal(t, expected, cmd)
+}
+
+func TestBuildLoginCommandWithEnv_AppleScriptProfile(t *testing.T) {
+	l := ClusterLauncher{
+		terminal:            []string{"iterm2"},
+		clusterLoginCommand: []string{"ocm-container", "-C", "%%CLUSTER_ID%%"},
+		profile:             &AppleScriptProfile{terminalName: "iterm2", appName: "iTerm2"},
+	}
+	vars := map[string]string{"%%CLUSTER_ID%%": "test-456"}
+	envFlags := []string{"-e", "INC_ID=P999"}
+
+	cmd := l.BuildLoginCommandWithEnv(vars, envFlags)
+
+	assert.Equal(t, "osascript", cmd[0])
+	assert.Equal(t, "-e", cmd[1])
+	assert.Len(t, cmd, 3, "AppleScript output should be exactly [osascript, -e, <script>]")
+	script := cmd[2]
+	assert.Contains(t, script, "ocm-container -e INC_ID=P999 -C test-456",
+		"env flags must be inside the AppleScript string, after ocm-container and before other args")
+}
+
+func TestBuildLoginCommandWithEnv_EmptyEnvFlags(t *testing.T) {
+	l := ClusterLauncher{
+		terminal:            []string{"gnome-terminal", "--"},
+		clusterLoginCommand: []string{"ocm-container", "-C", "%%CLUSTER_ID%%"},
+		profile:             &SeparatorProfile{terminalName: "gnome-terminal"},
+	}
+	vars := map[string]string{"%%CLUSTER_ID%%": "test-789"}
+
+	cmd := l.BuildLoginCommandWithEnv(vars, []string{})
+	cmdNoEnv := l.BuildLoginCommand(vars)
+
+	assert.Equal(t, cmdNoEnv, cmd, "empty envFlags should produce same result as BuildLoginCommand")
+}
+
+func TestBuildLoginCommandWithEnv_ToolboxWrapping(t *testing.T) {
+	l := ClusterLauncher{
+		terminal:            []string{"gnome-terminal", "--"},
+		clusterLoginCommand: []string{"ocm-container", "-C", "%%CLUSTER_ID%%"},
+		profile:             &SeparatorProfile{terminalName: "gnome-terminal"},
+		runInToolbox:        true,
+	}
+	vars := map[string]string{"%%CLUSTER_ID%%": "test-tb"}
+	envFlags := []string{"-e", "K=V"}
+
+	cmd := l.BuildLoginCommandWithEnv(vars, envFlags)
+
+	assert.Equal(t, "flatpak-spawn", cmd[0], "toolbox wrapping should still be applied")
+	assert.Equal(t, "--host", cmd[1])
+	assert.Contains(t, cmd, "-e")
+	assert.Contains(t, cmd, "K=V")
+}
+
+func TestBuildLoginCommandWithEnv_MultipleEnvFlags(t *testing.T) {
+	l := ClusterLauncher{
+		terminal:            []string{"ptyxis"},
+		clusterLoginCommand: []string{"ocm-container", "-C", "%%CLUSTER_ID%%"},
+		profile:             &SeparatorProfile{terminalName: "ptyxis"},
+	}
+	vars := map[string]string{"%%CLUSTER_ID%%": "abc"}
+	envFlags := []string{"-e", "A=1", "-e", "B=2", "-e", "C=3"}
+
+	cmd := l.BuildLoginCommandWithEnv(vars, envFlags)
+
+	cmdStr := strings.Join(cmd, " ")
+	assert.Contains(t, cmdStr, "ocm-container -e A=1 -e B=2 -e C=3 -C abc",
+		"all env flags should be inserted between ocm-container and its arguments")
+}
+
+// ---------------------------------------------------------------------------
+// BuildRawLoginCommand
+// ---------------------------------------------------------------------------
+
+func TestBuildRawLoginCommand(t *testing.T) {
+	l := ClusterLauncher{
+		terminal:            []string{"iterm2"},
+		clusterLoginCommand: []string{"ocm", "backplane", "login", "%%CLUSTER_ID%%"},
+		profile:             &AppleScriptProfile{terminalName: "iterm2", appName: "iTerm2"},
+	}
+	vars := map[string]string{"%%CLUSTER_ID%%": "test-raw"}
+
+	cmd := l.BuildRawLoginCommand(vars)
+
+	assert.Equal(t, []string{"ocm", "backplane", "login", "test-raw"}, cmd,
+		"should only replace vars in login cmd, no profile wrapping")
+}
+
+// ---------------------------------------------------------------------------
+// BuildLoginCommandForScript
+// ---------------------------------------------------------------------------
+
+func TestBuildLoginCommandForScript(t *testing.T) {
+	l := ClusterLauncher{
+		terminal:            []string{"iterm2"},
+		clusterLoginCommand: []string{"ocm", "backplane", "login", "%%CLUSTER_ID%%"},
+		profile:             &AppleScriptProfile{terminalName: "iterm2", appName: "iTerm2"},
+	}
+	vars := map[string]string{"%%CLUSTER_ID%%": "test-script"}
+
+	cmd := l.BuildLoginCommandForScript(vars, "/tmp/test-wrapper.sh")
+
+	assert.Equal(t, "osascript", cmd[0])
+	assert.Equal(t, "-e", cmd[1])
+	assert.Len(t, cmd, 3)
+	script := cmd[2]
+	assert.Contains(t, script, "/tmp/test-wrapper.sh",
+		"AppleScript should reference the wrapper script path")
+	assert.NotContains(t, script, "ocm",
+		"should NOT contain the original login command, only the script path")
+}
+
 // TestBuildLoginCommand_RosaBoundary documents that rosa-boundary shares the
 // cluster login conventions wholesale: it launches an interactive session
 // into a protected cluster exactly like ocm-container, so its launcher

--- a/pkg/launcher/profiles.go
+++ b/pkg/launcher/profiles.go
@@ -118,7 +118,7 @@ func (p *AppleScriptProfile) BuildCommand(terminalArgs []string, loginCmd []stri
 		return nil, fmt.Errorf("login command must not be empty")
 	}
 
-	fullLoginCmd := strings.Join(loginCmd, " ")
+	fullLoginCmd := appleScriptEscape(strings.Join(loginCmd, " "))
 
 	var script string
 	switch p.terminalName {
@@ -136,6 +136,14 @@ func (p *AppleScriptProfile) BuildCommand(terminalArgs []string, loginCmd []stri
 	}
 
 	return []string{"osascript", "-e", script}, nil
+}
+
+// appleScriptEscape escapes characters that are special inside
+// AppleScript double-quoted string literals.
+func appleScriptEscape(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	return s
 }
 
 // GenericProfile is the fallback that preserves the original launcher

--- a/pkg/launcher/profiles_test.go
+++ b/pkg/launcher/profiles_test.go
@@ -510,6 +510,81 @@ func TestAppleScriptProfile_BuildCommand_ITerm2_QuotesInCommand(t *testing.T) {
 	assert.Contains(t, script, "bash -c echo hello world")
 }
 
+// --- AppleScript escaping ---
+
+func TestAppleScriptEscape(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no special characters",
+			input:    "hello world",
+			expected: "hello world",
+		},
+		{
+			name:     "double quote",
+			input:    `say "hi"`,
+			expected: `say \"hi\"`,
+		},
+		{
+			name:     "backslash",
+			input:    `path\to\file`,
+			expected: `path\\to\\file`,
+		},
+		{
+			name:     "both quotes and backslashes",
+			input:    `a\"b`,
+			expected: `a\\\"b`,
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "unicode characters",
+			input:    "café résumé",
+			expected: "café résumé",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, appleScriptEscape(tt.input))
+		})
+	}
+}
+
+func TestAppleScriptProfile_BuildCommand_EscapesLoginCommand(t *testing.T) {
+	p := &AppleScriptProfile{terminalName: "iterm2", appName: "iTerm2"}
+	termArgs := []string{"iterm2"}
+	loginCmd := []string{"/tmp/login-script.sh"}
+
+	cmd, err := p.BuildCommand(termArgs, loginCmd)
+	require.NoError(t, err)
+
+	script := cmd[2]
+	assert.Contains(t, script, "/tmp/login-script.sh",
+		"simple path should pass through escaping unchanged")
+}
+
+func TestAppleScriptProfile_BuildCommand_EscapesBackslashInPath(t *testing.T) {
+	p := &AppleScriptProfile{terminalName: "terminal", appName: "Terminal"}
+	termArgs := []string{"terminal"}
+	loginCmd := []string{`/path/with\backslash/script.sh`}
+
+	cmd, err := p.BuildCommand(termArgs, loginCmd)
+	require.NoError(t, err)
+
+	script := cmd[2]
+	assert.Contains(t, script, `/path/with\\backslash/script.sh`,
+		"backslash in path must be escaped for AppleScript")
+	assert.NotContains(t, script, `with\b`,
+		"unescaped backslash should not appear")
+}
+
 func TestAppleScriptProfile_ValidateTerminal_ITerm2(t *testing.T) {
 	// "iterm2" is a virtual terminal name; validation should check for
 	// "osascript" rather than "iterm2" itself.

--- a/pkg/launcher/wrapper.go
+++ b/pkg/launcher/wrapper.go
@@ -1,0 +1,133 @@
+package launcher
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/log"
+)
+
+// shQuote wraps a string in single quotes for safe use in a POSIX shell
+// script. Single quotes inside the string are handled via the '\” idiom:
+// close the current single-quoted segment, emit an escaped single quote,
+// then reopen single quoting.
+func shQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+// WriteWrapperScript creates a short-lived shell script that exports
+// environment variables and exec's the login command. This is used for
+// AppleScript terminals where env vars cannot be passed via exec.Cmd.Env
+// (AppleEvents don't carry environment) or -e flags (no ocm-container).
+//
+// The baseDir parameter specifies where to create the script (e.g.,
+// ~/.cache/srepd/launch). The directory is created with 0700 permissions
+// if it doesn't exist.
+//
+// Returns the path to the created script.
+func WriteWrapperScript(loginCmd []string, envPairs []string, baseDir string) (string, error) {
+	if len(loginCmd) == 0 {
+		return "", fmt.Errorf("login command must not be empty")
+	}
+
+	if err := os.MkdirAll(baseDir, 0700); err != nil {
+		return "", fmt.Errorf("creating wrapper script directory: %w", err)
+	}
+
+	var b strings.Builder
+	b.WriteString("#!/bin/sh\n")
+
+	for _, pair := range envPairs {
+		eqIdx := strings.Index(pair, "=")
+		if eqIdx < 0 {
+			continue
+		}
+		key := pair[:eqIdx]
+		value := pair[eqIdx+1:]
+		fmt.Fprintf(&b, "export %s=%s\n", key, shQuote(value))
+	}
+
+	b.WriteString("exec")
+	for _, arg := range loginCmd {
+		b.WriteString(" ")
+		b.WriteString(shQuote(arg))
+	}
+	b.WriteString("\n")
+
+	f, err := os.CreateTemp(baseDir, "login-*.sh")
+	if err != nil {
+		return "", fmt.Errorf("creating wrapper script: %w", err)
+	}
+	path := f.Name()
+	success := false
+	defer func() {
+		_ = f.Close()
+		if !success {
+			_ = os.Remove(path)
+		}
+	}()
+
+	if _, err := f.WriteString(b.String()); err != nil {
+		return "", fmt.Errorf("writing wrapper script: %w", err)
+	}
+
+	if err := f.Chmod(0700); err != nil {
+		return "", fmt.Errorf("setting wrapper script permissions: %w", err)
+	}
+
+	success = true
+	log.Debug("launcher.WriteWrapperScript(): created wrapper", "path", path)
+	return path, nil
+}
+
+// CleanupWrapperScripts removes .sh files in baseDir older than maxAge.
+// It is best-effort: non-existent directories and individual removal
+// failures are logged but do not cause the function to return an error.
+func CleanupWrapperScripts(baseDir string, maxAge time.Duration) error {
+	entries, err := os.ReadDir(baseDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("reading wrapper script directory: %w", err)
+	}
+
+	cutoff := time.Now().Add(-maxAge)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if !strings.HasSuffix(entry.Name(), ".sh") {
+			continue
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			log.Debug("launcher.CleanupWrapperScripts(): stat failed", "file", entry.Name(), "error", err)
+			continue
+		}
+
+		if info.ModTime().Before(cutoff) {
+			path := filepath.Join(baseDir, entry.Name())
+			if err := os.Remove(path); err != nil {
+				log.Debug("launcher.CleanupWrapperScripts(): remove failed", "path", path, "error", err)
+			} else {
+				log.Debug("launcher.CleanupWrapperScripts(): removed stale wrapper", "path", path)
+			}
+		}
+	}
+
+	return nil
+}
+
+// WrapperScriptDir returns the default directory for wrapper scripts.
+func WrapperScriptDir() (string, error) {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("determining cache directory: %w", err)
+	}
+	return filepath.Join(cacheDir, "srepd", "launch"), nil
+}

--- a/pkg/launcher/wrapper_test.go
+++ b/pkg/launcher/wrapper_test.go
@@ -1,0 +1,286 @@
+package launcher
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// shQuote
+// ---------------------------------------------------------------------------
+
+func TestShQuote(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "simple string",
+			input:    "hello",
+			expected: "'hello'",
+		},
+		{
+			name:     "string with spaces",
+			input:    "hello world",
+			expected: "'hello world'",
+		},
+		{
+			name:     "string with single quote",
+			input:    "it's",
+			expected: "'it'\\''s'",
+		},
+		{
+			name:     "string with double quote",
+			input:    `say "hi"`,
+			expected: `'say "hi"'`,
+		},
+		{
+			name:     "string with dollar sign",
+			input:    "$HOME",
+			expected: "'$HOME'",
+		},
+		{
+			name:     "string with backslash",
+			input:    `path\to\file`,
+			expected: `'path\to\file'`,
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "''",
+		},
+		{
+			name:     "multiple single quotes",
+			input:    "a'b'c",
+			expected: "'a'\\''b'\\''c'",
+		},
+		{
+			name:     "string with backtick",
+			input:    "`cmd`",
+			expected: "'`cmd`'",
+		},
+		{
+			name:     "string with newline",
+			input:    "line1\nline2",
+			expected: "'line1\nline2'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, shQuote(tt.input))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WriteWrapperScript
+// ---------------------------------------------------------------------------
+
+func TestWriteWrapperScript_BasicContent(t *testing.T) {
+	tmpDir := t.TempDir()
+	loginCmd := []string{"ocm", "backplane", "login", "abc123"}
+	envPairs := []string{"PAGERDUTY_INCIDENT_ID=Q1ABC", "PAGERDUTY_CLUSTER_ID=abc123"}
+
+	path, err := WriteWrapperScript(loginCmd, envPairs, tmpDir)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(path, tmpDir))
+	assert.True(t, strings.HasSuffix(path, ".sh"))
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	script := string(content)
+
+	assert.True(t, strings.HasPrefix(script, "#!/bin/sh\n"))
+	assert.Contains(t, script, "export PAGERDUTY_INCIDENT_ID='Q1ABC'")
+	assert.Contains(t, script, "export PAGERDUTY_CLUSTER_ID='abc123'")
+	assert.Contains(t, script, "exec 'ocm' 'backplane' 'login' 'abc123'")
+}
+
+func TestWriteWrapperScript_SpecialCharsInEnvValues(t *testing.T) {
+	tmpDir := t.TempDir()
+	loginCmd := []string{"ocm", "backplane", "login", "test"}
+	envPairs := []string{
+		"TITLE=it's a test",
+		`URL=https://example.com?a=1&b="2"`,
+		"DOLLAR=$HOME/path",
+	}
+
+	path, err := WriteWrapperScript(loginCmd, envPairs, tmpDir)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	script := string(content)
+
+	assert.Contains(t, script, "export TITLE='it'\\''s a test'")
+	assert.Contains(t, script, "export URL='https://example.com?a=1&b=\"2\"'")
+	assert.Contains(t, script, "export DOLLAR='$HOME/path'")
+}
+
+func TestWriteWrapperScript_SpacesInArgv(t *testing.T) {
+	tmpDir := t.TempDir()
+	loginCmd := []string{"bash", "-c", "echo hello world"}
+	envPairs := []string{"K=V"}
+
+	path, err := WriteWrapperScript(loginCmd, envPairs, tmpDir)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	script := string(content)
+
+	assert.Contains(t, script, "exec 'bash' '-c' 'echo hello world'")
+}
+
+func TestWriteWrapperScript_FilePermissions(t *testing.T) {
+	tmpDir := t.TempDir()
+	loginCmd := []string{"test"}
+	envPairs := []string{"K=V"}
+
+	path, err := WriteWrapperScript(loginCmd, envPairs, tmpDir)
+	require.NoError(t, err)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0700), info.Mode().Perm(),
+		"wrapper script must be executable only by owner")
+}
+
+func TestWriteWrapperScript_EmptyEnvPairs(t *testing.T) {
+	tmpDir := t.TempDir()
+	loginCmd := []string{"ocm", "backplane", "login", "abc"}
+
+	path, err := WriteWrapperScript(loginCmd, []string{}, tmpDir)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	script := string(content)
+
+	assert.NotContains(t, script, "export")
+	assert.Contains(t, script, "exec 'ocm' 'backplane' 'login' 'abc'")
+}
+
+func TestWriteWrapperScript_EmptyLoginCmd(t *testing.T) {
+	tmpDir := t.TempDir()
+	_, err := WriteWrapperScript([]string{}, []string{"K=V"}, tmpDir)
+	assert.Error(t, err)
+}
+
+func TestWriteWrapperScript_CreatesSubdirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	launchDir := filepath.Join(tmpDir, "srepd", "launch")
+
+	loginCmd := []string{"test-cmd"}
+	envPairs := []string{"K=V"}
+
+	path, err := WriteWrapperScript(loginCmd, envPairs, launchDir)
+	require.NoError(t, err)
+
+	dirInfo, err := os.Stat(launchDir)
+	require.NoError(t, err)
+	assert.True(t, dirInfo.IsDir())
+	assert.Equal(t, os.FileMode(0700), dirInfo.Mode().Perm(),
+		"launch directory must be accessible only by owner")
+
+	assert.True(t, strings.HasPrefix(path, launchDir))
+}
+
+// ---------------------------------------------------------------------------
+// Regression: ocm-container + AppleScript with space-containing env values
+// ---------------------------------------------------------------------------
+
+func TestWriteWrapperScript_OCMContainerWithSpacesInEnvValues(t *testing.T) {
+	tmpDir := t.TempDir()
+	loginCmd := []string{"ocm-container", "-e", "PAGERDUTY_INCIDENT_TITLE=CPU high on node-42", "-C", "abc123"}
+	envPairs := []string{
+		"PAGERDUTY_INCIDENT_SERVICE=Production Web Service",
+		"PAGERDUTY_ALERT_NAMES=NodeCPUHigh,NodeMemoryPressure",
+	}
+
+	path, err := WriteWrapperScript(loginCmd, envPairs, tmpDir)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	script := string(content)
+
+	assert.Contains(t, script, "export PAGERDUTY_INCIDENT_SERVICE='Production Web Service'",
+		"space-containing env value must be single-quoted to survive shell tokenization")
+	assert.Contains(t, script, "'ocm-container'",
+		"ocm-container must be quoted in exec line")
+	assert.Contains(t, script, "'-e'",
+		"-e flag must be a separate quoted arg")
+	assert.Contains(t, script, "'PAGERDUTY_INCIDENT_TITLE=CPU high on node-42'",
+		"space-containing -e value must be quoted to preserve it as one arg")
+}
+
+// ---------------------------------------------------------------------------
+// CleanupWrapperScripts
+// ---------------------------------------------------------------------------
+
+func TestCleanupWrapperScripts_RemovesOldFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	oldFile := filepath.Join(tmpDir, "login-old.sh")
+	err := os.WriteFile(oldFile, []byte("#!/bin/sh\n"), 0700)
+	require.NoError(t, err)
+	oldTime := time.Now().Add(-2 * time.Hour)
+	require.NoError(t, os.Chtimes(oldFile, oldTime, oldTime))
+
+	newFile := filepath.Join(tmpDir, "login-new.sh")
+	err = os.WriteFile(newFile, []byte("#!/bin/sh\n"), 0700)
+	require.NoError(t, err)
+
+	err = CleanupWrapperScripts(tmpDir, 1*time.Hour)
+	require.NoError(t, err)
+
+	_, err = os.Stat(oldFile)
+	assert.True(t, os.IsNotExist(err), "old file should be removed")
+
+	_, err = os.Stat(newFile)
+	assert.NoError(t, err, "recent file should be kept")
+}
+
+func TestCleanupWrapperScripts_EmptyDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	err := CleanupWrapperScripts(tmpDir, 1*time.Hour)
+	assert.NoError(t, err)
+}
+
+func TestCleanupWrapperScripts_NonexistentDirectory(t *testing.T) {
+	err := CleanupWrapperScripts("/tmp/nonexistent-srepd-test-dir-xyz", 1*time.Hour)
+	assert.NoError(t, err, "should not error on nonexistent directory")
+}
+
+func TestCleanupWrapperScripts_OnlyRemovesShFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	shFile := filepath.Join(tmpDir, "login-old.sh")
+	err := os.WriteFile(shFile, []byte("#!/bin/sh\n"), 0700)
+	require.NoError(t, err)
+	oldTime := time.Now().Add(-2 * time.Hour)
+	require.NoError(t, os.Chtimes(shFile, oldTime, oldTime))
+
+	otherFile := filepath.Join(tmpDir, "notes.txt")
+	err = os.WriteFile(otherFile, []byte("keep me"), 0600)
+	require.NoError(t, err)
+	require.NoError(t, os.Chtimes(otherFile, oldTime, oldTime))
+
+	err = CleanupWrapperScripts(tmpDir, 1*time.Hour)
+	require.NoError(t, err)
+
+	_, err = os.Stat(shFile)
+	assert.True(t, os.IsNotExist(err), "old .sh file should be removed")
+
+	_, err = os.Stat(otherFile)
+	assert.NoError(t, err, "non-.sh file should be kept even if old")
+}

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -872,52 +872,6 @@ func buildPagerDutyEnvVars(incident *pagerduty.Incident, alerts []pagerduty.Inci
 	return envFlags
 }
 
-// commandContainsOCMContainer returns true if any element of the command
-// slice contains "ocm-container", indicating this is an ocm-container flow
-// where -e flags should be passed directly as container arguments.
-func commandContainsOCMContainer(command []string) bool {
-	for _, arg := range command {
-		if strings.Contains(arg, "ocm-container") {
-			return true
-		}
-	}
-	return false
-}
-
-// insertOCMContainerEnvFlags inserts -e env flags into a command at the
-// correct position for ocm-container: after the ocm-container command itself
-// but before its other arguments (like --cluster-id).
-func insertOCMContainerEnvFlags(command []string, envFlags []string) []string {
-	if len(envFlags) == 0 {
-		return command
-	}
-
-	// Find the ocm-container argument in the command slice
-	ocmIdx := -1
-	for i, arg := range command {
-		if strings.Contains(arg, "ocm-container") {
-			ocmIdx = i
-			break
-		}
-	}
-
-	log.Debug("tui.insertOCMContainerEnvFlags()", "ocmIdx", ocmIdx, "commandLen", len(command))
-
-	if ocmIdx < 0 {
-		// No ocm-container found; return command unchanged
-		return command
-	}
-
-	// Insert env flags right after the ocm-container argument
-	insertIdx := ocmIdx + 1
-	result := make([]string, 0, len(command)+len(envFlags))
-	result = append(result, command[:insertIdx]...)
-	result = append(result, envFlags...)
-	result = append(result, command[insertIdx:]...)
-
-	return result
-}
-
 // extractEnvVarPairs extracts "KEY=VALUE" strings from a slice of
 // ["-e", "KEY=VALUE", "-e", "KEY2=VALUE2", ...] pairs. It skips the "-e"
 // elements and returns only the environment variable assignments, suitable
@@ -933,40 +887,53 @@ func extractEnvVarPairs(envFlags []string) []string {
 }
 
 func login(vars map[string]string, l launcher.ClusterLauncher, incident *pagerduty.Incident, alerts []pagerduty.IncidentAlert, notes []pagerduty.IncidentNote) tea.Cmd {
-	// All process work happens inside the returned command so the Update
-	// loop is never blocked by command construction or a slow Start().
-	// The arguments are snapshots (map, launcher value, pointer, slices),
-	// so deferring execution is safe.
 	return func() tea.Msg {
-		// The first element of Terminal is the command to be executed, followed by args, in order
-		// This handles if folks use, eg: flatpak run <some package> as a terminal.
-		command := l.BuildLoginCommand(vars)
-
-		// Build individual PAGERDUTY_* environment variables filtered to the selected cluster
 		clusterID := vars["%%CLUSTER_ID%%"]
 		envFlags := buildPagerDutyEnvVars(incident, alerts, notes, clusterID)
 
-		// Determine the correct env var passing mechanism based on the command flow:
-		// 1. ocm-container flow: use -e flags (they become podman -e flags)
-		// 2. Non-ocm-container in toolbox: use --env= flags on flatpak-spawn
-		// 3. Non-ocm-container, not in toolbox: set on exec.Cmd.Env
+		// Determine the correct env var passing mechanism. Detection uses
+		// the raw launcher state (before profile wrapping) so that
+		// AppleScript profiles don't break when "ocm-container" appears
+		// inside an AppleScript string literal.
 
 		var finalCommand []string
-		var processEnvVars []string // Only used for the exec.Cmd.Env case
+		var processEnvVars []string
 
-		if commandContainsOCMContainer(command) {
-			// ocm-container flow: insert -e flags into the command for ocm-container
-			finalCommand = insertOCMContainerEnvFlags(command, envFlags)
+		if l.NeedsWrapperScript() {
+			// AppleScript terminals: write a wrapper script that exports
+			// env vars and exec's the login command with proper quoting.
+			// This handles both ocm-container and non-ocm-container flows.
+			loginCmd := l.BuildRawLoginCommand(vars)
+			if l.LoginCommandContainsOCMContainer() {
+				loginCmd = launcher.InsertEnvFlagsAfterOCMContainer(loginCmd, envFlags)
+			}
+
+			wrapperDir, err := launcher.WrapperScriptDir()
+			if err != nil {
+				log.Error("tui.login(): wrapper dir", "error", err)
+				return loginFinishedMsg{err: fmt.Errorf("wrapper script setup: %w", err)}
+			}
+
+			scriptPath, err := launcher.WriteWrapperScript(loginCmd, extractEnvVarPairs(envFlags), wrapperDir)
+			if err != nil {
+				log.Error("tui.login(): wrapper script", "error", err)
+				return loginFinishedMsg{err: fmt.Errorf("wrapper script creation: %w", err)}
+			}
+
+			finalCommand = l.BuildLoginCommandForScript(vars, scriptPath)
+			log.Debug("tui.login(): AppleScript wrapper flow", "scriptPath", scriptPath, "finalCommand", finalCommand)
+		} else if l.LoginCommandContainsOCMContainer() {
+			// Non-AppleScript ocm-container: inject -e flags before
+			// profile wrapping so argv boundaries are preserved.
+			finalCommand = l.BuildLoginCommandWithEnv(vars, envFlags)
 			log.Debug("tui.login(): ocm-container flow", "finalCommand", finalCommand)
 		} else if l.IsToolbox() {
-			// Non-ocm-container in toolbox: use --env= flags on flatpak-spawn
-			// so that the host process launched via flatpak-spawn inherits them
+			command := l.BuildLoginCommand(vars)
 			toolboxFlags := l.ToolboxEnvFlags(envFlags)
 			finalCommand = launcher.InsertToolboxEnvFlags(command, toolboxFlags)
 			log.Debug("tui.login(): toolbox non-ocm-container flow", "toolboxFlags", toolboxFlags, "finalCommand", finalCommand)
 		} else {
-			// Non-ocm-container, not in toolbox: set env vars on the process directly
-			finalCommand = command
+			finalCommand = l.BuildLoginCommand(vars)
 			processEnvVars = extractEnvVarPairs(envFlags)
 			log.Debug("tui.login(): direct process env flow", "processEnvVars", processEnvVars, "finalCommand", finalCommand)
 		}
@@ -977,12 +944,10 @@ func login(vars map[string]string, l launcher.ClusterLauncher, incident *pagerdu
 		c.Stderr = &stderrBuf
 		c.WaitDelay = 5 * time.Second
 
-		// For the non-ocm-container, non-toolbox case, set env vars on the process
 		if len(processEnvVars) > 0 {
 			c.Env = append(os.Environ(), processEnvVars...)
 		}
 
-		log.Debug("tui.login(): original command", "command", command)
 		log.Debug("tui.login(): env flags", "envFlags", envFlags)
 		log.Debug("tui.login(): final command", "finalCommand", finalCommand)
 		log.Debug("tui.login()", "command", c.String())

--- a/pkg/tui/commands_test.go
+++ b/pkg/tui/commands_test.go
@@ -1538,68 +1538,6 @@ func TestGetUniqueClusters_MixedWithAndWithoutClusterID(t *testing.T) {
 	assert.Equal(t, []string{"cluster-abc-123", "cluster-def-456"}, result)
 }
 
-func TestCommandContainsOCMContainer_True(t *testing.T) {
-	tests := []struct {
-		name    string
-		command []string
-	}{
-		{
-			name:    "direct ocm-container command",
-			command: []string{"ocm-container", "--cluster-id", "abc123"},
-		},
-		{
-			name:    "gnome-terminal with ocm-container",
-			command: []string{"gnome-terminal", "--", "ocm-container", "-C", "abc123"},
-		},
-		{
-			name:    "flatpak-spawn with ocm-container",
-			command: []string{"flatpak-spawn", "--host", "gnome-terminal", "--", "ocm-container", "-C", "abc123"},
-		},
-		{
-			name:    "tmux with ocm-container",
-			command: []string{"tmux", "new-window", "-n", "cluster", "ocm-container", "-C", "abc123"},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.True(t, commandContainsOCMContainer(tt.command), "expected true for command containing ocm-container")
-		})
-	}
-}
-
-func TestCommandContainsOCMContainer_False(t *testing.T) {
-	tests := []struct {
-		name    string
-		command []string
-	}{
-		{
-			name:    "ocm backplane login",
-			command: []string{"gnome-terminal", "--", "ocm", "backplane", "login", "abc123"},
-		},
-		{
-			name:    "direct ocm command",
-			command: []string{"ocm", "backplane", "login", "abc123"},
-		},
-		{
-			name:    "empty command",
-			command: []string{},
-		},
-		{
-			name:    "nil command",
-			command: nil,
-		},
-		{
-			name:    "flatpak-spawn without ocm-container",
-			command: []string{"flatpak-spawn", "--host", "gnome-terminal", "--", "ocm", "backplane", "login", "abc123"},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.False(t, commandContainsOCMContainer(tt.command), "expected false for command without ocm-container")
-		})
-	}
-}
-
 func TestExtractEnvVarPairs(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -1635,40 +1573,6 @@ func TestExtractEnvVarPairs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := extractEnvVarPairs(tt.input)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestInsertOCMContainerEnvFlags(t *testing.T) {
-	tests := []struct {
-		name     string
-		command  []string
-		envFlags []string
-		expected []string
-	}{
-		{
-			name:     "gnome-terminal with separator and ocm-container",
-			command:  []string{"gnome-terminal", "--", "ocm-container", "--cluster-id", "abc123"},
-			envFlags: []string{"-e", "KEY=val"},
-			expected: []string{"gnome-terminal", "--", "ocm-container", "-e", "KEY=val", "--cluster-id", "abc123"},
-		},
-		{
-			name:     "tmux with ocm-container no separator",
-			command:  []string{"tmux", "new-window", "ocm-container", "-C", "abc123"},
-			envFlags: []string{"-e", "KEY=val"},
-			expected: []string{"tmux", "new-window", "ocm-container", "-e", "KEY=val", "-C", "abc123"},
-		},
-		{
-			name:     "empty env flags returns command as-is",
-			command:  []string{"gnome-terminal", "--", "ocm-container", "--cluster-id", "abc123"},
-			envFlags: []string{},
-			expected: []string{"gnome-terminal", "--", "ocm-container", "--cluster-id", "abc123"},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := insertOCMContainerEnvFlags(tt.command, tt.envFlags)
 			assert.Equal(t, tt.expected, result)
 		})
 	}


### PR DESCRIPTION
## Summary

- **Fix broken env var passing** for AppleScript terminals (iTerm2, Terminal.app):
  all AppleScript launches now route through a wrapper script at
  `~/.cache/srepd/launch/login-*.sh` that exports env vars with
  single-quote escaping and exec's the login command with per-arg
  quoting, preserving argv boundaries across the AppleScript→shell
  transition
- **Move ocm-container detection** from post-wrap (commands.go) to
  pre-wrap (launcher layer) so it operates on the raw login command,
  not the AppleScript string literal
- **Add AppleScript escaping** (`\` → `\\`, `"` → `\"`) as
  defense-in-depth in `AppleScriptProfile.BuildCommand`
- **Add startup cleanup** of stale wrapper scripts (>1 hour) in
  `cmd/root.go`

### Bug details

Three bugs in AppleScript terminal support:

1. `commandContainsOCMContainer()` matched "ocm-container" inside the
   AppleScript string at `argv[2]`, then `-e KEY=VAL` flags were appended
   as extra `osascript` arguments (treated as AppleScript expressions, not
   env vars). Even if detection worked correctly, `strings.Join` flattening
   in `BuildCommand` re-tokenized space-containing values like incident
   titles into extra arguments.
2. Login command interpolated raw into AppleScript double-quoted string —
   `"` or `\` in values would break the script.
3. TCC permission denial caused silent error -1743 (already surfaced by
   PR #420's error modal).

### Design decisions

- **TerminalProfile interface unchanged** — fix is entirely in the
  launcher layer and `login()` refactor
- **All AppleScript through wrapper** — even ocm-container uses the
  wrapper script because `strings.Join` flattening breaks space-containing
  env values (incident titles, service names)
- **`BuildLoginCommandWithEnv` kept** for non-AppleScript ocm profiles
  where argv boundaries are preserved end-to-end

## Test plan

- [x] `TestLoginCommandContainsOCMContainer` — raw login cmd detection
- [x] `TestNeedsWrapperScript` — true for all AppleScript profiles
- [x] `TestBuildLoginCommandWithEnv` — env flag insertion before profile wrap
- [x] `TestBuildRawLoginCommand` / `TestBuildLoginCommandForScript`
- [x] `TestShQuote` — edge cases (single quotes, empty, backticks, newlines)
- [x] `TestWriteWrapperScript` — content, permissions, special chars, subdirectory creation
- [x] `TestWriteWrapperScript_OCMContainerWithSpacesInEnvValues` — **regression test**
- [x] `TestCleanupWrapperScripts` — old file removal, non-.sh preservation
- [x] `TestAppleScriptEscape` — quotes, backslashes, unicode
- [x] `TestAppleScriptProfile_BuildCommand_Escapes*` — escaping applied in BuildCommand
- [x] All existing tests pass, no golden snapshot changes
- [x] `make test-all` (fmt, vet, lint, test, race)
- [x] TUI smoke test with `--dev` mode — no regressions
- [ ] macOS testing: no device available; wrapper script approach validated by unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)