### PR TITLE
 feat: support jumping with g+G in incident views 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ coverage: ## Generate test coverage report
 .PHONY: getlint
 getlint: ## Install golangci-lint if not already installed
 	@echo "Checking for golangci-lint..."
-	@which golangci-lint >/dev/null 2>&1 || (echo "Installing golangci-lint..." && go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION))
+	$(BIN_DIR)/golangci-lint >/dev/null 2>&1 || (echo "Installing golangci-lint..." && go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION))
 
 .PHONY: lint
 lint: getlint ## Run golangci-lint

--- a/pkg/tui/model_test.go
+++ b/pkg/tui/model_test.go
@@ -1290,6 +1290,39 @@ func TestTabSwitch_TabKey(t *testing.T) {
 	}
 }
 
+func TestIncidentViewer_TopBottom(t *testing.T) {
+	m := createTestModel()
+	m.viewingIncident = true
+	m.selectedIncident = &pagerduty.Incident{
+		APIObject: pagerduty.APIObject{ID: "Q123"},
+	}
+	m.incidentViewer = newIncidentViewer()
+	m.incidentViewer.Height = 5
+	lines := ""
+	for i := 0; i < 50; i++ {
+		lines += "line\n"
+	}
+	m.incidentViewer.SetContent(lines)
+
+	// Scroll down first so we're not at the top
+	m.incidentViewer.GotoBottom()
+	assert.Greater(t, m.incidentViewer.YOffset, 0)
+
+	t.Run("g jumps to top", func(t *testing.T) {
+		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}}
+		result, _ := m.Update(msg)
+		updated := result.(model)
+		assert.Equal(t, 0, updated.incidentViewer.YOffset)
+	})
+
+	t.Run("G jumps to bottom", func(t *testing.T) {
+		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'G'}}
+		result, _ := m.Update(msg)
+		updated := result.(model)
+		assert.Greater(t, updated.incidentViewer.YOffset, 0)
+	})
+}
+
 // captureLogOutput runs a function while capturing log output at the given level.
 // Returns the captured log output as a string.
 func captureLogOutput(level log.Level, fn func()) string {

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -917,6 +917,14 @@ func switchIncidentFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.incidentViewer, _ = m.incidentViewer.Update(msg)
 			return m, nil
 
+		case key.Matches(msg, defaultKeyMap.Top):
+			m.incidentViewer.GotoTop()
+			return m, nil
+
+		case key.Matches(msg, defaultKeyMap.Bottom):
+			m.incidentViewer.GotoBottom()
+			return m, nil
+
 		// Tab/Shift+Tab: switch between tabs
 		case key.Matches(msg, defaultKeyMap.TabNext):
 			m.activeTab = (m.activeTab + 1) % tabCount


### PR DESCRIPTION
### What type of PR is this?

_(bug/feature/cleanup/documentation)_

Feature

### What this PR does / Why we need it?

This PR extends the vim-style jump motions (g/G) to the tabs within the incident viewer. Previously these keystrokes were ignored. This allows quickly scrolling SLs and other incident contextual information.

This PR also fixes the `getlint` Makefile recipe to check for golangci-lint the same way it is invoked in `lint`. Previously, having golangci-lint installed to a location like `/usr/bin` would fail to run `lint`.

### Which Jira/Github issue(s) does this PR fix?

_Resolves #_

N/A

### Special notes for your reviewer

### Pre-checks (if applicable)

- [x] Ran unit tests locally against the changes
- [ ] Included documentation changes with PR
  - [x] existing documentation covers this
