### PR TITLE
feat: show cluster creation timestamp in cluster context view

### DIFF
--- a/pkg/ocm/client.go
+++ b/pkg/ocm/client.go
@@ -272,6 +272,7 @@ func clusterFromResponse(cluster *cmv1.Cluster) *ClusterInfo {
 		State:         string(cluster.State()),
 		CloudProvider: cluster.CloudProvider().ID(),
 		Version:       cluster.OpenshiftVersion(),
+		CreatedAt:     cluster.CreationTimestamp(),
 	}
 
 	if cluster.Region() != nil {

--- a/pkg/ocm/fixtures.go
+++ b/pkg/ocm/fixtures.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 type fixtureCluster struct {
@@ -20,6 +21,7 @@ type fixtureCluster struct {
 	CCS            bool   `json:"ccs"`
 	Organization   string `json:"organization"`
 	OrganizationID string `json:"organization_id"`
+	CreatedAt      time.Time `json:"created_at"`
 }
 
 type fixtureServiceLog struct {
@@ -84,6 +86,7 @@ func loadClusterFixtures(path string, mock *MockClient) error {
 			CCS:            fc.CCS,
 			Organization:   fc.Organization,
 			OrganizationID: fc.OrganizationID,
+			CreatedAt:      fc.CreatedAt,
 		}
 	}
 	return nil

--- a/pkg/ocm/fixtures.go
+++ b/pkg/ocm/fixtures.go
@@ -9,18 +9,18 @@ import (
 )
 
 type fixtureCluster struct {
-	ID             string `json:"id"`
-	ExternalID     string `json:"external_id"`
-	Name           string `json:"name"`
-	DisplayName    string `json:"display_name"`
-	State          string `json:"state"`
-	Region         string `json:"region"`
-	CloudProvider  string `json:"cloud_provider"`
-	Version        string `json:"version"`
-	Hypershift     bool   `json:"hypershift"`
-	CCS            bool   `json:"ccs"`
-	Organization   string `json:"organization"`
-	OrganizationID string `json:"organization_id"`
+	ID             string    `json:"id"`
+	ExternalID     string    `json:"external_id"`
+	Name           string    `json:"name"`
+	DisplayName    string    `json:"display_name"`
+	State          string    `json:"state"`
+	Region         string    `json:"region"`
+	CloudProvider  string    `json:"cloud_provider"`
+	Version        string    `json:"version"`
+	Hypershift     bool      `json:"hypershift"`
+	CCS            bool      `json:"ccs"`
+	Organization   string    `json:"organization"`
+	OrganizationID string    `json:"organization_id"`
 	CreatedAt      time.Time `json:"created_at"`
 }
 

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -1,6 +1,9 @@
 package ocm
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // ClusterInfo contains enriched cluster data from the OCM API.
 type ClusterInfo struct {
@@ -16,6 +19,7 @@ type ClusterInfo struct {
 	CCS            bool
 	Organization   string
 	OrganizationID string
+	CreatedAt      time.Time
 }
 
 // ServiceLog represents a single service log entry.

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -589,6 +589,7 @@ func (m model) renderClusterTab() (string, error) {
 		fmt.Fprintf(&content, "* CCS: %v\n", info.CCS)
 		fmt.Fprintf(&content, "* Organization: %s\n", info.Organization)
 		fmt.Fprintf(&content, "* Organization ID: %s\n", info.OrganizationID)
+		fmt.Fprintf(&content, "* Created: %s\n", info.CreatedAt.Format("2006-01-02 15:04:05 UTC"))
 		if i < len(clusters)-1 {
 			content.WriteString("\n---\n")
 		}

--- a/testdata/fixtures/clusters.json
+++ b/testdata/fixtures/clusters.json
@@ -11,7 +11,8 @@
     "hypershift": false,
     "ccs": true,
     "organization": "Fake Aeronautical Ltd",
-    "organization_id": "1a2b3c4d5e6f7g8h9i0j"
+    "organization_id": "1a2b3c4d5e6f7g8h9i0j",
+    "created_at": "2024-03-15T10:30:00Z"
   },
   "b2d4e6f8-fake-uuid-test-def012345678": {
     "id": "cluster-osd-002",


### PR DESCRIPTION
### What type of PR is this?

_(bug/feature/cleanup/documentation)_

Feature

### What this PR does / Why we need it?

This PR adds the cluster creation time to the cluster context view for an incident. I have found cluster creation time to be useful to see if the cluster was recently provisioned.

**before**

<img width="645" height="458" alt="image" src="https://github.com/user-attachments/assets/b19007cb-0f80-4cc1-b7b2-8d49149fecdc" />


**after**

<img width="645" height="458" alt="image" src="https://github.com/user-attachments/assets/64572928-beab-4a63-8a0c-386c040e7cee" />


### Which Jira/Github issue(s) does this PR fix?

_Resolves #_

N/A

### Special notes for your reviewer

Open to the fact others may not find this as useful as me, but given we have room in this view, it felt worth including.

### Pre-checks (if applicable)

- [x] Ran unit tests locally against the changes
- [ ] Included documentation changes with PR

