### PR TITLE
ci: disable GitHub Actions ahead of Prow migration

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -2,13 +2,12 @@
 
 name: Go CI
 
+# DISABLED: workflows are being migrated to Prow. Re-enable or remove
+# once Prow CI is configured on openshift-online/srepd.
 on:
   push:
     branches:
-      - main
-  pull_request:
-    branches:
-      - main
+      - disabled
 
 # No job writes to the repo; the Codecov upload uses its own CODECOV_TOKEN secret,
 # not GITHUB_TOKEN. Grant the minimal read-only scope.


### PR DESCRIPTION
## Summary

- Disable GitHub Actions CI workflow by pointing triggers at a nonexistent branch (`disabled`)
- Workflow file and all job definitions are preserved for reference during Prow migration
- No functional changes to any CI job logic

## Context

The repo is moving to openshift-online/srepd where CI will run via Prow. This prevents the GitHub Actions workflow from firing on the upstream repo while preserving it for reference.

## Test plan

- [x] Verify workflow file is syntactically valid
- [x] Confirm no triggers will fire on `main` or PR branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)