### PR TITLE
fix: restore PR #426 g/G navigation reverted by #419 rebase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ coverage: ## Generate test coverage report
 .PHONY: getlint
 getlint: ## Install golangci-lint if not already installed
 	@echo "Checking for golangci-lint..."
-	@which golangci-lint >/dev/null 2>&1 || (echo "Installing golangci-lint..." && go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION))
+	$(BIN_DIR)/golangci-lint >/dev/null 2>&1 || (echo "Installing golangci-lint..." && go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION))
 
 .PHONY: lint
 lint: getlint ## Run golangci-lint

--- a/docs/plans/419-restore-426-navigation.md
+++ b/docs/plans/419-restore-426-navigation.md
@@ -1,0 +1,34 @@
+# Plan 419: Restore PR #426 — g/G navigation in incident viewer
+
+## Problem
+
+PR #426 added g/G (top/bottom) keyboard navigation to the incident viewer
+and fixed the `getlint` Makefile target to use `$(BIN_DIR)/golangci-lint`
+instead of `which golangci-lint`. It merged successfully, but a subsequent
+rebase of PR #419 resolved a conflict by keeping only the #419 side,
+silently dropping all three #426 changes. The loss was undetectable by CI
+because both the feature code and its test were removed together, leaving
+a consistent green tree.
+
+## What was lost
+
+1. **`pkg/tui/msgHandlers.go`** — two `case` blocks in
+   `switchIncidentFocusMode` handling `defaultKeyMap.Top` and
+   `defaultKeyMap.Bottom` to call `GotoTop()`/`GotoBottom()` on the
+   incident viewer viewport.
+2. **`pkg/tui/model_test.go`** — `TestIncidentViewer_TopBottom`, the test
+   covering the above navigation.
+3. **`Makefile`** — line 71 of the `getlint` target changed from
+   `@which golangci-lint` to `$(BIN_DIR)/golangci-lint`, ensuring the
+   project-local binary is used.
+
+## Approach
+
+Surgical restoration of the exact changes from PR #426, verified against
+`gh pr diff 426 --repo clcollins/srepd`. No modifications, no adjacent
+changes.
+
+## Revert check
+
+Deleting the two `case` blocks causes `TestIncidentViewer_TopBottom` to
+fail, confirming the test is wired to the feature code.

--- a/pkg/tui/model_test.go
+++ b/pkg/tui/model_test.go
@@ -1290,6 +1290,39 @@ func TestTabSwitch_TabKey(t *testing.T) {
 	}
 }
 
