### PR TITLE
chore: bridge release v1.6.5 — redirect update URL to openshift-online/srepd

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+> [!IMPORTANT]
+> **srepd has moved to [openshift-online/srepd](https://github.com/openshift-online/srepd).**
+> This repository is archived. Release v1.6.5 is a final bridge release:
+> running `srepd update` from any older version will migrate you to the
+> new repository automatically. New installs:
+> `go install github.com/openshift-online/srepd@latest`
+
 ![srepd](img/srepd.jpg)
 
 # SREPD

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -14,7 +14,7 @@ var updateCmd = &cobra.Command{
 	Long: `Update srepd to the latest GitHub release in place.
 
 Downloads the latest release binary for the current OS and architecture
-from https://github.com/clcollins/srepd/releases, extracts it, and
+from https://github.com/openshift-online/srepd/releases, extracts it, and
 replaces the current binary. Restart srepd after updating.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := tui.RunSelfUpdate(); err != nil {

--- a/docs/plans/421-bridge-release-migration.md
+++ b/docs/plans/421-bridge-release-migration.md
@@ -1,0 +1,75 @@
+# Plan 421: Bridge Release v1.6.5 — clcollins/srepd → openshift-online/srepd Migration
+
+## Problem
+
+srepd is moving to `github.com/openshift-online/srepd`. Because this is a
+fresh commit to a new repo (not a GitHub repository transfer), GitHub sets up
+no redirects of any kind. Every srepd binary in the field (v1.6.4 and earlier)
+has this URL compiled in:
+
+```
+https://api.github.com/repos/clcollins/srepd/releases/latest
+```
+
+(`githubReleasesURL` constant, `pkg/tui/update.go`). Without a bridge, existing
+users will never learn about releases in the new repo: the startup update banner
+fails silently (debug-level log only) and `srepd update` reports "already up to
+date" forever.
+
+## Approach
+
+Publish one final release in the old repo (`clcollins/srepd`) whose only
+functional change is pointing `githubReleasesURL` at `openshift-online/srepd`.
+Old binaries see v1.6.5 as an update, self-update to it from this repo's release
+assets, and from then on check `openshift-online/srepd` — where they'll find
+v1.7.0+ and complete the migration.
+
+## Changes
+
+**Functional (the only real change):**
+- `pkg/tui/update.go`: `githubReleasesURL` → `openshift-online/srepd`
+
+**Cosmetic (consistency):**
+- `pkg/tui/update.go`: dev-mode fake release URL → `openshift-online/srepd`
+- `cmd/update.go`: help text URL → `openshift-online/srepd`
+
+**Documentation:**
+- `README.md`: prominent `[!IMPORTANT]` migration notice at the very top
+
+**Explicitly NOT changed:**
+- `go.mod` module path or any import paths — repo keeps `github.com/clcollins/srepd`
+- `.goreleaser.yaml` — `release.github.owner` stays `clcollins` so the release
+  publishes to this repo where old binaries are looking
+- `pkg/tui/update_test.go` — fixture URLs are self-contained httptest strings
+  that don't reference the constant; tests pass unchanged
+
+## Ordering / Prerequisites
+
+- **`openshift-online/srepd` must rename its `go.mod` module path** from
+  `github.com/clcollins/srepd` to `github.com/openshift-online/srepd` (and
+  update all internal import paths) before publishing v1.7.0. Without this,
+  `go install github.com/openshift-online/srepd@latest` (advertised in the
+  bridge README notice) fails with a module path mismatch error for new users.
+- openshift-online/srepd must have a published release (v1.7.0) before or
+  promptly after v1.6.5 ships. Until then, the startup banner fails silently
+  (harmless) but `srepd update` prints a 404 error for anyone who runs it.
+- Version must be lower than the new repo's first release (v1.6.5 < v1.7.0)
+  so `isNewerVersion` immediately offers the next hop.
+
+## Release Procedure
+
+1. PR and merge to `main` (CI is disabled; run `make test-all` locally first)
+2. `git tag v1.6.5 && git push origin v1.6.5`
+3. `make release` (goreleaser; reads GITHUB_TOKEN from
+   `~/.config/goreleaser/goreleaser_token`)
+4. After confirming migration works end-to-end, **archive** the repository
+   (Settings → Archive). Never delete — archived repos keep serving the
+   releases API and asset downloads, so stragglers who run `srepd update`
+   months later still get bridged.
+
+## Verification
+
+- `curl -s https://api.github.com/repos/clcollins/srepd/releases/latest | jq .tag_name` → `"v1.6.5"`
+- Download a v1.6.4 binary, run `srepd update` → updates to v1.6.5
+- Run the v1.6.5 binary's `srepd update` → reaches openshift-online/srepd
+- `strings dist/.../srepd | grep releases/latest` → shows only the openshift-online URL

--- a/pkg/tui/update.go
+++ b/pkg/tui/update.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	githubReleasesURL  = "https://api.github.com/repos/clcollins/srepd/releases/latest"
+	githubReleasesURL  = "https://api.github.com/repos/openshift-online/srepd/releases/latest"
 	updateCheckTimeout = 10 * time.Second
 )
 
@@ -52,7 +52,7 @@ func checkForUpdate(devMode bool, apiURL string) tea.Cmd {
 			return updateAvailableMsg{
 				current:    Version,
 				latest:     "v99.0.0",
-				releaseURL: "https://github.com/clcollins/srepd/releases/tag/v99.0.0",
+				releaseURL: "https://github.com/openshift-online/srepd/releases/tag/v99.0.0",
 			}
 		}
 


### PR DESCRIPTION
## Summary

This is the final PR to `clcollins/srepd`. It prepares a bridge release (v1.6.5) so existing users can migrate automatically to the new home at [openshift-online/srepd](https://github.com/openshift-online/srepd).

**The only functional change** is redirecting `githubReleasesURL` in `pkg/tui/update.go` from `clcollins/srepd` to `openshift-online/srepd`. Everything else is cosmetic or documentation.

### Migration flow

1. User runs `srepd update` on any binary ≤ v1.6.4 → finds v1.6.5 here → self-updates
2. v1.6.5 binary's `githubReleasesURL` now points at `openshift-online/srepd`
3. User runs `srepd update` again → finds v1.7.0 in the new repo → migration complete

### Changes

| File | Change |
|------|--------|
| `pkg/tui/update.go` | `githubReleasesURL` constant → `openshift-online/srepd` (functional) |
| `pkg/tui/update.go` | dev-mode fake release URL → `openshift-online/srepd` (cosmetic) |
| `cmd/update.go` | help text URL → `openshift-online/srepd` (cosmetic) |
| `README.md` | `[!IMPORTANT]` migration notice at top |
| `docs/plans/421-bridge-release-migration.md` | plan document |

### Explicitly NOT changed

- `go.mod` module path — stays `github.com/clcollins/srepd` (module rename happens in the new repo)
- `.goreleaser.yaml` — `release.github.owner` stays `clcollins` so assets publish here where old binaries look
- `pkg/tui/update_test.go` — fixture URLs are self-contained httptest strings; tests pass unchanged

### Prerequisites before tagging v1.6.5

- [ ] `openshift-online/srepd` must rename `go.mod` to `module github.com/openshift-online/srepd`
- [ ] `openshift-online/srepd` must publish v1.7.0

### After release

Archive this repository (Settings → Archive). Never delete — the releases API and asset downloads must keep serving for stragglers running `srepd update` months later.

### Pre-existing hardening issues filed

Four pre-existing issues in the self-update code were identified during review and filed in the new repo for follow-up:

- openshift-online/srepd#9 — validate asset download URL scheme (https:// guard)
- openshift-online/srepd#10 — add `io.LimitReader` to tar extraction
- openshift-online/srepd#11 — rename `os` variable shadow in `releaseAssetName`
- openshift-online/srepd#12 — guard `goos[:1]` against empty string

## Test plan

- [x] `make test-all` passes locally (all checks green)
- [ ] After tagging: `curl -s https://api.github.com/repos/clcollins/srepd/releases/latest | jq .tag_name` → `"v1.6.5"`
- [ ] Download a v1.6.4 binary, run `srepd update` → updates to v1.6.5
- [ ] Run v1.6.5 binary's `srepd update` → reaches `openshift-online/srepd`
- [ ] `strings dist/.../srepd | grep releases/latest` → shows only the `openshift-online` URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)