+func TestIncidentViewer_TopBottom(t *testing.T) {
+	m := createTestModel()
+	m.viewingIncident = true
+	m.selectedIncident = &pagerduty.Incident{
+		APIObject: pagerduty.APIObject{ID: "Q123"},
+	}
+	m.incidentViewer = newIncidentViewer()
+	m.incidentViewer.Height = 5
+	lines := ""
+	for i := 0; i < 50; i++ {
+		lines += "line\n"
+	}
+	m.incidentViewer.SetContent(lines)
+
+	// Scroll down first so we're not at the top
+	m.incidentViewer.GotoBottom()
+	assert.Greater(t, m.incidentViewer.YOffset, 0)
+
+	t.Run("g jumps to top", func(t *testing.T) {
+		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}}
+		result, _ := m.Update(msg)
+		updated := result.(model)
+		assert.Equal(t, 0, updated.incidentViewer.YOffset)
+	})
+
+	t.Run("G jumps to bottom", func(t *testing.T) {
+		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'G'}}
+		result, _ := m.Update(msg)
+		updated := result.(model)
+		assert.Greater(t, updated.incidentViewer.YOffset, 0)
+	})
+}
+
 // captureLogOutput runs a function while capturing log output at the given level.
 // Returns the captured log output as a string.
 func captureLogOutput(level log.Level, fn func()) string {

--- a/pkg/tui/msgHandlers.go
+++ b/pkg/tui/msgHandlers.go
@@ -917,6 +917,14 @@ func switchIncidentFocusMode(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.incidentViewer, _ = m.incidentViewer.Update(msg)
 			return m, nil
 
+		case key.Matches(msg, defaultKeyMap.Top):
+			m.incidentViewer.GotoTop()
+			return m, nil
+
+		case key.Matches(msg, defaultKeyMap.Bottom):
+			m.incidentViewer.GotoBottom()
+			return m, nil
+
 		// Tab/Shift+Tab: switch between tabs
 		case key.Matches(msg, defaultKeyMap.TabNext):
 			m.activeTab = (m.activeTab + 1) % tabCount


### PR DESCRIPTION
## Problem

PR #426 added g/G (top/bottom) keyboard navigation to the incident viewer and fixed the `getlint`
Makefile target. It merged successfully, but PR #419's rebase resolved a conflict by keeping only
the #419 side, silently dropping all three #426 changes. CI could not catch the regression because
the feature code AND its test were removed together — a consistent, green tree.

## Approach

Surgical restoration of the exact changes from PR #426, verified line-by-line against
`gh pr diff 426 --repo clcollins/srepd`. No modifications, no adjacent changes.

### Changes restored

1. **`pkg/tui/msgHandlers.go`** — two `case` blocks in `switchIncidentFocusMode` handling
   `defaultKeyMap.Top`/`Bottom` to call `GotoTop()`/`GotoBottom()` on the incident viewer viewport.
2. **`pkg/tui/model_test.go`** — `TestIncidentViewer_TopBottom` covering the above navigation.
3. **`Makefile`** — line 71 of the `getlint` target changed from `@which golangci-lint` to
   `$(BIN_DIR)/golangci-lint`, ensuring the project-local binary is used.

## Revert checks

Deleted the two `case` blocks from `switchIncidentFocusMode`, confirmed
`TestIncidentViewer_TopBottom` **FAILS**, restored:

```
=== RUN   TestIncidentViewer_TopBottom
=== RUN   TestIncidentViewer_TopBottom/g_jumps_to_top
    model_test.go:1315:
            Error Trace:    /workspace/github.com__clcollins__srepd/pkg/tui/model_test.go:1315
            Error:          Not equal:
                            expected: 0
                            actual  : 46
            Test:           TestIncidentViewer_TopBottom/g_jumps_to_top
=== RUN   TestIncidentViewer_TopBottom/G_jumps_to_bottom
--- FAIL: TestIncidentViewer_TopBottom (0.00s)
    --- FAIL: TestIncidentViewer_TopBottom/g_jumps_to_top (0.00s)
    --- PASS: TestIncidentViewer_TopBottom/G_jumps_to_bottom (0.00s)
FAIL
FAIL    github.com/clcollins/srepd/pkg/tui      0.027s
FAIL
```

After restoring the code:

```
=== RUN   TestIncidentViewer_TopBottom
=== RUN   TestIncidentViewer_TopBottom/g_jumps_to_top
=== RUN   TestIncidentViewer_TopBottom/G_jumps_to_bottom
--- PASS: TestIncidentViewer_TopBottom (0.00s)
    --- PASS: TestIncidentViewer_TopBottom/g_jumps_to_top (0.00s)
    --- PASS: TestIncidentViewer_TopBottom/G_jumps_to_bottom (0.00s)
PASS
ok      github.com/clcollins/srepd/pkg/tui      0.023s
```

## Test evidence

- `make lint`: 0 issues
- `go test ./pkg/tui/... -count=1`: PASS
- `make test-race` for `pkg/tui`: PASS (86.7s)
- Pre-existing `cmd` test failure on `origin/main` (unrelated to this PR)

## Per-file verification against PR #426

| File | PR #426 change | Status on branch |
|------|---------------|------------------|
| `Makefile` | `@which golangci-lint` → `$(BIN_DIR)/golangci-lint` | Restored |
| `pkg/tui/model_test.go` | `TestIncidentViewer_TopBottom` | Restored |
| `pkg/tui/msgHandlers.go` | Top/Bottom cases in `switchIncidentFocusMode` | Restored |

## Testing this live

1. `make build`
2. `./dist/srepd_linux_amd64_v1/srepd --dev`
3. Select an incident with Enter to open the incident viewer
4. Press `G` — EXPECT: viewport scrolls to bottom
5. Press `g` — EXPECT: viewport scrolls to top
6. Press Esc — returns to incident list

## Visual validation

tui-mcp was not available in this environment (headless container). The test
`TestIncidentViewer_TopBottom` exercises the exact key dispatch and viewport
offset assertions that verify the feature works correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)